### PR TITLE
count check before its use

### DIFF
--- a/chatterbot/adapters/storage/mongodb.py
+++ b/chatterbot/adapters/storage/mongodb.py
@@ -157,10 +157,10 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         count = self.count()
 
-        random_integer = randint(0, count - 1)
-
-        if self.count() < 1:
+        if count < 1:
             raise self.EmptyDatabaseException()
+
+        random_integer = randint(0, count - 1)
 
         statement = self.statements.find().limit(1).skip(random_integer)
 


### PR DESCRIPTION

        count = self.count()
        random_integer = randint(0, count - 1)    #l2
        if self.count() < 1:
            raise self.EmptyDatabaseException()

if count is less than 1, then #2 will result in valueError
```
In [5]: count  = 0
In [6]: random.randint(0, count-1)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-ab1e1b11223b> in <module>()
----> 1 random.randint(0, count-1)

/usr/lib/python2.7/random.pyc in randint(self, a, b)
    240         """
    241 
--> 242         return self.randrange(a, b+1)
    243 
    244     def _randbelow(self, n, _log=_log, _int=int, _maxwidth=1L<<BPF,

/usr/lib/python2.7/random.pyc in randrange(self, start, stop, step, _int, _maxwidth)
    216             return _int(istart + _int(self.random()*width))
    217         if step == 1:
--> 218             raise ValueError, "empty range for randrange() (%d,%d, %d)" % (istart, istop, width)
    219 
    220         # Non-unit step argument supplied.

ValueError: empty range for randrange() (0,0, 0)
```

same  error  with all values less than 1  e.g. `count=-1`