### PR TITLE
Modify synset_distance comparison function

### DIFF
--- a/chatterbot/adapters/logic/base_match.py
+++ b/chatterbot/adapters/logic/base_match.py
@@ -17,10 +17,34 @@ class BaseMatchAdapter(LogicAdapter):
 
     def get(self, input_statement):
         """
-        This method should be overridden with one to select a match
-        based on the input statement.
+        Takes a statement string and a list of statement strings.
+        Returns the closest matching statement from the list.
         """
-        raise self.AdapterMethodNotImplementedError()
+        statement_list = self.context.storage.get_response_statements()
+
+        if not statement_list:
+            if self.has_storage_context:
+                # Use a randomly picked statement
+                self.logger.info(
+                    u'No statements have known responses. ' +
+                    u'Choosing a random response to return.'
+                )
+                return 0, self.context.storage.get_random()
+            else:
+                raise self.EmptyDatasetException()
+
+        closest_match = input_statement
+        max_confidence = 0
+
+        # Find the closest matching known statement
+        for statement in statement_list:
+            confidence = self.compare_statements(input_statement, statement)
+
+            if confidence > max_confidence:
+                max_confidence = confidence
+                closest_match = statement
+
+        return max_confidence, closest_match
 
     def can_process(self, statement):
         """

--- a/chatterbot/adapters/logic/closest_match.py
+++ b/chatterbot/adapters/logic/closest_match.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from fuzzywuzzy import fuzz
 from .base_match import BaseMatchAdapter
 
 
@@ -11,33 +10,11 @@ class ClosestMatchAdapter(BaseMatchAdapter):
     of each statement.
     """
 
-    def get(self, input_statement):
-        """
-        Takes a statement string and a list of statement strings.
-        Returns the closest matching statement from the list.
-        """
-        statement_list = self.context.storage.get_response_statements()
+    def __init__(self, **kwargs):
+        super(ClosestMatchAdapter, self).__init__(**kwargs)
+        from chatterbot.conversation.comparisons import levenshtein_distance
 
-        if not statement_list:
-            if self.has_storage_context:
-                # Use a randomly picked statement
-                self.logger.info(
-                    u'No statements have known responses. ' +
-                    u'Choosing a random response to return.'
-                )
-                return 0, self.context.storage.get_random()
-            else:
-                raise self.EmptyDatasetException()
-
-        closest_match = input_statement
-        max_confidence = 0
-
-        # Find the closest matching known statement
-        for statement in statement_list:
-            confidence = self.compare_statements(input_statement, statement)
-
-            if confidence > max_confidence:
-                max_confidence = confidence
-                closest_match = statement
-
-        return max_confidence, closest_match
+        self.compare_statements = kwargs.get(
+            'statement_comparison_function',
+            levenshtein_distance
+        )

--- a/chatterbot/adapters/logic/closest_match.py
+++ b/chatterbot/adapters/logic/closest_match.py
@@ -30,17 +30,14 @@ class ClosestMatchAdapter(BaseMatchAdapter):
                 raise self.EmptyDatasetException()
 
         closest_match = input_statement
-        closest_similarity = -1
+        max_confidence = 0
 
         # Find the closest matching known statement
         for statement in statement_list:
-            similarity = self.compare_statements(input_statement, statement)
+            confidence = self.compare_statements(input_statement, statement)
 
-            if similarity > closest_similarity:
-                closest_similarity = similarity
+            if confidence > max_confidence:
+                max_confidence = confidence
                 closest_match = statement
 
-        # Convert the confidence integer to a percent
-        confidence = closest_similarity / 100.0
-
-        return confidence, closest_match
+        return max_confidence, closest_match

--- a/chatterbot/adapters/logic/closest_meaning.py
+++ b/chatterbot/adapters/logic/closest_meaning.py
@@ -39,22 +39,14 @@ class ClosestMeaningAdapter(BaseMatchAdapter):
                 raise self.EmptyDatasetException()
 
         closest_match = input_statement
-        closest_similarity = -1
-        total_similarity = 0
+        max_confidence = 0
 
-        # For each option in the list of options
+        # Find the closest matching known statement
         for statement in statement_list:
-            similarity = self.compare_statements(input_statement, statement)
+            confidence = self.compare_statements(input_statement, statement)
 
-            total_similarity += similarity
-
-            if similarity > closest_similarity:
-                closest_similarity = similarity
+            if confidence > max_confidence:
+                max_confidence = confidence
                 closest_match = statement
 
-        try:
-            confidence = closest_similarity / total_similarity
-        except:
-            confidence = 0
-
-        return confidence, closest_match
+        return max_confidence, closest_match

--- a/chatterbot/adapters/logic/closest_meaning.py
+++ b/chatterbot/adapters/logic/closest_meaning.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from .base_match import BaseMatchAdapter
 
 
@@ -19,34 +20,3 @@ class ClosestMeaningAdapter(BaseMatchAdapter):
             'statement_comparison_function',
             synset_distance
         )
-
-    def get(self, input_statement):
-        """
-        Takes a statement string and a list of statement strings.
-        Returns the closest matching statement from the list.
-        """
-        statement_list = self.context.storage.get_response_statements()
-
-        if not statement_list:
-            if self.has_storage_context:
-                # Use a randomly picked statement
-                self.logger.info(
-                    u'No statements have known responses. ' +
-                    u'Choosing a random response to return.'
-                )
-                return 0, self.context.storage.get_random()
-            else:
-                raise self.EmptyDatasetException()
-
-        closest_match = input_statement
-        max_confidence = 0
-
-        # Find the closest matching known statement
-        for statement in statement_list:
-            confidence = self.compare_statements(input_statement, statement)
-
-            if confidence > max_confidence:
-                max_confidence = confidence
-                closest_match = statement
-
-        return max_confidence, closest_match

