### PR TITLE
ClosestMeaningAdapter wasn't useable

### DIFF
--- a/chatterbot/adapters/logic/closest_meaning.py
+++ b/chatterbot/adapters/logic/closest_meaning.py
@@ -8,8 +8,8 @@ from nltk import word_tokenize
 
 class ClosestMeaningAdapter(LogicAdapter):
 
-    def __init__(self):
-        super(ClosestMeaningAdapter, self).__init__()
+    def __init__(self, **kwargs):
+        super(ClosestMeaningAdapter, self).__init__(**kwargs)
         from nltk.data import find
         from nltk import download
 


### PR DESCRIPTION
TypeError: __init__() got an unexpected keyword argument 'logic_adapter because chatterbot.py initializes the logic adapters with his kwargs. The Closestmatch adapter uses the __init__() from logic.py