### PR TITLE
Rename EvaluateMathematically logic adapter to MathematicalEvaluation

### DIFF
--- a/chatterbot/adapters/logic/__init__.py
+++ b/chatterbot/adapters/logic/__init__.py
@@ -4,5 +4,5 @@ from .closest_meaning import ClosestMeaningAdapter
 from .time_adapter import TimeLogicAdapter
 from .multi_adapter import MultiLogicAdapter
 from .no_knowledge_adapter import NoKnowledgeAdapter
-from .evaluate_mathematically import EvaluateMathematically
+from .mathematical_evaluation import MathematicalEvaluation
 from .weather import WeatherLogicAdapter

--- a/chatterbot/adapters/logic/mathematical_evaluation.py
+++ b/chatterbot/adapters/logic/mathematical_evaluation.py
@@ -6,11 +6,11 @@ import json
 import decimal
 
 
-class EvaluateMathematically(LogicAdapter):
+class MathematicalEvaluation(LogicAdapter):
     """
-    The EvaluateMathematically logic adapter parses input to
+    The MathematicalEvaluation logic adapter parses input to
     determine whether the user is asking a question that requires
-    math to be done. If so, EvaluateMathematically goes through a
+    math to be done. If so, MathematicalEvaluation goes through a
     set of steps to parse the input and extract the equation that
     must be solved. The steps, in order, are:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -98,7 +98,7 @@ and returns a response to that statement.
 You can choose to use as many logic adapters as you would like.
 In this example we will use two logic adapters. The TimeLogicAdapter returns
 the current time when the input statement asks for it.
-The EvaluateMathematically adapter solves math problems that use basic
+The MathematicalEvaluation adapter solves math problems that use basic
 operations.
 
 .. code-block:: python
@@ -109,7 +109,7 @@ operations.
        input_adapter="chatterbot.adapters.input.TerminalAdapter",
        output_adapter="chatterbot.adapters.output.TerminalAdapter",
        logic_adapters=[
-           "chatterbot.adapters.logic.EvaluateMathematically",
+           "chatterbot.adapters.logic.MathematicalEvaluation",
            "chatterbot.adapters.logic.TimeLogicAdapter"
        ],
        database="./database.json"

--- a/examples/math_and_time.py
+++ b/examples/math_and_time.py
@@ -4,7 +4,7 @@ from chatterbot import ChatBot
 bot = ChatBot(
     "Math & Time Bot",
     logic_adapters=[
-        "chatterbot.adapters.logic.EvaluateMathematically",
+        "chatterbot.adapters.logic.MathematicalEvaluation",
         "chatterbot.adapters.logic.TimeLogicAdapter"
     ],
     input_adapter="chatterbot.adapters.input.VariableInputTypeAdapter",

--- a/examples/terminal_example.py
+++ b/examples/terminal_example.py
@@ -10,7 +10,7 @@ ctrl-c or ctrl-d on the keyboard.
 bot = ChatBot("Terminal",
     storage_adapter="chatterbot.adapters.storage.JsonDatabaseAdapter",
     logic_adapters=[
-        "chatterbot.adapters.logic.EvaluateMathematically",
+        "chatterbot.adapters.logic.MathematicalEvaluation",
         "chatterbot.adapters.logic.TimeLogicAdapter",
         "chatterbot.adapters.logic.ClosestMatchAdapter"
     ],

--- a/tests/logic_adapter_tests/test_evaluate_mathematically.py
+++ b/tests/logic_adapter_tests/test_evaluate_mathematically.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
-from chatterbot.adapters.logic import EvaluateMathematically
+from chatterbot.adapters.logic import MathematicalEvaluation
 from chatterbot.conversation import Statement
 
 
-class EvaluateMathematicallyTests(TestCase):
+class MathematicalEvaluationTests(TestCase):
 
     def setUp(self):
-        self.adapter = EvaluateMathematically()
+        self.adapter = MathematicalEvaluation()
 
     def test_can_process(self):
         statement = Statement("What is 10 + 10 + 10?")
@@ -47,12 +47,12 @@ class EvaluateMathematicallyTests(TestCase):
         self.assertIn("numbers", self.adapter.data)
 
 
-class MathematicalEvaluationTests(TestCase):
+class MathematicalEvaluationOperationTests(TestCase):
 
     def setUp(self):
         import sys
 
-        self.adapter = EvaluateMathematically()
+        self.adapter = MathematicalEvaluation()
 
         # Some tests may return decimals under python 3
         self.python_version = sys.version_info[0]


### PR DESCRIPTION
:rocket: This is just a rename for aesthetic purposes. "MathematicalEvaluation adapter" rolls off the tongue a bit better.