### PR TITLE
Avoid problems in str.format() with char accents

### DIFF
--- a/chatterbot/utils/read_input.py
+++ b/chatterbot/utils/read_input.py
@@ -10,4 +10,8 @@ def input_function():
         user_input = str(raw_input())
     else:
         user_input = input()
+
+    if user_input:
+        user_input = user_input.decode('utf-8')
+        
     return user_input


### PR DESCRIPTION
If you input a char like "é" or "ã" with terminalAdapter, in log method str.format(), if no unicode .format(() raise a error.

To reproduce, just clone master, and run with IN/OUT using TerminalAdapter.

Thanks