### PR TITLE
Fixes twitter oauth features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,9 +74,7 @@ log_dir = "path/to/conversation_engrams/"
 
 TWITTER = {
     "CONSUMER_KEY": "<consumer_key>",
-    "CONSUMER_SECRET": "<consumer_secret>",
-    "ACCESS_KEY": "<access_key>",
-    "ACCESS_SECRET": "<access_secret>"
+    "CONSUMER_SECRET": "<consumer_secret>"
 }
 
 chatbot = SocialBot(log_directory=log_dir, twitter=TWITTER)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fuzzywuzzy==0.4.0
-oauth2==1.5.211
+requests-oauthlib==0.4.2

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -1,9 +1,24 @@
 from .base_case import ChatBotTestCase
+from chatterbot.apis.twitter import Twitter
 from chatterbot.algorithms.twitter import remove_leeding_usernames
 from chatterbot.algorithms.twitter import remove_trailing_usernames
 
 
 class TwitterTests(ChatBotTestCase):
+
+    def test_consumer_stored(self):
+        TWITTER = {
+            "CONSUMER_KEY": "blahblahblah",
+            "CONSUMER_SECRET": "nullvoidnullvoidnullvoid"
+        }
+
+        chatbot = Twitter(twitter=TWITTER)
+
+        self.assertEqual(TWITTER["CONSUMER_KEY"], chatbot.consumer_key)
+        self.assertEqual(TWITTER["CONSUMER_SECRET"], chatbot.consumer_secret)
+
+
+class TwitterAlgorithmTests(ChatBotTestCase):
 
     def test_remove_leeding_usernames(self):
 


### PR DESCRIPTION
This fixes incompatibilities with python3 by removing the `python-oauth2` library in favor of `requests-oauthlib`.
This also changes the oauth workflow to make it possible to redirect request urls to third party apps.

Closes #16