### PR TITLE
Return a confidence of zero if a random response is selected

### DIFF
--- a/chatterbot/adapters/logic/base_match.py
+++ b/chatterbot/adapters/logic/base_match.py
@@ -57,4 +57,7 @@ class BaseMatchAdapter(TieBreaking, LogicAdapter):
         else:
             response = self.context.storage.get_random()
 
+            # Set confidence to zero if a random response is selected
+            confidence = 0
+
         return confidence, response

--- a/tests/logic_adapter_tests/test_closest_match.py
+++ b/tests/logic_adapter_tests/test_closest_match.py
@@ -84,3 +84,22 @@ class ClosestMatchAdapterTests(TestCase):
         confidence, match = self.adapter.get(statement)
 
         self.assertEqual(confidence, 0)
+
+    def test_no_known_responses(self):
+        """
+        In the case that a match is selected which has no known responses.
+        In this case a random response will be returned, but the confidence
+        should be zero because it is a random choice.
+        """
+        self.adapter.context.storage.update = MagicMock()
+        self.adapter.context.storage.filter = MagicMock(
+            return_value=[]
+        )
+        self.adapter.context.storage.get_random = MagicMock(
+            return_value=Statement("Random")
+        )
+
+        confidence, match = self.adapter.process(Statement("Blah"))
+
+        self.assertEqual(confidence, 0)
+        self.assertEqual(match.text, "Random")


### PR DESCRIPTION
In the base class for the matching adapters, if no possible responses to the input are known then a random response is chosen from the database. This needed to be changed so that if so that if a random response is selected, a confidence value of zero is returned.

Closes #243