--- a/chatterbot/conversation/comparisons.py
+++ b/chatterbot/conversation/comparisons.py
@@ -8,12 +8,15 @@ def levenshtein_distance(statement, other_statement):
     Compare two statements based on the Levenshtein distance
     (fuzzy string comparison) of each statement's text.
 
-    :return: The ratio of difference between the text of the statements.
+    :return: The percent of similarity between the text of the statements.
     :rtype: float
     """
     from fuzzywuzzy import fuzz
 
-    return fuzz.ratio(statement.text.lower(), other_statement.text.lower())
+    similarity = fuzz.ratio(statement.text.lower(), other_statement.text.lower())
+
+    # Convert the similarity from an integer to a percent
+    return similarity / 100.0
 
 
 def synset_distance(statement, other_statement):
@@ -22,7 +25,7 @@ def synset_distance(statement, other_statement):
     This is based on the total maximum synset similarity
     between each word in each sentence.
 
-    :return: The ratio of difference between the synset distance of both statements.
+    :return: The percent of similarity between the closest synset distance.
     :rtype: float
     """
     from chatterbot.utils.wordnet import Wordnet
@@ -36,6 +39,7 @@ def synset_distance(statement, other_statement):
     tokens2 = tokenizer.get_tokens(other_statement.text)
 
     total_similarity = 0
+    max_similarity = 0
 
     # Get the highest matching value for each possible combination of words
     for combination in itertools.product(*[tokens1, tokens2]):
@@ -45,8 +49,6 @@ def synset_distance(statement, other_statement):
 
         if synset1 and synset2:
 
-            max_similarity = 0
-
             # Get the highest similarity for each combination of synsets
             for synset in itertools.product(*[synset1, synset2]):
                 similarity = synset[0].path_similarity(synset[1])
@@ -54,10 +56,13 @@ def synset_distance(statement, other_statement):
                 if similarity and (similarity > max_similarity):
                     max_similarity = similarity
 
-            # Add the most similar path value to the total
-            total_similarity += max_similarity
+                    # Add the most similar path value to the total
+                    total_similarity += similarity
 
-    return total_similarity
+    if total_similarity == 0:
+        return 0
+
+    return max_similarity / total_similarity
 
 
 def jaccard_similarity(statement, other_statement, threshold=0.5):

--- a/chatterbot/conversation/comparisons.py
+++ b/chatterbot/conversation/comparisons.py
@@ -38,7 +38,15 @@ def synset_distance(statement, other_statement):
     tokens1 = tokenizer.get_tokens(statement.text)
     tokens2 = tokenizer.get_tokens(other_statement.text)
 
-    total_similarity = 0.0
+    # The maximum possible similarity is an exact match
+    # Because path_similarity returns a value between 0 and 1,
+    # max_possible_similarity is the number of words in the longer
+    # of the two input statements.
+    max_possible_similarity = max(
+        len(statement.text.split()),
+        len(other_statement.text.split())
+    )
+
     max_similarity = 0.0
 
     # Get the highest matching value for each possible combination of words
@@ -56,13 +64,10 @@ def synset_distance(statement, other_statement):
                 if similarity and (similarity > max_similarity):
                     max_similarity = similarity
 
-                    # Add the most similar path value to the total
-                    total_similarity += similarity
-
-    if total_similarity == 0:
+    if max_possible_similarity == 0:
         return 0
 
-    return max_similarity / total_similarity
+    return max_similarity / max_possible_similarity
 
 
 def jaccard_similarity(statement, other_statement, threshold=0.5):

--- a/chatterbot/conversation/comparisons.py
+++ b/chatterbot/conversation/comparisons.py
@@ -38,8 +38,8 @@ def synset_distance(statement, other_statement):
     tokens1 = tokenizer.get_tokens(statement.text)
     tokens2 = tokenizer.get_tokens(other_statement.text)
 
-    total_similarity = 0
-    max_similarity = 0
+    total_similarity = 0.0
+    max_similarity = 0.0
 
     # Get the highest matching value for each possible combination of words
     for combination in itertools.product(*[tokens1, tokens2]):

--- a/tests/logic_adapter_tests/test_closest_meaning.py
+++ b/tests/logic_adapter_tests/test_closest_meaning.py
@@ -38,7 +38,7 @@ class ClosestMeaningAdapterTests(TestCase):
         possible_choices = [
             Statement('This is a lovely bog.', in_response_to=[Response('This is a lovely bog.')]),
             Statement('This is a beautiful swamp.', in_response_to=[Response('This is a beautiful swamp.')]),
-            Statement('It smells like swamp.', in_response_to=[Response('It smells like swamp.')])
+            Statement('It smells like a swamp.', in_response_to=[Response('It smells like a swamp.')])
         ]
         self.adapter.context.storage.filter = MagicMock(
             return_value=possible_choices


### PR DESCRIPTION
This pull request makes two changes:

1. This makes changes to the function so that it will return a percent of similarity between the two statements it takes as parameters. By returning a percent it makes the output of this function easier to
compare to the output of other comparison functions.
2. By normalizing the output from the statement comparison functions, it allows redundant code in the statement matching adapters to be combined.