### PR TITLE
Commented the print statement in terminal.py io-adapter

### DIFF
--- a/chatterbot/adapters/io/terminal.py
+++ b/chatterbot/adapters/io/terminal.py
@@ -12,6 +12,6 @@ class TerminalAdapter(IOAdapter):
         return user_input
 
     def process_response(self, statement):
-        print(statement.text)
+#        print(statement.text)
         return statement.text
 


### PR DESCRIPTION
I have commented the "print" statement in terminal.py in adapters/io/,
because,
chatterbot.ChatBot.get_response("Some query"), would return a response as well as print that. It was getting printed because of the print statement in terminal.py. Removing that solves the issue. 