### PR TITLE
Renamed DatabaseAdapter to StorageAdapter

### DIFF
--- a/chatterbot/adapters/storage/__init__.py
+++ b/chatterbot/adapters/storage/__init__.py
@@ -1,4 +1,4 @@
-from .database import DatabaseAdapter
+from .storage import StorageAdapter
 from .jsondatabase import JsonDatabaseAdapter
 from .mongodb import MongoDatabaseAdapter
 

--- a/chatterbot/adapters/storage/jsondatabase.py
+++ b/chatterbot/adapters/storage/jsondatabase.py
@@ -1,10 +1,10 @@
-from chatterbot.adapters.storage import DatabaseAdapter
+from chatterbot.adapters.storage import StorageAdapter
 from chatterbot.adapters.exceptions import EmptyDatabaseException
 from chatterbot.conversation import Statement
 from jsondb.db import Database
 
 
-class JsonDatabaseAdapter(DatabaseAdapter):
+class JsonDatabaseAdapter(StorageAdapter):
 
     def __init__(self, **kwargs):
         super(JsonDatabaseAdapter, self).__init__(**kwargs)

--- a/chatterbot/adapters/storage/mongodb.py
+++ b/chatterbot/adapters/storage/mongodb.py
@@ -1,10 +1,10 @@
-from chatterbot.adapters.storage import DatabaseAdapter
+from chatterbot.adapters.storage import StorageAdapter
 from chatterbot.adapters.exceptions import EmptyDatabaseException
 from chatterbot.conversation import Statement
 from pymongo import MongoClient
 
 
-class MongoDatabaseAdapter(DatabaseAdapter):
+class MongoDatabaseAdapter(StorageAdapter):
 
     def __init__(self, **kwargs):
         super(MongoDatabaseAdapter, self).__init__(**kwargs)

--- a/chatterbot/adapters/storage/storage.py
+++ b/chatterbot/adapters/storage/storage.py
@@ -1,7 +1,7 @@
 from chatterbot.adapters.exceptions import AdapterNotImplementedError
 
 
-class DatabaseAdapter(object):
+class StorageAdapter(object):
     """
     This is an abstract class that represents the interface
     that all storage adapters should implement.


### PR DESCRIPTION
This change is to maintain consistency with the name of this module (`chatterbot.adapters.storage`).

In the future, I also feel that the term _storage_ is more flexible then the term _database_. In the future, it is possible that there may be non-database storage sources.