### PR TITLE
Separate classifier out

### DIFF
--- a/chatterbot/adapters/logic/__init__.py
+++ b/chatterbot/adapters/logic/__init__.py
@@ -5,3 +5,4 @@ from .time_adapter import TimeLogicAdapter
 from .multi_adapter import MultiLogicAdapter
 from .no_knowledge_adapter import NoKnowledgeAdapter
 from .evaluate_mathematically import EvaluateMathematically
+from .classifier_naivebayes import NaiveBayes_Classifier

--- a/chatterbot/adapters/logic/base_classifier.py
+++ b/chatterbot/adapters/logic/base_classifier.py
@@ -1,0 +1,23 @@
+from chatterbot.adapters import Adapter
+from chatterbot.adapters.exceptions import AdapterNotImplementedError
+
+
+class ClassifierAdapter(Adapter):
+    """
+    This is an abstract class that represents the interface
+    that all classifier logic adapters should implement.
+    """
+
+    def train(self, training_data):
+        """
+        Data is given to train the classifier to respond to
+        specific statements.
+        """
+        raise AdapterNotImplementedError()
+
+    def classify(self, statement):
+        """
+        Method that takes an input statement and returns
+        a confidence value as output.
+        """
+        raise AdapterNotImplementedError()

--- a/chatterbot/adapters/logic/classifier_naivebayes.py
+++ b/chatterbot/adapters/logic/classifier_naivebayes.py
@@ -1,0 +1,22 @@
+from textblob.classifiers import NaiveBayesClassifier
+from .base_classifier import ClassifierAdapter
+
+class NaiveBayes_Classifier(ClassifierAdapter):
+    def __init__(self, training_data):
+        self.train(training_data)
+
+    def train(self, training_data):
+        """
+        Data is given to train the classifier to respond to
+        specific statements.
+        """
+
+        self.classifier = NaiveBayesClassifier(training_data)
+
+    def classify(self, input_text):
+        """
+        Method that takes an input statement and returns
+        a confidence value as output.
+        """
+
+        return self.classifier.classify(input_text.lower())

--- a/chatterbot/adapters/logic/classifier_naivebayes.py
+++ b/chatterbot/adapters/logic/classifier_naivebayes.py
@@ -2,8 +2,8 @@ from textblob.classifiers import NaiveBayesClassifier
 from .base_classifier import ClassifierAdapter
 
 class NaiveBayes_Classifier(ClassifierAdapter):
-    def __init__(self, training_data):
-        self.train(training_data)
+    def __init__(self):
+        pass
 
     def train(self, training_data):
         """

--- a/chatterbot/adapters/logic/time_adapter.py
+++ b/chatterbot/adapters/logic/time_adapter.py
@@ -1,6 +1,6 @@
 from .logic import LogicAdapter
+from .classifier_naivebayes import NaiveBayes_Classifier
 from chatterbot.conversation import Statement
-from textblob.classifiers import NaiveBayesClassifier
 from datetime import datetime
 
 
@@ -9,7 +9,7 @@ class TimeLogicAdapter(LogicAdapter):
     def __init__(self, **kwargs):
         super(TimeLogicAdapter, self).__init__(**kwargs)
 
-        training_data = [
+        self.training_data = [
             ("what time is it", 1),
             ("do you know the time", 1),
             ("do you know what time it is", 1),
@@ -21,7 +21,7 @@ class TimeLogicAdapter(LogicAdapter):
             ("what is", 0)
         ]
 
-        self.classifier = NaiveBayesClassifier(training_data)
+        self.classifier = NaiveBayes_Classifier(self.training_data)
 
     def process(self, statement):
         now = datetime.now()

--- a/chatterbot/adapters/logic/time_adapter.py
+++ b/chatterbot/adapters/logic/time_adapter.py
@@ -21,7 +21,8 @@ class TimeLogicAdapter(LogicAdapter):
             ("what is", 0)
         ]
 
-        self.classifier = NaiveBayes_Classifier(self.training_data)
+        self.classifier = NaiveBayes_Classifier()
+        self.classifier.train(self.training_data)
 
     def process(self, statement):
         now = datetime.now()

--- a/tests/logic_adapter_tests/test_naivebayes_classifier.py
+++ b/tests/logic_adapter_tests/test_naivebayes_classifier.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+from chatterbot.adapters.logic import NaiveBayes_Classifier
+
+
+class NaiveBayesClassifierTests(TestCase):
+
+    def setUp(self):
+        self.adapter = NaiveBayes_Classifier()
+
+    def test_training(self):
+        training_data = [
+            ("what time it is?", 1),
+            ("what is the current time", 1),
+            ("who am I?", 0)
+        ]
+
+        self.adapter.train(training_data)
+        self.assertEqual(self.adapter.classify("what time it is?"), 1)


### PR DESCRIPTION
This PR separates the classifier out from the logic adapter. Although the current NaiveBayes classifier is pretty simple, future classifiers might be much more complicated. Because of this, separating the classifiers out will make the code much easier to understand in the future.