### PR TITLE
Add a sentiment selection based logic adapter

### DIFF
--- a/chatterbot/adapters/logic/__init__.py
+++ b/chatterbot/adapters/logic/__init__.py
@@ -6,3 +6,4 @@ from .multi_adapter import MultiLogicAdapter
 from .no_knowledge_adapter import NoKnowledgeAdapter
 from .mathematical_evaluation import MathematicalEvaluation
 from .approximate_sentence_match import ApproximateSentenceMatchAdapter
+from .sentiment_adapter import SentimentAdapter

--- a/chatterbot/adapters/logic/sentiment_adapter.py
+++ b/chatterbot/adapters/logic/sentiment_adapter.py
@@ -1,0 +1,45 @@
+from chatterbot.adapters.logic import LogicAdapter
+from chatterbot.conversation import Statement
+from textblob import TextBlob
+
+
+class SentimentAdapter(LogicAdapter):
+    """
+    This adapter selects a response with the closest
+    matching sentiment value to the input statement.
+    """
+
+    def calculate_closeness(self, input_sentiment, response_sentiment):
+        """
+        Return the difference between the input and response
+        sentiment values.
+        """
+        return abs(input_sentiment - response_sentiment)
+
+    def process(self, statement):
+        input_blob = TextBlob(statement.text)
+        input_sentiment = input_blob.sentiment.polarity
+
+        response_list = self.context.storage.filter(
+            in_response_to__contains=statement.text
+        )
+
+        if not response_list:
+            return 0, self.context.storage.get_random()
+
+        best_response = response_list[0]
+        max_closeness = 1
+
+        for response in response_list:
+            blob = TextBlob(response.text)
+            sentiment = blob.sentiment.polarity
+
+            closeness = self.calculate_closeness(input_sentiment, sentiment)
+            if closeness < max_closeness:
+                best_response = response
+                max_closeness = closeness
+
+        # The confidence is the percentage of closeness
+        confidence = 1.0 - max_closeness
+
+        return confidence, best_response

