### PR TITLE
Create language filter

### DIFF
--- a/chatterbot/adapters/storage/mongodb.py
+++ b/chatterbot/adapters/storage/mongodb.py
@@ -25,6 +25,30 @@ class Query(object):
 
         return Query(query)
 
+    def statement_text_does_not_contain(self, word_list):
+        query = self.query.copy()
+
+        word_string = '|'.join(word_list).strip()
+
+        word_string = '{}'.format(word_string)
+
+        print 'regex-->', word_string
+
+        query = {
+            'in_response_to': {
+                '$elemMatch': {
+                    'text': {
+                        '$regex': '^((?!crap).)*$',
+
+                        # Option i allows for case insensitive search
+                        '$options' : 'i'
+                    }
+                }
+            }
+        }
+
+        return Query(query)
+
     def statement_text_not_in(self, statements):
         query = self.query.copy()
 

--- a/chatterbot/filters.py
+++ b/chatterbot/filters.py
@@ -34,3 +34,27 @@ class RepetitiveResponseFilter(Filter):
 
         return query
 
+
+class LanguageFilter(Filter):
+    """
+    A filter that excludes swear words and explicit
+    language from the selection of possible responses
+    that a chat bot can respond with.
+    """
+
+    def __init__(self):
+        import os
+        import io
+
+        current_directory = os.path.dirname(__file__)
+        swear_words = os.path.join(
+            current_directory, 'corpus', 'data', 'english', 'swear_words.csv'
+        )
+
+        with io.open(swear_words, encoding='utf-8') as data_file:
+            self.words = data_file.read().split(',')
+
+    def filter_selection(self, chatterbot):
+        return chatterbot.storage.base_query.statement_text_does_not_contain(
+            self.words
+        )

--- a/docs/filters/index.rst
+++ b/docs/filters/index.rst
@@ -21,3 +21,15 @@ Repetitive response filter
        filters="chatterbot.filters.RepetitiveResponseFilter"
    )
 
+Language filter
+===============
+
+.. autofunction:: chatterbot.filters.LanguageFilter
+
+.. code-block:: python
+
+   chatbot = ChatBot(
+       "My ChatterBot",
+       filters="chatterbot.filters.LanguageFilter"
+   )
+

--- a/examples/terminal_mongo_example.py
+++ b/examples/terminal_mongo_example.py
@@ -1,5 +1,5 @@
 from chatterbot import ChatBot
-from chatterbot.filters import RepetitiveResponseFilter
+from chatterbot.filters import LanguageFilter, RepetitiveResponseFilter
 import logging
 
 
@@ -13,6 +13,7 @@ bot = ChatBot("Terminal",
         "chatterbot.adapters.logic.ClosestMatchAdapter"
     ],
     filters=(
+        LanguageFilter,
         RepetitiveResponseFilter
     ),
     input_adapter="chatterbot.adapters.input.TerminalAdapter",

--- a/tests/filter_integration_tests/test_filters_with_mongo_storage.py
+++ b/tests/filter_integration_tests/test_filters_with_mongo_storage.py
@@ -27,3 +27,32 @@ class RepetitiveResponseFilterTestCase(ChatBotMongoTestCase):
         self.assertEqual(first_response.text, 'Hi')
         self.assertEqual(second_response.text, 'Hi, how are you?')
 
+
+class LanguageFilterTestCase(ChatBotMongoTestCase):
+
+    def test_filter_selection(self):
+        from chatterbot.filters import LanguageFilter
+        from chatterbot.trainers import ListTrainer
+
+        self.chatbot.filters.append(LanguageFilter)
+        self.chatbot.set_trainer(ListTrainer)
+
+        self.chatbot.train([
+            'Look over there at that pile of crap!',
+            'Wow, that is a lot shit.',
+            'Dammit! Who is going to clean that up?'
+        ])
+
+        self.chatbot.train([
+            'Look at that pile of crap!',
+            'Wow, that is a lot poop.',
+            'Who is going to clean that up?'
+        ])
+
+        # Check that the bot avoids responses with swears
+        response = self.chatbot.get_response(
+            'Look over there at that pile of crap!'
+        )
+
+        self.assertEqual(response.text, 'Wow, that is a lot poop.')
+


### PR DESCRIPTION
When I'm presenting an application built with ChatterBot, having this filter enabled will make it so that the chat bot cannot return a response with a swear in it :)

That's what I get for using Twitter as a source of training data :dizzy_face: 

WIP status:
- [x] Resolve issue with random response and base query
  - Priority for filters?
- [x] Resolve issue with response data containing results that we want to ignore

***

Closes #1052