### PR TITLE
Correct issue with response objects using mongo storage adapter

### DIFF
--- a/chatterbot/adapters/storage/mongodb.py
+++ b/chatterbot/adapters/storage/mongodb.py
@@ -91,6 +91,10 @@ class MongoDatabaseAdapter(StorageAdapter):
         for match in matches:
             statement_text = match['text']
             del(match['text'])
+
+            response_list = self.deserialize_responses(match["in_response_to"])
+            match["in_response_to"] = response_list
+
             results.append(Statement(statement_text, **match))
 
         return results

--- a/tests/storage_adapter_tests/test_jsondb_adapter.py
+++ b/tests/storage_adapter_tests/test_jsondb_adapter.py
@@ -93,7 +93,7 @@ class JsonDatabaseAdapterTestCase(BaseJsonDatabaseAdapterTestCase):
         random_statement = self.adapter.get_random()
         self.assertEqual(random_statement.text, statement.text)
 
-    def test_find_returns_nested_responces(self):
+    def test_find_returns_nested_responses(self):
         response_list = [
             Response("Yes"),
             Response("No")

--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -33,7 +33,7 @@ class BaseMongoDatabaseAdapterTestCase(TestCase):
         """
         self.adapter.drop()
 
-class JsonDatabaseAdapterTestCase(BaseMongoDatabaseAdapterTestCase):
+class MongoDatabaseAdapterTestCase(BaseMongoDatabaseAdapterTestCase):
 
     def test_count_returns_zero(self):
         """
@@ -107,7 +107,7 @@ class JsonDatabaseAdapterTestCase(BaseMongoDatabaseAdapterTestCase):
         random_statement = self.adapter.get_random()
         self.assertEqual(random_statement.text, statement.text)
 
-    def test_find_returns_nested_responces(self):
+    def test_find_returns_nested_responses(self):
         response_list = [
             Response("Yes"),
             Response("No")
@@ -122,7 +122,6 @@ class JsonDatabaseAdapterTestCase(BaseMongoDatabaseAdapterTestCase):
 
         self.assertIn("Yes", result.in_response_to)
         self.assertIn("No", result.in_response_to)
-
 
     def test_filter_no_results(self):
         statement1 = Statement("Testing...")
@@ -244,6 +243,23 @@ class JsonDatabaseAdapterTestCase(BaseMongoDatabaseAdapterTestCase):
         results = self.adapter.filter()
 
         self.assertEqual(len(results), 2)
+
+    def test_response_list_in_results(self):
+        """
+        If a statement with response values is found using the
+        filter method, they should be returned as response objects.
+        """
+        statement = Statement(
+            "The first is to help yourself, the second is to help others.",
+            in_response_to=[
+                Response("Why do people have two hands?")
+            ]
+        )
+        self.adapter.update(statement)
+        found = self.adapter.filter(text=statement.text)
+
+        self.assertEqual(len(found[0].in_response_to), 1)
+        self.assertEqual(type(found[0].in_response_to[0]), Response)
 
 
 class ReadOnlyMongoDatabaseAdapterTestCase(BaseMongoDatabaseAdapterTestCase):


### PR DESCRIPTION
Response objects were being returned from the mongo storage adapter as dictionaries instead of Response object lists. This was happening because the conversion method was not being called to normalize the results before they were returned.