### PR TITLE
Add ability to set per-adapter parameters

### DIFF
--- a/docs/chatterbot.rst
+++ b/docs/chatterbot.rst
@@ -58,6 +58,44 @@ Example chat bot parameters
    )
 
 
+Example expanded chat bot parameters
+====================================
+
+It is also possible to pass parameters directly to individual adapters.
+To do this, you must use a dictionary that contains a key called :code:`import_path`
+which specifies the import path to the adapter class.
+
+.. code-block:: python
+
+   ChatBot(
+       'Leander Jenkins',
+       storage_adapter={
+           'import_path': 'my.storage.AdapterClass',
+           'database_name': 'my-database'
+       },
+       logic_adapters=[
+           {
+               'import_path': 'my.logic.AdapterClass1',
+               'statement_comparison_function': 'chatterbot.conversation.comparisons.levenshtein_distance'
+               'response_selection_method': 'chatterbot.conversation.response_selection.get_first_response'
+           },
+           {
+               'import_path': 'my.logic.AdapterClass2',
+               'statement_comparison_function': 'my.custom.comparison_function'
+               'response_selection_method': 'my.custom.selection_method'
+           }
+       ],
+       input_adapter={
+           'import_path': 'my.input.AdapterClass',
+           'api_key': '0000-1111-2222-3333-DDDD'
+       },
+       output_adapter={
+           'import_path': 'my.output.AdapterClass',
+           'api_key': '0000-1111-2222-3333-DDDD'
+       }
+   )
+
+
 Enable logging
 ==============
 

--- a/tests/test_adapter_validation.py
+++ b/tests/test_adapter_validation.py
@@ -64,20 +64,38 @@ class AdapterValidationTests(ChatBotTestCase):
         except ChatBot.InvalidAdapterException:
             self.fail('Test raised InvalidAdapterException unexpectedly!')
 
+    def test_valid_adapter_dictionary(self):
+        kwargs = self.get_kwargs()
+        kwargs['storage_adapter'] = {
+            'import_path': 'chatterbot.adapters.storage.JsonFileStorageAdapter'
+        }
+        try:
+            self.chatbot = ChatBot('Test Bot', **kwargs)
+        except ChatBot.InvalidAdapterException:
+            self.fail('Test raised InvalidAdapterException unexpectedly!')
+
+    def test_invalid_adapter_dictionary(self):
+        kwargs = self.get_kwargs()
+        kwargs['storage_adapter'] = {
+            'import_path': 'chatterbot.adapters.logic.ClosestMatchAdapter'
+        }
+        with self.assertRaises(ChatBot.InvalidAdapterException):
+            self.chatbot = ChatBot('Test Bot', **kwargs)
+
 
 class MultiAdapterTests(ChatBotTestCase):
 
     def test_add_logic_adapter(self):
         count_before = len(self.chatbot.logic.adapters)
 
-        self.chatbot.add_adapter(
+        self.chatbot.add_logic_adapter(
             'chatterbot.adapters.logic.ClosestMatchAdapter'
         )
         self.assertEqual(len(self.chatbot.logic.adapters), count_before + 1)
 
     def test_insert_logic_adapter(self):
-        self.chatbot.add_adapter('chatterbot.adapters.logic.TimeLogicAdapter')
-        self.chatbot.add_adapter('chatterbot.adapters.logic.ClosestMatchAdapter')
+        self.chatbot.add_logic_adapter('chatterbot.adapters.logic.TimeLogicAdapter')
+        self.chatbot.add_logic_adapter('chatterbot.adapters.logic.ClosestMatchAdapter')
 
         self.chatbot.insert_logic_adapter('chatterbot.adapters.logic.MathematicalEvaluation', 1)
 
@@ -87,8 +105,8 @@ class MultiAdapterTests(ChatBotTestCase):
         )
 
     def test_remove_logic_adapter(self):
-        self.chatbot.add_adapter('chatterbot.adapters.logic.TimeLogicAdapter')
-        self.chatbot.add_adapter('chatterbot.adapters.logic.MathematicalEvaluation')
+        self.chatbot.add_logic_adapter('chatterbot.adapters.logic.TimeLogicAdapter')
+        self.chatbot.add_logic_adapter('chatterbot.adapters.logic.MathematicalEvaluation')
 
         adapter_count = len(self.chatbot.logic.adapters)
 
