### PR TITLE
Make sure that closest match adapter confidence returns value between 0 and 1

### DIFF
--- a/chatterbot/adapters/logic/closest_match.py
+++ b/chatterbot/adapters/logic/closest_match.py
@@ -35,6 +35,9 @@ class ClosestMatchAdapter(BaseMatchAdapter):
             limit=1
         )[0]
 
+        # Convert the confidence integer to a percent
+        confidence /= 100.0
+
         return confidence, next(
             (s for s in statement_list if s.text == closest_match), None
         )

--- a/tests/logic_adapter_tests/test_closest_match.py
+++ b/tests/logic_adapter_tests/test_closest_match.py
@@ -37,3 +37,41 @@ class ClosestMatchAdapterTests(TestCase):
 
         self.assertEqual("What... is your quest?", match)
 
+    def test_confidence_exact_match(self):
+        possible_choices = [
+            Statement("What is your quest?", in_response_to=[Response("What is your quest?")])
+        ]
+
+        statement = Statement("What is your quest?")
+
+        confidence, match = self.adapter.get(
+            statement, possible_choices
+        )
+
+        self.assertEqual(confidence, 1)
+
+    def test_confidence_half_match(self):
+        possible_choices = [
+            Statement("xxyy", in_response_to=[Response("xxyy")])
+        ]
+
+        statement = Statement("wwxx")
+
+        confidence, match = self.adapter.get(
+            statement, possible_choices
+        )
+
+        self.assertEqual(confidence, 0.5)
+
+    def test_confidence_no_match(self):
+        possible_choices = [
+            Statement("xxx", in_response_to=[Response("xxx")])
+        ]
+
+        statement = Statement("yyy")
+
+        confidence, match = self.adapter.get(
+            statement, possible_choices
+        )
+
+        self.assertEqual(confidence, 0)


### PR DESCRIPTION
This updates and adds tests to ensure that the confidence value returned by the closest match adapter fall within the range between 0 and 1.