### PR TITLE
Avoid import chatterbot in __init__.py when the loaded script is setu…

### DIFF
--- a/chatterbot/__init__.py
+++ b/chatterbot/__init__.py
@@ -1,5 +1,12 @@
-from .chatterbot import ChatBot
+import os
+import sys
+
+script_name = os.path.basename(sys.argv[0])
+
+if script_name != 'setup.py':
+        from .chatterbot import ChatBot
 
 __version__ = "0.3.7"
 __author__ = "Gunther Cox"
 __email__ = "gunthercx@gmail.com"
+


### PR DESCRIPTION
Hello, I had a problem installing Chattebot from `setup.py`:

```
Traceback (most recent call last):
  File "setup.py", line 7, in <module>
    version = __import__('chatterbot').__version__
  File "/Users/danno/ChatterBot/chatterbot/__init__.py", line 1, in <module>
    from .chatterbot import ChatBot
  File "/Users/danno/ChatterBot/chatterbot/chatterbot.py", line 2, in <module>
    from .adapters.storage import StorageAdapter
  File "/Users/danno/ChatterBot/chatterbot/adapters/storage/__init__.py", line 2, in <module>
    from .jsondatabase import JsonDatabaseAdapter
  File "/Users/danno/ChatterBot/chatterbot/adapters/storage/jsondatabase.py", line 4, in <module>
    from jsondb import Database
ImportError: cannot import name 'Database'
```

It was due to `setup.py` imports Chatterbot module (`__init__.py`) to get the author, version and name for the installation and since dependencies are not installed yet, the script gets the above error.

I'm new to python and I don't know if this commit is the best solution for the problem, but if not, I would appreciate any other fix, because Chatterbot will be a dependency to a project I'm working on :).

