### PR TITLE
Add method for removing a statement

### DIFF
--- a/chatterbot/adapters/storage/jsondatabase.py
+++ b/chatterbot/adapters/storage/jsondatabase.py
@@ -35,6 +35,18 @@ class JsonDatabaseAdapter(StorageAdapter):
 
         return Statement(statement_text, **values)
 
+    def remove(self, statement_text):
+        """
+        Removes the statement that matches the input text.
+        Removes any responses from statements if the response text matches the
+        input text.
+        """
+        for statement in self.filter(in_response_to__contains=statement_text):
+            statement.remove_response(statement_text)
+            self.update(statement)
+
+        self.database.delete(statement_text)
+
     def deserialize_responses(self, response_list):
         """
         Takes the list of response items and returns the

--- a/chatterbot/adapters/storage/mongodb.py
+++ b/chatterbot/adapters/storage/mongodb.py
@@ -48,6 +48,18 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         return Statement(statement_text, **values)
 
+    def remove(self, statement_text):
+        """
+        Removes the statement that matches the input text.
+        Removes any responses from statements if the response text matches the
+        input text.
+        """
+        for statement in self.filter(in_response_to__contains=statement_text):
+            statement.remove_response(statement_text)
+            self.update(statement)
+
+        self.statements.remove({'text': statement_text})
+
     def deserialize_responses(self, response_list):
         """
         Takes the list of response items and returns the

--- a/chatterbot/adapters/storage/storage.py
+++ b/chatterbot/adapters/storage/storage.py
@@ -26,6 +26,14 @@ class StorageAdapter(Adapter):
         """
         raise AdapterNotImplementedError()
 
+    def remove(self, statement_text):
+        """
+        Removes the statement that matches the input text.
+        Removes any responses from statements where the response text matches
+        the input text.
+        """
+        raise AdapterNotImplementedError()
+
     def filter(self, **kwargs):
         """
         Returns a list of objects from the database.

--- a/chatterbot/conversation/statement.py
+++ b/chatterbot/conversation/statement.py
@@ -47,6 +47,17 @@ class Statement(object):
                 Response(statement.text)
             )
 
+    def remove_response(self, response_text):
+        """
+        Removes a response from the statement's response list based
+        on the value of the response text.
+        """
+        for response in self.in_response_to:
+            if response_text == response.text:
+                self.in_response_to.remove(response)
+                return True
+        return False
+
     def get_response_count(self, statement):
         """
         Return the number of times the statement occurs in the database.

--- a/tests/conversation_tests/test_statements.py
+++ b/tests/conversation_tests/test_statements.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from chatterbot.conversation import Statement
+from chatterbot.conversation import Statement, Response
 
 
 class StatementTests(TestCase):
@@ -37,6 +37,16 @@ class StatementTests(TestCase):
             1
         )
 
+    def test_remove_response_exists(self):
+        self.statement.add_response(Response("Testing"))
+        removed = self.statement.remove_response("Testing")
+        self.assertTrue(removed)
+
+    def test_remove_response_does_not_exist(self):
+        self.statement.add_response(Response("Testing"))
+        removed = self.statement.remove_response("Test")
+        self.assertFalse(removed)
+
     def test_serializer(self):
         data = self.statement.serialize()
         self.assertEqual(self.statement.text, data["text"])
@@ -71,4 +81,3 @@ class StatementTests(TestCase):
 
         self.assertEqual(len(self.statement.in_response_to), 1)
         self.assertEqual(self.statement.in_response_to[0].occurrence, 2)
-

--- a/tests/storage_adapter_tests/integration_tests/mongo_integration_tests.py
+++ b/tests/storage_adapter_tests/integration_tests/mongo_integration_tests.py
@@ -14,7 +14,7 @@ class MongoStorageIntegrationTests(StorageIntegrationTests, ChatBotTestCase):
         # Skip these tests if a mongo client is not running
         try:
             client = MongoClient(
-                serverSelectionTimeoutMS=0.5
+                serverSelectionTimeoutMS=0.2
             )
             client.server_info()
 

--- a/tests/storage_adapter_tests/test_jsondb_adapter.py
+++ b/tests/storage_adapter_tests/test_jsondb_adapter.py
@@ -163,6 +163,27 @@ class JsonDatabaseAdapterTestCase(JsonAdapterTestCase):
 
         self.assertEqual(len(results), 2)
 
+    def test_remove(self):
+        text = "Sometimes you have to run before you can walk."
+        statement = Statement(text)
+        self.adapter.update(statement)
+        self.adapter.remove(statement.text)
+        result = self.adapter.find(text)
+
+        self.assertIsNone(result)
+
+    def test_remove_response(self):
+        text = "Sometimes you have to run before you can walk."
+        statement = Statement(
+            "A test flight is not recommended at this design phase.",
+            in_response_to=[Response(text)]
+        )
+        self.adapter.update(statement)
+        self.adapter.remove(statement.text)
+        results = self.adapter.filter(in_response_to__contains=text)
+
+        self.assertEqual(results, [])
+
 
 class JsonDatabaseAdapterFilterTestCase(JsonAdapterTestCase):
 

--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -18,7 +18,7 @@ class MongoAdapterTestCase(TestCase):
         # Skip these tests if a mongo client is not running.
         try:
             client = MongoClient(
-                serverSelectionTimeoutMS=0.5
+                serverSelectionTimeoutMS=0.2
             )
             client.server_info()
 
@@ -173,6 +173,27 @@ class MongoDatabaseAdapterTestCase(MongoAdapterTestCase):
         results = self.adapter.deserialize_responses(response_list)
 
         self.assertEqual(len(results), 2)
+
+    def test_remove(self):
+        text = "Sometimes you have to run before you can walk."
+        statement = Statement(text)
+        self.adapter.update(statement)
+        self.adapter.remove(statement.text)
+        result = self.adapter.find(text)
+
+        self.assertIsNone(result)
+
+    def test_remove_response(self):
+        text = "Sometimes you have to run before you can walk."
+        statement = Statement(
+            "A test flight is not recommended at this design phase.",
+            in_response_to=[Response(text)]
+        )
+        self.adapter.update(statement)
+        self.adapter.remove(statement.text)
+        results = self.adapter.filter(in_response_to__contains=text)
+
+        self.assertEqual(results, [])
 
 
 class MongoAdapterFilterTestCase(MongoAdapterTestCase):


### PR DESCRIPTION
In the case that a statement needs to be removed from a database, this pull request adds the ability to do so.

Closes #126

### Example

The removal of a statement with the text `"Decepticons forever!"` would be executed as follows:

```python
chatbot = ChatBot("Optimus")
chatbot.storage.remove("Decepticons forever!")
```