### PR TITLE
Move sentiment matching to it's own function

### DIFF
--- a/chatterbot/adapters/logic/sentiment_adapter.py
+++ b/chatterbot/adapters/logic/sentiment_adapter.py
@@ -1,5 +1,4 @@
-from chatterbot.conversation import Statement
-from textblob import TextBlob
+# -*- coding: utf-8 -*-
 from .base_match import BaseMatchAdapter
 
 
@@ -9,52 +8,11 @@ class SentimentAdapter(BaseMatchAdapter):
     matching sentiment value to the input statement.
     """
 
-    def calculate_closeness(self, input_sentiment, response_sentiment):
-        """
-        Return the difference between the input and response
-        sentiment values.
-        """
-        self.logger.info(
-            u'Comparing input equality of {} to response of {}.'.format(
-                input_sentiment, response_sentiment
-            )
+    def __init__(self, **kwargs):
+        super(SentimentAdapter, self).__init__(**kwargs)
+        from chatterbot.conversation.comparisons import sentiment_comparison
+
+        self.compare_statements = kwargs.get(
+            'statement_comparison_function',
+            sentiment_comparison
         )
-        values = [input_sentiment, response_sentiment]
-
-        return max(values) - min(values)
-
-    def process(self, input_statement):
-        input_blob = TextBlob(input_statement.text)
-        input_sentiment = input_blob.sentiment.polarity
-
-        self.logger.info(
-            u'"{}" has a sentiment polarity of {}.'.format(
-                input_statement.text, input_sentiment
-            )
-        )
-
-        response_list = self.context.storage.get_response_statements()
-
-        best_match = response_list[0]
-        max_closeness = 1
-
-        for response in response_list:
-            blob = TextBlob(response.text)
-            sentiment = blob.sentiment.polarity
-
-            closeness = self.calculate_closeness(input_sentiment, sentiment)
-            if closeness < max_closeness:
-                best_match = response
-                max_closeness = closeness
-
-        confidence = 1.0 - max_closeness
-
-        # Get all statements that are in response to the closest match
-        response_list = self.context.storage.filter(
-            in_response_to__contains=best_match.text
-        )
-
-        # Choose a response from the selection
-        response_statement = self.select_response(input_statement, response_list)
-
-        return confidence, response_statement

--- a/chatterbot/conversation/comparisons.py
+++ b/chatterbot/conversation/comparisons.py
@@ -70,6 +70,27 @@ def synset_distance(statement, other_statement):
     return max_similarity / max_possible_similarity
 
 
+def sentiment_comparison(statement, other_statement):
+    """
+    Calculate the similarity of two statements based on the closeness of
+    the sentiment value calculated for each statement.
+
+    :return: The percent of similarity between the sentiment value.
+    :rtype: float
+    """
+    from textblob import TextBlob
+
+    statement_blob = TextBlob(statement.text)
+    other_statement_blob = TextBlob(other_statement.text)
+
+    statement_sentiment = statement_blob.sentiment.polarity
+    other_statement_sentiment = other_statement_blob.sentiment.polarity
+
+    values = [statement_sentiment, other_statement_sentiment]
+    difference = max(values) - min(values)
+
+    return 1.0 - difference
+
 def jaccard_similarity(statement, other_statement, threshold=0.5):
     """
     The Jaccard index is composed of a numerator and denominator.


### PR DESCRIPTION
This allows the sentiment matching adapter to be simplified.
This is related to the changes made in #385.