### PR TITLE
Add a MacOSX TTS io adapter

### DIFF
--- a/chatterbot/adapters/io/__init__.py
+++ b/chatterbot/adapters/io/__init__.py
@@ -2,3 +2,4 @@ from .io import IOAdapter
 from .terminal import TerminalAdapter
 from .io_json import JsonAdapter
 from .no_output import NoOutputAdapter
+from .tts import MacOSXTTS

--- a/chatterbot/adapters/io/tts.py
+++ b/chatterbot/adapters/io/tts.py
@@ -20,6 +20,7 @@ class MacOSXTTS(IOAdapter):
         Speak the response.
         """
         cmd = ['say', str(statement.text)]
-        subprocess.call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if platform.system().lower() == 'darwin':
+            subprocess.call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         return statement.text

--- a/chatterbot/adapters/io/tts.py
+++ b/chatterbot/adapters/io/tts.py
@@ -1,0 +1,25 @@
+from chatterbot.adapters.io import IOAdapter
+from chatterbot.utils.read_input import input_function
+
+import os
+import platform
+import subprocess
+
+
+class MacOSXTTS(IOAdapter):
+
+    def process_input(self):
+        """
+        Read the user's input from the terminal.
+        """
+        user_input = input_function()
+        return user_input
+
+    def process_response(self, statement):
+        """
+        Speak the response.
+        """
+        cmd = ['say', str(statement.text)]
+        subprocess.call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        return statement.text

--- a/tests/io_adapter_tests/test_tts.py
+++ b/tests/io_adapter_tests/test_tts.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+from chatterbot.conversation import Statement
+from chatterbot.adapters.io import MacOSXTTS
+
+
+class MacOSXTTSTests(TestCase):
+    """
+    The MacOSXTTS adapter is designed to allow
+    interaction with the chat bot to occur through
+    a command line interface and via speech.
+    """
+
+    def setUp(self):
+        self.adapter = MacOSXTTS()
+
+    def test_response_is_returned(self):
+        """
+        For consistency across io adapters, the
+        MacOSXTTS should return the output value.
+        """
+        statement = Statement("Testing speech synthesis.")
+
+        self.assertEqual(
+            self.adapter.process_response(statement),
+            statement.text
+        )


### PR DESCRIPTION
I added an io adapter for a TTS engine built in to MacOSX.

Although I added an output adapter, I have not added a corresponding STT adapter so it gets input using the Terminal. I recommend we make a change to the way io adapters are structured (which will also solve the problem with multiple inputs in my other PR), separating out input adapters and output adapters. This way, the user can specify more precisely what they would like to use for inputs and outputs. @gunthercox What do you think?