### PR TITLE
Move logic adapter statement comparison methods to their own module

### DIFF
--- a/chatterbot/adapters/logic/approximate_sentence_match.py
+++ b/chatterbot/adapters/logic/approximate_sentence_match.py
@@ -8,7 +8,7 @@ class ApproximateSentenceMatchAdapter(BaseMatchAdapter):
         super(ClosestMatchAdapter, self).__init__(**kwargs)
         from chatterbot.conversation.comparisons import jaccard_similarity
 
-        self.statement_comparison_function = kwargs.get(
+        self.compare_statements = kwargs.get(
             'statement_comparison_function',
             jaccard_similarity
         )
@@ -31,10 +31,7 @@ class ApproximateSentenceMatchAdapter(BaseMatchAdapter):
         sentence_match = input_statement
         # Find the matching known statement
         for statement in statement_list:
-            ratio = self.statement_comparison_function(
-                input_statement.text,
-                statement.text
-            )
+            ratio = self.compare_statements(input_statement, statement)
             if ratio:
                 closest_match = statement
             else:

--- a/chatterbot/adapters/logic/approximate_sentence_match.py
+++ b/chatterbot/adapters/logic/approximate_sentence_match.py
@@ -1,72 +1,17 @@
 # -*- coding: utf-8 -*-
-from chatterbot.adapters import Adapter
 from .base_match import BaseMatchAdapter
-from nltk.corpus import wordnet
-import nltk.corpus
-import nltk.tokenize.punkt
-import nltk.stem.snowball
-import string
 
 
 class ApproximateSentenceMatchAdapter(BaseMatchAdapter):
-    """
-    The Jaccard index is composed of a numerator and denominator.
-    In the numerator, we count the number of items that are shared between the sets.
-    In the denominator, we count the total number of items across both sets.
-    Let’s say we define sentences to be equivalent if 50% or more of their tokens are equivalent.
-    Here are two sample sentences:
-
-        The young cat is hungry.
-        The cat is very hungry.
-
-    When we parse these sentences to remove stopwords, we end up with the following two sets:
-
-        {young, cat, hungry}
-        {cat, very, hungry}
-
-    In our example above, our intersection is {cat, hungry}, which has count of two.
-    The union of the sets is {young, cat, very, hungry}, which has a count of four.
-    Therefore, our Jaccard similarity index is two divided by four, or 50%.
-    Given our threshold above, we would consider this to be  a match
-    """
 
     def __init__(self, **kwargs):
         super(ClosestMatchAdapter, self).__init__(**kwargs)
-        # Get default English stopwords and extend with punctuation
-        self.stopwords = nltk.corpus.stopwords.words('english')
-        self.stopwords.extend(string.punctuation)
-        self.stopwords.append('')
-        self.lemmatizer = nltk.stem.wordnet.WordNetLemmatizer()
+        from chatterbot.conversation.comparisons import jaccard_similarity
 
-    def get_wordnet_pos(self, pos_tag):
-        if pos_tag[1].startswith('J'):
-            return (pos_tag[0], wordnet.ADJ)
-        elif pos_tag[1].startswith('V'):
-            return (pos_tag[0], wordnet.VERB)
-        elif pos_tag[1].startswith('N'):
-            return (pos_tag[0], wordnet.NOUN)
-        elif pos_tag[1].startswith('R'):
-            return (pos_tag[0], wordnet.ADV)
-        else:
-            return (pos_tag[0], wordnet.NOUN)
-
-
-    def is_ci_lemma_stopword_set_match(self,a, b, threshold=0.5):
-        """Check if a and b are matches."""
-        ratio = 0
-        pos_a = map(self.get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(a)))
-        pos_b = map(self.get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(b)))
-        lemmae_a = [self.lemmatizer.lemmatize(token.lower().strip(string.punctuation), pos) for token, pos in pos_a \
-                        if pos == wordnet.NOUN and token.lower().strip(string.punctuation) not in self.stopwords]
-        lemmae_b = [self.lemmatizer.lemmatize(token.lower().strip(string.punctuation), pos) for token, pos in pos_b \
-                        if pos == wordnet.NOUN and token.lower().strip(string.punctuation) not in self.stopwords]
-
-        # Calculate Jaccard similarity
-        try:
-            ratio = len(set(lemmae_a).intersection(lemmae_b)) / float(len(set(lemmae_a).union(lemmae_b)))
-        except Exception as e:
-            print("Error", e)
-        return (ratio >= threshold)
+        self.statement_comparison_function = kwargs.get(
+            'statement_comparison_function',
+            jaccard_similarity
+        )
 
     def get(self, input_statement):
         """
@@ -84,11 +29,14 @@ class ApproximateSentenceMatchAdapter(BaseMatchAdapter):
 
         confidence = -1
         sentence_match = input_statement
-        # Find the  matching known statement
+        # Find the matching known statement
         for statement in statement_list:
-            ratio = self.is_ci_lemma_stopword_set_match(input_statement.text, statement.text)
+            ratio = self.statement_comparison_function(
+                input_statement.text,
+                statement.text
+            )
             if ratio:
                 closest_match = statement
             else:
                 closest_match = statement
-        return 0.5,closest_match
+        return 0.5, closest_match

--- a/chatterbot/adapters/logic/base_match.py
+++ b/chatterbot/adapters/logic/base_match.py
@@ -18,7 +18,7 @@ class BaseMatchAdapter(TieBreaking, LogicAdapter):
             "first_response"
         )
 
-        self.statement_comparison_function = kwargs.get(
+        self.compare_statements = kwargs.get(
             'statement_comparison_function',
             levenshtein_distance
         )

--- a/chatterbot/adapters/logic/base_match.py
+++ b/chatterbot/adapters/logic/base_match.py
@@ -11,10 +11,16 @@ class BaseMatchAdapter(TieBreaking, LogicAdapter):
 
     def __init__(self, **kwargs):
         super(BaseMatchAdapter, self).__init__(**kwargs)
+        from chatterbot.conversation.comparisons import levenshtein_distance
 
         self.tie_breaking_method = kwargs.get(
             "tie_breaking_method",
             "first_response"
+        )
+
+        self.statement_comparison_function = kwargs.get(
+            'statement_comparison_function',
+            levenshtein_distance
         )
 
     @property

--- a/chatterbot/adapters/logic/closest_match.py
+++ b/chatterbot/adapters/logic/closest_match.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from fuzzywuzzy import fuzz
-
 from .base_match import BaseMatchAdapter
 
 
 class ClosestMatchAdapter(BaseMatchAdapter):
     """
