### PR TITLE
Don't overide get method on ApproximateSentenceMatchAdapter

### DIFF
--- a/chatterbot/adapters/logic/approximate_sentence_match.py
+++ b/chatterbot/adapters/logic/approximate_sentence_match.py
@@ -12,28 +12,3 @@ class ApproximateSentenceMatchAdapter(BaseMatchAdapter):
             'statement_comparison_function',
             jaccard_similarity
         )
-
-    def get(self, input_statement):
-        """
-        Takes a statement string and a list of statement strings.
-        Returns the closest matching statement from the list.
-        """
-        statement_list = self.context.storage.get_response_statements()
-
-        if not statement_list:
-            if self.has_storage_context:
-                # Use a randomly picked statement
-                return 0, self.context.storage.get_random()
-            else:
-                raise self.EmptyDatasetException()
-
-        confidence = -1
-        sentence_match = input_statement
-        # Find the matching known statement
-        for statement in statement_list:
-            ratio = self.compare_statements(input_statement, statement)
-            if ratio:
-                closest_match = statement
-            else:
-                closest_match = statement
-        return 0.5, closest_match


### PR DESCRIPTION
This removed redundant code from the `ApproximateSentenceMatchAdapter`.