### PR TITLE
readme fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,12 @@ from chatterbot import ChatBot
 chatbot = ChatBot("Ron Obvious")
 
 # Train based on the english corpus
-chatbot.train("chatterbot.corpus.english")
+
+# For better greetings
+chatbot.train("chatterbot.corpus.english.greetings")
+
+# For more verbose conversations
+chatbot.train("chatterbot.corpus.english.conversations")
 
 # Get a response to an input statement
 chatbot.get_response("Hello, how are you today?")


### PR DESCRIPTION
Hey, I'm using chatterbot for one of my projects. I installed via pip, but the bot.train("chattbot.corpus.english") caused a "no module named english" error. I noticed the greetings.json and the conversations.json weren't included in the pip install. However, after I copied them both into the chatterbot I was still getting the same error. I added a quick fix so your readme works, if you just do a full path on train the json files are added. 