@@ -98,7 +116,7 @@ class MultiAdapterTests(ChatBotTestCase):
         self.assertEqual(len(self.chatbot.logic.adapters), adapter_count - 1)
 
     def test_remove_logic_adapter_not_found(self):
-        self.chatbot.add_adapter('chatterbot.adapters.logic.TimeLogicAdapter')
+        self.chatbot.add_logic_adapter('chatterbot.adapters.logic.TimeLogicAdapter')
 
         adapter_count = len(self.chatbot.logic.adapters)
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,0 +1,73 @@
+from .base_case import ChatBotTestCase
+
+
+class StringInitalizationTestCase(ChatBotTestCase):
+
+    def get_kwargs(self):
+        return {
+            'input_adapter': 'chatterbot.adapters.input.VariableInputTypeAdapter',
+            'output_adapter': 'chatterbot.adapters.output.OutputFormatAdapter',
+            'database': self.create_test_data_directory(),
+            'silence_performance_warning': True
+        }
+
+    def test_storage_initialized(self):
+        from chatterbot.adapters.storage import JsonFileStorageAdapter
+        self.assertTrue(isinstance(self.chatbot.storage, JsonFileStorageAdapter))
+
+    def test_logic_initialized(self):
+        from chatterbot.adapters.logic import ClosestMatchAdapter
+        self.assertTrue(isinstance(self.chatbot.logic.adapters[1], ClosestMatchAdapter))
+
+    def test_input_initialized(self):
+        from chatterbot.adapters.input import VariableInputTypeAdapter
+        self.assertTrue(isinstance(self.chatbot.input, VariableInputTypeAdapter))
+
+    def test_output_initialized(self):
+        from chatterbot.adapters.output import OutputFormatAdapter
+        self.assertTrue(isinstance(self.chatbot.output, OutputFormatAdapter))
+
+
+class DictionaryInitalizationTestCase(ChatBotTestCase):
+
+    def get_kwargs(self):
+        return {
+            'storage_adapter': {
+                'import_path': 'chatterbot.adapters.storage.JsonFileStorageAdapter',
+                'database': self.create_test_data_directory(),
+                'silence_performance_warning': True
+            },
+
+            'input_adapter': {
+                'import_path': 'chatterbot.adapters.input.VariableInputTypeAdapter'
+            },
+            'output_adapter': {
+                 'import_path': 'chatterbot.adapters.output.OutputFormatAdapter'
+            },
+            'logic_adapters': [
+                {
+                    'import_path': 'chatterbot.adapters.logic.ClosestMatchAdapter',
+                },
+                {
+                    'import_path': 'chatterbot.adapters.logic.MathematicalEvaluation',
+                }
+            ]
+        }
+
+    def test_storage_initialized(self):
+        from chatterbot.adapters.storage import JsonFileStorageAdapter
+        self.assertTrue(isinstance(self.chatbot.storage, JsonFileStorageAdapter))
+
+    def test_logic_initialized(self):
+        from chatterbot.adapters.logic import ClosestMatchAdapter
+        from chatterbot.adapters.logic import MathematicalEvaluation
+        self.assertTrue(isinstance(self.chatbot.logic.adapters[1], ClosestMatchAdapter))
+        self.assertTrue(isinstance(self.chatbot.logic.adapters[2], MathematicalEvaluation))
+
+    def test_input_initialized(self):
+        from chatterbot.adapters.input import VariableInputTypeAdapter
+        self.assertTrue(isinstance(self.chatbot.input, VariableInputTypeAdapter))
+
+    def test_output_initialized(self):
+        from chatterbot.adapters.output import OutputFormatAdapter
+        self.assertTrue(isinstance(self.chatbot.output, OutputFormatAdapter))


### PR DESCRIPTION
This adds a backwards compatible method for setting parameters for specific adapters.

- [x] Tests
- [x] Documentation

Closes #287