### PR TITLE
Added system adapter for case when database is empty

### DIFF
--- a/chatterbot/adapters/adaptation.py
+++ b/chatterbot/adapters/adaptation.py
@@ -22,6 +22,9 @@ class Adaptation(object):
         self.logic = MultiLogicAdapter(**kwargs)
         self.logic.set_context(self)
 
+        # Add required system adapter
+        self.add_adapter("chatterbot.adapters.logic.NoKnowledgeAdapter")
+
     def add_adapter(self, adapter, **kwargs):
         NewAdapter = import_module(adapter)
 

--- a/chatterbot/adapters/logic/__init__.py
+++ b/chatterbot/adapters/logic/__init__.py
@@ -2,3 +2,4 @@ from .logic import LogicAdapter
 from .closest_match import ClosestMatchAdapter
 from .closest_meaning import ClosestMeaningAdapter
 from .multi_adapter import MultiLogicAdapter
+from .no_knowledge_adapter import NoKnowledgeAdapter

--- a/chatterbot/adapters/logic/base_match.py
+++ b/chatterbot/adapters/logic/base_match.py
@@ -44,6 +44,14 @@ class BaseMatchAdapter(TieBreaking, LogicAdapter):
         """
         raise AdapterNotImplementedError()
 
+    def can_process(self, statement):
+        """
+        Override the can_process method to check if the
+        storage context is available and there is at least
+        one statement in the database.
+        """
+        return self.has_storage_context and self.context.storage.count()
+
     def process(self, input_statement):
 
         # Select the closest match to the input statement

--- a/chatterbot/adapters/logic/logic.py
+++ b/chatterbot/adapters/logic/logic.py
@@ -8,6 +8,15 @@ class LogicAdapter(Adapter):
     that all logic adapters should implement.
     """
 
+    def can_process(self, statement):
+        """
+        A preliminary check that is called to determine if a
+        logic adapter can process a given statement. By default,
+        this method returns true but it can be overridden in
+        child classes as needed.
+        """
+        return True
+
     def process(self, statement):
         """
         Method that takes an input statement and returns

--- a/chatterbot/adapters/logic/multi_adapter.py
+++ b/chatterbot/adapters/logic/multi_adapter.py
@@ -17,10 +17,11 @@ class MultiLogicAdapter(LogicAdapter):
         max_confidence = -1
 
         for adapter in self.adapters:
-            confidence, output = adapter.process(statement)
-            if confidence > max_confidence:
-                result = output
-                max_confidence = confidence
+            if adapter.can_process(statement):
+                confidence, output = adapter.process(statement)
+                if confidence > max_confidence:
+                    result = output
+                    max_confidence = confidence
 
         return max_confidence, result
 

--- a/chatterbot/adapters/logic/no_knowledge_adapter.py
+++ b/chatterbot/adapters/logic/no_knowledge_adapter.py
@@ -1,0 +1,23 @@
+from .logic import LogicAdapter
+
+
+class NoKnowledgeAdapter(LogicAdapter):
+    """
+    This is a system adapter that is automatically added
+    to the list of logic adapters durring initialization.
+    This adapter is placed at the beginning of the list
+    to be given the highest priority.
+    """
+
+    def process(self, statement):
+        """
+        If there are no known responses in the database,
+        then a confidence of 1 should be returned with
+        the input statement.
+        Otherwise, a confidence of 0 should be returned.
+        """
+
+        if self.context.storage.count():
+            return 0, statement
+
+        return 1, statement

--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -71,14 +71,6 @@ class ChatBot(Adaptation):
         if not plugin_response is False:
             return self.io.process_response(Statement(plugin_response))
 
-        # If no responses exist, return the input statement
-        if not self.storage.count():
-            self.storage.update(input_statement)
-            self.recent_statements.append(input_statement)
-
-            # Process the response output with the IO adapter
-            return self.io.process_response(input_statement)
-
         # Select a response to the input statement
         confidence, response = self.logic.process(input_statement)
 

--- a/tests/test_adaptation.py
+++ b/tests/test_adaptation.py
@@ -14,10 +14,12 @@ class AdaptationTests(TestCase):
         self.assertEqual(len(self.adaptation.storage_adapters), 1)
 
     def test_add_logic_adapter(self):
+        count_before = len(self.adaptation.logic.adapters)
+
         self.adaptation.add_adapter(
             "chatterbot.adapters.logic.ClosestMatchAdapter"
         )
-        self.assertEqual(len(self.adaptation.logic.adapters), 1)
+        self.assertEqual(len(self.adaptation.logic.adapters), count_before + 1)
 
     def test_add_io_adapter(self):
         self.adaptation.add_adapter(


### PR DESCRIPTION
This moves a section of code in `chatterbot.py` that handles the case that no responses exist in the database to its own logic adapter. The new logic adapter will always be set as the first logic adapter in the list so that it takes priority over each of the other logic adapters.