### PR TITLE
Improve the Bayes classifier in time_adapter.py

### DIFF
--- a/chatterbot/adapters/logic/time_adapter.py
+++ b/chatterbot/adapters/logic/time_adapter.py
@@ -17,7 +17,6 @@ class TimeLogicAdapter(LogicAdapter):
             ("do you know the time", 1),
             ("do you know what time it is", 1),
             ("what is the time", 1),
-            ("do you know the time", 0),
             ("it is time to go to sleep", 0),
             ("what is your favorite color", 0),
             ("i had a great time", 0),


### PR DESCRIPTION
It looks like `"do you know the time"` was accidentally added to both the "hit" and "miss" lists. This commit ensures it's classified as a match.