-    The ClosestMatchAdapter logic adapter creates a response by 
-    using fuzzywuzzy's process class to extract the most similar
-    response to the input. This adapter selects a response to an
-    input statement by selecting the closest known matching
-    statement based on the Levenshtein Distance between the text
+    The ClosestMatchAdapter logic adapter selects a known response
+    to an input by searching for a known statement that most closely
+    matches the input based on the Levenshtein Distance between the text
     of each statement.
     """
 

--- a/chatterbot/adapters/logic/closest_match.py
+++ b/chatterbot/adapters/logic/closest_match.py
@@ -29,18 +29,18 @@ class ClosestMatchAdapter(BaseMatchAdapter):
             else:
                 raise self.EmptyDatasetException()
 
-        confidence = -1
         closest_match = input_statement
+        closest_similarity = -1
 
         # Find the closest matching known statement
         for statement in statement_list:
             ratio = fuzz.ratio(input_statement.text.lower(), statement.text.lower())
 
-            if ratio > confidence:
-                confidence = ratio
+            if ratio > closest_similarity:
+                closest_similarity = ratio
                 closest_match = statement
 
         # Convert the confidence integer to a percent
-        confidence /= 100.0
+        confidence = closest_similarity / 100.0
 
         return confidence, closest_match

--- a/chatterbot/adapters/logic/closest_match.py
+++ b/chatterbot/adapters/logic/closest_match.py
@@ -34,10 +34,10 @@ class ClosestMatchAdapter(BaseMatchAdapter):
 
         # Find the closest matching known statement
         for statement in statement_list:
-            ratio = fuzz.ratio(input_statement.text.lower(), statement.text.lower())
+            similarity = self.compare_statements(input_statement, statement)
 
-            if ratio > closest_similarity:
-                closest_similarity = ratio
+            if similarity > closest_similarity:
+                closest_similarity = similarity
                 closest_match = statement
 
         # Convert the confidence integer to a percent

--- a/chatterbot/adapters/logic/closest_meaning.py
+++ b/chatterbot/adapters/logic/closest_meaning.py
@@ -15,7 +15,7 @@ class ClosestMeaningAdapter(BaseMatchAdapter):
         super(ClosestMeaningAdapter, self).__init__(**kwargs)
         from chatterbot.conversation.comparisons import synset_distance
 
-        self.statement_comparison_function = kwargs.get(
+        self.compare_statements = kwargs.get(
             'statement_comparison_function',
             synset_distance
         )
@@ -44,10 +44,7 @@ class ClosestMeaningAdapter(BaseMatchAdapter):
 
         # For each option in the list of options
         for statement in statement_list:
-            similarity = self.statement_comparison_function(
-                input_statement,
-                statement
-            )
+            similarity = self.compare_statements(input_statement, statement)
 
             total_similarity += similarity
 

--- a/chatterbot/adapters/logic/closest_meaning.py
+++ b/chatterbot/adapters/logic/closest_meaning.py
@@ -38,7 +38,7 @@ class ClosestMeaningAdapter(BaseMatchAdapter):
             else:
                 raise self.EmptyDatasetException()
 
-        closest_statement = None
+        closest_match = input_statement
         closest_similarity = -1
         total_similarity = 0
 
@@ -53,11 +53,11 @@ class ClosestMeaningAdapter(BaseMatchAdapter):
 
             if similarity > closest_similarity:
                 closest_similarity = similarity
-                closest_statement = statement
+                closest_match = statement
 
         try:
             confidence = closest_similarity / total_similarity
         except:
             confidence = 0
 
-        return confidence, closest_statement
+        return confidence, closest_match

--- a/chatterbot/adapters/logic/closest_meaning.py
+++ b/chatterbot/adapters/logic/closest_meaning.py
@@ -38,15 +38,6 @@ class ClosestMeaningAdapter(BaseMatchAdapter):
             else:
                 raise self.EmptyDatasetException()
 
-        # Get the text of each statement
-        text_of_all_statements = []
-        for statement in statement_list:
-            text_of_all_statements.append(statement.text)
-
-        # Check if an exact match exists
-        if input_statement.text in text_of_all_statements:
-            return 1, input_statement
-
         closest_statement = None
         closest_similarity = -1
         total_similarity = 0

--- a/chatterbot/conversation/comparisons.py
+++ b/chatterbot/conversation/comparisons.py
@@ -1,0 +1,125 @@
+def levenshtein_distance(statement, other_statement):
+    from fuzzywuzzy import fuzz
+
+    return fuzz.ratio(statement.text, other_statement.text)
+
+
+def synset_distance(statement, other_statement):
+    """
+    Calculate the similarity of two statements.
+    This is based on the total similarity between
+    each word in each sentence.
+    """
+    from chatterbot.utils.pos_tagger import POSTagger
+    from chatterbot.utils.stop_words import StopWordsManager
+    from chatterbot.utils.word_net import Wordnet
+    import itertools
+
+    wordnet = Wordnet()
+    tagger = POSTagger()
+    stopwords = StopWordsManager()
+
+    def get_tokens(text, exclude_stop_words=True):
+        """
+        Takes a string and converts it to a tuple
+        of each word. Skips common stop words such
+        as ("is, the, a, ...") is 'exclude_stop_words'
+        is True.
+        """
+        lower = text.lower()
+        tokens = tagger.tokenize(lower)
+
+        # Remove any stop words from the string
+        if exclude_stop_words:
+            excluded_words = stopwords.words('english')
+
+            tokens = set(tokens) - set(excluded_words)
+
+        return tokens
+
+    tokens1 = get_tokens(statement.text)
+    tokens2 = get_tokens(other_statement.text)
+
+    total_similarity = 0
+
+    # Get the highest matching value for each possible combination of words
+    for combination in itertools.product(*[tokens1, tokens2]):
+
+        synset1 = wordnet.synsets(combination[0])
+        synset2 = wordnet.synsets(combination[1])
+
+        if synset1 and synset2:
+
+            max_similarity = 0
+
+            # Get the highest similarity for each combination of synsets
+            for synset in itertools.product(*[synset1, synset2]):
+                similarity = synset[0].path_similarity(synset[1])
+
+                if similarity and (similarity > max_similarity):
+                    max_similarity = similarity
+
+            # Add the most similar path value to the total
+            total_similarity += max_similarity
+
+    return total_similarity
+
+
+def jaccard_similarity(self,a, b, threshold=0.5):
+    """
+    The Jaccard index is composed of a numerator and denominator.
+    In the numerator, we count the number of items that are shared between the sets.
+    In the denominator, we count the total number of items across both sets.
+    Let's say we define sentences to be equivalent if 50% or more of their tokens are equivalent.
+    Here are two sample sentences:
+
+        The young cat is hungry.
+        The cat is very hungry.
+
+    When we parse these sentences to remove stopwords, we end up with the following two sets:
+
+        {young, cat, hungry}
+        {cat, very, hungry}
+
+    In our example above, our intersection is {cat, hungry}, which has count of two.
+    The union of the sets is {young, cat, very, hungry}, which has a count of four.
+    Therefore, our Jaccard similarity index is two divided by four, or 50%.
+    Given our threshold above, we would consider this to be  a match
+    """
+    from nltk.corpus import wordnet
+    import nltk.corpus
+    import nltk
+    import string
+
+    # Get default English stopwords and extend with punctuation
+    self.stopwords = nltk.corpus.stopwords.words('english')
+    self.stopwords.extend(string.punctuation)
+    self.stopwords.append('')
+    self.lemmatizer = nltk.stem.wordnet.WordNetLemmatizer()
+
+    def get_wordnet_pos(pos_tag):
+        if pos_tag[1].startswith('J'):
+            return (pos_tag[0], wordnet.ADJ)
+        elif pos_tag[1].startswith('V'):
+            return (pos_tag[0], wordnet.VERB)
+        elif pos_tag[1].startswith('N'):
+            return (pos_tag[0], wordnet.NOUN)
+        elif pos_tag[1].startswith('R'):
+            return (pos_tag[0], wordnet.ADV)
+        else:
+            return (pos_tag[0], wordnet.NOUN)
+
+    ratio = 0
+    pos_a = map(get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(a)))
+    pos_b = map(get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(b)))
+    lemmae_a = [self.lemmatizer.lemmatize(token.lower().strip(string.punctuation), pos) for token, pos in pos_a \
+                    if pos == wordnet.NOUN and token.lower().strip(string.punctuation) not in self.stopwords]
+    lemmae_b = [self.lemmatizer.lemmatize(token.lower().strip(string.punctuation), pos) for token, pos in pos_b \
+                    if pos == wordnet.NOUN and token.lower().strip(string.punctuation) not in self.stopwords]
+
+    # Calculate Jaccard similarity
+    try:
+        ratio = len(set(lemmae_a).intersection(lemmae_b)) / float(len(set(lemmae_a).union(lemmae_b)))
+    except Exception as e:
+        print('Error', e)
+    return (ratio >= threshold)

--- a/chatterbot/conversation/comparisons.py
+++ b/chatterbot/conversation/comparisons.py
@@ -1,7 +1,7 @@
 def levenshtein_distance(statement, other_statement):
     from fuzzywuzzy import fuzz
 
-    return fuzz.ratio(statement.text, other_statement.text)
+    return fuzz.ratio(statement.text.lower(), other_statement.text.lower())
 
 
 def synset_distance(statement, other_statement):


### PR DESCRIPTION
Logic adapters should use the comparison method passed to the chat bot. This should simplify and reduce the amount of code that needs to be written to create text-matching style logic adapters.