### PR TITLE
minor fixes in logic adapters & terminal example

### DIFF
--- a/chatterbot/adapters/logic/evaluate_mathematically.py
+++ b/chatterbot/adapters/logic/evaluate_mathematically.py
@@ -25,11 +25,11 @@ class EvaluateMathematically(LogicAdapter):
         input_text = statement.text
 
         # Getting the mathematical terms within the input statement
-        expression = self.simplify_chunks(self.normalize(input_text))
+        expression = str(self.simplify_chunks(self.normalize(input_text)))
 
         # Returning important information
         try:
-            expression += '= ' + str(eval(expression))
+            expression += "= " + str(eval(expression))
 
             # return a confidence of 1 if the expression could be evaluated
             return 1, Statement(expression)

--- a/chatterbot/adapters/logic/time_adapter.py
+++ b/chatterbot/adapters/logic/time_adapter.py
@@ -17,7 +17,8 @@ class TimeLogicAdapter(LogicAdapter):
             ("do you know the time", 0),
             ("it is time to go to sleep", 0),
             ("what is your favorite color", 0),
-            ("i had a great time", 0)
+            ("i had a great time", 0),
+            ("what is", 0)
         ]
 
         self.classifier = NaiveBayesClassifier(training_data)

--- a/examples/terminal_example.py
+++ b/examples/terminal_example.py
@@ -4,7 +4,11 @@ from chatterbot import ChatBot
 # Create a new instance of a ChatBot
 bot = ChatBot("Terminal",
     storage_adapter="chatterbot.adapters.storage.JsonDatabaseAdapter",
-    logic_adapter="chatterbot.adapters.logic.ClosestMatchAdapter",
+    logic_adapters=[
+        "chatterbot.adapters.logic.EvaluateMathematically",
+        "chatterbot.adapters.logic.TimeLogicAdapter",
+        "chatterbot.adapters.logic.ClosestMatchAdapter"
+    ],
     io_adapter="chatterbot.adapters.io.TerminalAdapter",
     database="../database.db")
 


### PR DESCRIPTION
Just a couple of minor changes, including:

1) Add additional logic adapters to the terminal example adding functionality
2) Possible bug fix in evaluate_mathematically (not really sure, but this makes sure no bug will ever arise)
3) Sometimes, the time logic adapter would find a statement similar to "what is 100 * 10?" as something it should process. By adding the additional piece of training data, the time adapter does not incorrectly process math statements as often