### PR TITLE
Force training even if read_only is True

### DIFF
--- a/chatterbot/adapters/storage/django_storage.py
+++ b/chatterbot/adapters/storage/django_storage.py
@@ -72,7 +72,7 @@ class DjangoStorageAdapter(StorageAdapter):
 
         return results
 
-    def update(self, statement):
+    def update(self, statement, **kwargs):
         from chatterbot.ext.django_chatterbot.models import Statement as StatementModel
         from chatterbot.ext.django_chatterbot.models import Response as ResponseModel
         # Do not alter the database unless writing is enabled

--- a/chatterbot/adapters/storage/jsonfile.py
+++ b/chatterbot/adapters/storage/jsonfile.py
@@ -129,7 +129,7 @@ class JsonFileStorageAdapter(StorageAdapter):
 
         return results
 
-    def update(self, statement):
+    def update(self, statement, **kwargs):
         # Do not alter the database unless writing is enabled
         if not self.read_only:
             data = statement.serialize()

--- a/chatterbot/adapters/storage/mongodb.py
+++ b/chatterbot/adapters/storage/mongodb.py
@@ -173,9 +173,9 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         return results
 
-    def update(self, statement, force=False):
+    def update(self, statement, **kwargs):
         from pymongo import UpdateOne, ReplaceOne
-
+        force = kwargs.get('force', False)
         # Do not alter the database unless writing is enabled
         if not self.read_only or force == True:
             data = statement.serialize()

--- a/chatterbot/adapters/storage/mongodb.py
+++ b/chatterbot/adapters/storage/mongodb.py
@@ -173,11 +173,11 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         return results
 
-    def update(self, statement):
+    def update(self, statement, force = False):
         from pymongo import UpdateOne, ReplaceOne
 
         # Do not alter the database unless writing is enabled
-        if not self.read_only:
+        if not self.read_only or force == True:
             data = statement.serialize()
 
             operations = []

--- a/chatterbot/adapters/storage/mongodb.py
+++ b/chatterbot/adapters/storage/mongodb.py
@@ -173,7 +173,7 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         return results
 
-    def update(self, statement, force = False):
+    def update(self, statement, force=False):
         from pymongo import UpdateOne, ReplaceOne
 
         # Do not alter the database unless writing is enabled

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -69,7 +69,7 @@ class ListTrainer(Trainer):
                 )
 
             statement_history.append(statement)
-            self.storage.update(statement)
+            self.storage.update(statement, force=True)
 
 
 class ChatterBotCorpusTrainer(Trainer):


### PR DESCRIPTION
This is just a proposal. 

Scenario
Most of my clients want a training corpora but they dont want bots to auto-learn.

So when i am starting up the bot

````
bot = ChatBot('name', read_only=True)
bot.train('english') # Add corpus even if read_only is True
````

What do you think?