--- a/chatterbot/adapters/logic/sentiment_adapter.py
+++ b/chatterbot/adapters/logic/sentiment_adapter.py
@@ -14,21 +14,27 @@ class SentimentAdapter(LogicAdapter):
         Return the difference between the input and response
         sentiment values.
         """
+        self.logger.info(
+            u'Comparing input equality of {} to response of {}.'.format(
+                input_sentiment, response_sentiment
+            )
+        )
         return abs(input_sentiment - response_sentiment)
 
     def process(self, statement):
         input_blob = TextBlob(statement.text)
         input_sentiment = input_blob.sentiment.polarity
 
-        response_list = self.context.storage.filter(
-            in_response_to__contains=statement.text
+        self.logger.info(
+            u'"{}" has a sentiment polarity of {}.'.format(
+                statement.text, input_sentiment
+            )
         )
 
-        if not response_list:
-            return 0, self.context.storage.get_random()
+        response_list = self.context.storage.filter()
 
         best_response = response_list[0]
-        max_closeness = 1
+        max_closeness = 0.0
 
         for response in response_list:
             blob = TextBlob(response.text)
@@ -39,7 +45,4 @@ class SentimentAdapter(LogicAdapter):
                 best_response = response
                 max_closeness = closeness
 
-        # The confidence is the percentage of closeness
-        confidence = 1.0 - max_closeness
-
-        return confidence, best_response
+        return max_closeness, best_response

--- a/docs/adapters/logic.rst
+++ b/docs/adapters/logic.rst
@@ -107,6 +107,14 @@ Example
 | User: What is four plus four?
 | Bot: (4 + 4) = 8
 
+SentimentAdapter
+================
+
+.. autofunction:: chatterbot.adapters.logic.SentimentAdapter
+
+This is a logic adapter that selects a response that has the closest matching
+sentiment value to the input.
+
 .. _wordnet: http://www.nltk.org/howto/wordnet.html
 .. _NLTK: http://www.nltk.org/
 .. _`Jaccard similarity index`: https://en.wikipedia.org/wiki/Jaccard_index

--- a/tests/logic_adapter_tests/test_sentiment.py
+++ b/tests/logic_adapter_tests/test_sentiment.py
@@ -17,28 +17,28 @@ class SentimentAdapterTests(ChatBotTestCase):
 
         self.chatbot.train([
             'What is your favorite flavor of ice cream?',
-            'I love raspberry ice cream',
-            'That is great',
-            'Thank you'
+            'I enjoy raspberry ice cream.',
+            'I am glad to hear that.',
+            'Thank you.'
         ])
 
-        happy_statement = Statement('I love raspberry ice cream')
+        happy_statement = Statement('I enjoy raspberry ice cream.')
         confidence, response = self.adapter.process(happy_statement)
 
-        self.assertEqual(confidence, 0.7)
-        self.assertEqual(response.text, 'That is great')
+        self.assertEqual(confidence, 1)
+        self.assertEqual(response.text, 'I am glad to hear that.')
 
     def test_close_input(self):
 
         self.chatbot.train([
-            'Do you like ice cream?',
-            'I love ice cream',
-            'That is great',
-            'Thank you'
+            'What is your favorite flavor of ice cream?',
+            'I enjoy raspberry ice cream.',
+            'I am glad to hear that.',
+            'Thank you.'
         ])
 
-        happy_statement = Statement('I like ice cream')
+        happy_statement = Statement('I like raspberry ice cream.')
         confidence, response = self.adapter.process(happy_statement)
 
-        self.assertEqual(confidence, 0.2)
-        self.assertEqual(response.text, 'That is great')
+        self.assertEqual(confidence, 0.6)
+        self.assertEqual(response.text, 'I am glad to hear that.')

--- a/tests/logic_adapter_tests/test_sentiment.py
+++ b/tests/logic_adapter_tests/test_sentiment.py
@@ -1,0 +1,42 @@
+from tests.base_case import ChatBotTestCase
+from chatterbot.adapters.logic import SentimentAdapter
+from chatterbot.conversation import Statement
+
+
+class SentimentAdapterTests(ChatBotTestCase):
+
+    def setUp(self):
+        super(SentimentAdapterTests, self).setUp()
+        self.adapter = SentimentAdapter()
+        self.adapter.set_context(self.chatbot)
+
+    def test_exact_input(self):
+
+        self.chatbot.train([
+            'What is your favorite flavor of ice cream?',
+            'I love raspberry ice cream',
+            'That is great',
+            'Thank you'
+        ])
+
+        happy_statement = Statement('I love raspberry ice cream')
+        confidence, response = self.adapter.process(happy_statement)
+
+        self.assertEqual(confidence, 0.7)
+        self.assertEqual(response.text, 'That is great')
+
+    def test_close_input(self):
+
+        self.chatbot.train([
+            'I love ice cream',
+            'That is great',
+            'Thank you'
+        ])
+
+        happy_statement = Statement('I like ice cream')
+        confidence, response = self.adapter.process(happy_statement)
+
+        print response
+
+        self.assertEqual(confidence, 0.2)
+        self.assertEqual(response.text, 'That is great')

--- a/tests/logic_adapter_tests/test_sentiment.py
+++ b/tests/logic_adapter_tests/test_sentiment.py
@@ -7,6 +7,9 @@ class SentimentAdapterTests(ChatBotTestCase):
 
     def setUp(self):
         super(SentimentAdapterTests, self).setUp()
+        from chatterbot.trainers import ListTrainer
+
+        self.chatbot.set_trainer(ListTrainer)
         self.adapter = SentimentAdapter()
         self.adapter.set_context(self.chatbot)
 
@@ -28,6 +31,7 @@ class SentimentAdapterTests(ChatBotTestCase):
     def test_close_input(self):
 
         self.chatbot.train([
+            'Do you like ice cream?',
             'I love ice cream',
             'That is great',
             'Thank you'
@@ -35,8 +39,6 @@ class SentimentAdapterTests(ChatBotTestCase):
 
         happy_statement = Statement('I like ice cream')
         confidence, response = self.adapter.process(happy_statement)
-
-        print response
 
         self.assertEqual(confidence, 0.2)
         self.assertEqual(response.text, 'That is great')


### PR DESCRIPTION
The goal of this adapter is to allow the chat bot to respond to input based on the level of sentiment that the input contains.

- [x] Create logic adapter
- [x] Add tests
- [x] Update documentation

Recreation of #167
Closes #7 