### PR TITLE
Rename 'context' to 'chatbot'

### DIFF
--- a/chatterbot/adapters/adapter.py
+++ b/chatterbot/adapters/adapter.py
@@ -8,14 +8,27 @@ class Adapter(object):
 
     def __init__(self, **kwargs):
         self.logger = kwargs.get('logger', logging.getLogger(__name__))
-        self.context = None
+        self.chatbot = None
 
-    def set_context(self, context):
-        self.context = context
+    def set_chatbot(self, chatbot):
+        """
+        Gives the adapter access to an instance of the ChatBot class.
+        """
+        self.chatbot = chatbot
 
     class AdapterMethodNotImplementedError(NotImplementedError):
+        """
+        An exception to be raised when an adapter method has not been implemented.
+        Typically this indicates that the developer is expected to implement the
+        method in a subclass.
+        """
 
-        def __init__(self, message='This method must be overridden in a subclass method.'):
+        def __init__(self, message=None):
+            """
+            Set the message for the esception.
+            """
+            if not message:
+                message = 'This method must be overridden in a subclass method.'
             self.message = message
 
         def __str__(self):

--- a/chatterbot/adapters/input/hipchat.py
+++ b/chatterbot/adapters/input/hipchat.py
@@ -75,8 +75,8 @@ class HipChat(InputAdapter):
 
         new_message = False
 
-        input_statement = self.context.get_last_input_statement()
-        response_statement = self.context.get_last_response_statement()
+        input_statement = self.chatbot.get_last_input_statement()
+        response_statement = self.chatbot.get_last_response_statement()
 
         if input_statement:
             last_message_id = input_statement.extra_data.get(

--- a/chatterbot/adapters/input/input_adapter.py
+++ b/chatterbot/adapters/input/input_adapter.py
@@ -21,7 +21,7 @@ class InputAdapter(Adapter):
         input_statement = self.process_input(*args, **kwargs)
         self.logger.info('Recieved input statement: {}'.format(input_statement.text))
 
-        existing_statement = self.context.storage.find(input_statement.text)
+        existing_statement = self.chatbot.storage.find(input_statement.text)
 
         if existing_statement:
             self.logger.info('"{}" is a known statement'.format(input_statement.text))

--- a/chatterbot/adapters/logic/multi_adapter.py
+++ b/chatterbot/adapters/logic/multi_adapter.py
@@ -1,13 +1,13 @@
 from __future__ import unicode_literals
-from .logic_adapter import LogicAdapter
 from collections import Counter
+from .logic_adapter import LogicAdapter
 
 
 class MultiLogicAdapter(LogicAdapter):
     """
     MultiLogicAdapter allows ChatterBot to use multiple logic
     adapters. It has methods that allow ChatterBot to add an
-    adapter, set the context, and process an input statement
+    adapter, set the chat bot, and process an input statement
     to get a response.
     """
 
@@ -84,11 +84,11 @@ class MultiLogicAdapter(LogicAdapter):
         """
         self.adapters.append(adapter)
 
-    def set_context(self, context):
+    def set_chatbot(self, chatbot):
         """
-        Set the context for each of the contained logic adapters.
+        Set the chatbot for each of the contained logic adapters.
         """
-        super(MultiLogicAdapter, self).set_context(context)
+        super(MultiLogicAdapter, self).set_chatbot(chatbot)
 
         for adapter in self.adapters:
-            adapter.set_context(context)
+            adapter.set_chatbot(chatbot)

--- a/chatterbot/adapters/logic/no_knowledge_adapter.py
+++ b/chatterbot/adapters/logic/no_knowledge_adapter.py
@@ -18,7 +18,7 @@ class NoKnowledgeAdapter(LogicAdapter):
         Otherwise, a confidence of 0 should be returned.
         """
 
-        if self.context.storage.count():
+        if self.chatbot.storage.count():
             return 0, statement
 
         return 1, statement

--- a/chatterbot/adapters/output/hipchat.py
+++ b/chatterbot/adapters/output/hipchat.py
@@ -58,7 +58,7 @@ class HipChat(OutputAdapter):
         data = self.send_message(self.hipchat_room, statement.text)
 
         # Update the output statement with the message id
-        self.context.recent_statements[-1][1].add_extra_data(
+        self.chatbot.recent_statements[-1][1].add_extra_data(
             'hipchat_message_id', data['id']
         )
 

--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -56,12 +56,12 @@ class ChatBot(object):
         for adapter in logic_adapters:
             self.add_logic_adapter(adapter, **kwargs)
 
-        # Share context information such as the name, the current conversation,
-        # or access to other adapters with each of the adapters
-        self.storage.set_context(self)
-        self.logic.set_context(self)
-        self.input.set_context(self)
-        self.output.set_context(self)
+        # Add the chatbot instance to each adapter to share information such as
+        # the name, the current conversation, or other adapters
+        self.storage.set_chatbot(self)
+        self.logic.set_chatbot(self)
+        self.input.set_chatbot(self)
+        self.output.set_chatbot(self)
 
         # Use specified trainer or fall back to the default
         trainer = kwargs.get('trainer', 'chatterbot.trainers.Trainer')

--- a/docs/adapters/index.rst
+++ b/docs/adapters/index.rst
@@ -27,12 +27,17 @@ Adapters types
 3. Output adapters - Provide methods that allow ChatterBot to return a response to a defined data source.
 4. Logic adapters - Define the logic that ChatterBot uses to respond to input it receives.
 
-Context
--------
+Accessing the chatbot instance
+-------------------------------
 
-When ChatterBot initializes each adapter, it sets an attribute named 'context'. The context variable makes it possible for each adapter to have access to all of the other adapters being used. Perhaps two input and output adapters need to share some information or maybe you want to give your logic adapter direct access to the storage adapter. These are just a few cases where this functionality is useful.
+When ChatterBot initializes each adapter, it sets an attribute named :code:`chatbot`.
+The chatbot variable makes it possible for each adapter to have access to all of the other adapters being used.
+Suppose two input and output adapters need to share some information or perhaps you want to give your logic adapter
+direct access to the storage adapter. These are just a few cases where this functionality is useful.
 
-Each adapter can be accessed on the context object from within an adapter by referencing `self.context`. Then, `self.context.storage` refers to the storage adapter, `self.context.input` refers to the input adapter, `self.context.output` refers to the current output adapter, and `self.context.logic` refers to the list of logic adapters.
+Each adapter can be accessed on the chatbot object from within an adapter by referencing `self.chatbot`.
+Then, :code:`self.chatbot.storage` refers to the storage adapter, :code:`self.chatbot.input` refers to the input adapter,
+:code:`self.chatbot.output` refers to the current output adapter, and :code:`self.chatbot.logic` refers to the logic adapters.
 
 Adapter defaults
 ----------------

--- a/tests/input_adapter_tests/test_input_adapter.py
+++ b/tests/input_adapter_tests/test_input_adapter.py
@@ -23,7 +23,7 @@ class InputAdapterTestCase(ChatBotTestCase):
             self.adapter.process_input_statement()
 
     def test_process_response_statement_initialized(self):
-        self.adapter.context = self.chatbot
+        self.adapter.chatbot = self.chatbot
         self.adapter.process_input = lambda *args, **kwargs: Statement('Hi')
         response = self.adapter.process_input_statement()
         self.assertEqual(response, 'Hi')

--- a/tests/logic_adapter_tests/test_closest_match.py
+++ b/tests/logic_adapter_tests/test_closest_match.py
@@ -5,7 +5,7 @@ from chatterbot.adapters.storage import StorageAdapter
 from chatterbot.conversation import Statement, Response
 
 
-class MockContext(object):
+class MockChatBot(object):
     def __init__(self):
         self.storage = StorageAdapter()
 
@@ -19,11 +19,11 @@ class ClosestMatchAdapterTests(TestCase):
     def setUp(self):
         self.adapter = ClosestMatchAdapter()
 
-        # Add a mock storage adapter to the context
-        self.adapter.set_context(MockContext())
+        # Add a mock chatbot to the logic adapter
+        self.adapter.set_chatbot(MockChatBot())
 
     def test_no_choices(self):
-        self.adapter.context.storage.filter = MagicMock(return_value=[])
+        self.adapter.chatbot.storage.filter = MagicMock(return_value=[])
 
         statement = Statement("What is your quest?")
 
@@ -44,7 +44,7 @@ class ClosestMatchAdapterTests(TestCase):
             Statement("Yuck, black licorice jelly beans.", in_response_to=[Response("What is the meaning of life?")]),
             Statement("I hear you are going on a quest?", in_response_to=[Response("Who do you love?")]),
         ]
-        self.adapter.context.storage.filter = MagicMock(return_value=possible_choices)
+        self.adapter.chatbot.storage.filter = MagicMock(return_value=possible_choices)
 
         statement = Statement("What is your quest?")
 
@@ -56,7 +56,7 @@ class ClosestMatchAdapterTests(TestCase):
         possible_choices = [
             Statement("What is your quest?", in_response_to=[Response("What is your quest?")])
         ]
-        self.adapter.context.storage.filter = MagicMock(return_value=possible_choices)
+        self.adapter.chatbot.storage.filter = MagicMock(return_value=possible_choices)
 
         statement = Statement("What is your quest?")
         confidence, match = self.adapter.get(statement)
@@ -67,7 +67,7 @@ class ClosestMatchAdapterTests(TestCase):
         possible_choices = [
             Statement("xxyy", in_response_to=[Response("xxyy")])
         ]
-        self.adapter.context.storage.filter = MagicMock(return_value=possible_choices)
+        self.adapter.chatbot.storage.filter = MagicMock(return_value=possible_choices)
 
         statement = Statement("wwxx")
         confidence, match = self.adapter.get(statement)
@@ -78,7 +78,7 @@ class ClosestMatchAdapterTests(TestCase):
         possible_choices = [
             Statement("xxx", in_response_to=[Response("xxx")])
         ]
-        self.adapter.context.storage.filter = MagicMock(return_value=possible_choices)
+        self.adapter.chatbot.storage.filter = MagicMock(return_value=possible_choices)
 
         statement = Statement("yyy")
         confidence, match = self.adapter.get(statement)
@@ -91,11 +91,11 @@ class ClosestMatchAdapterTests(TestCase):
         In this case a random response will be returned, but the confidence
         should be zero because it is a random choice.
         """
-        self.adapter.context.storage.update = MagicMock()
-        self.adapter.context.storage.filter = MagicMock(
+        self.adapter.chatbot.storage.update = MagicMock()
+        self.adapter.chatbot.storage.filter = MagicMock(
             return_value=[]
         )
-        self.adapter.context.storage.get_random = MagicMock(
+        self.adapter.chatbot.storage.get_random = MagicMock(
             return_value=Statement("Random")
         )
 

--- a/tests/logic_adapter_tests/test_closest_meaning.py
+++ b/tests/logic_adapter_tests/test_closest_meaning.py
@@ -3,15 +3,7 @@ from mock import MagicMock, Mock
 from chatterbot.adapters.logic import ClosestMeaningAdapter
 from chatterbot.adapters.storage import StorageAdapter
 from chatterbot.conversation import Statement, Response
-
-
-class MockContext(object):
-    def __init__(self):
-        self.storage = StorageAdapter()
-
-        self.storage.get_random = Mock(
-            side_effect=ClosestMeaningAdapter.EmptyDatasetException()
-        )
+from tests.logic_adapter_tests.test_closest_match import MockChatBot
 
 
 class ClosestMeaningAdapterTests(TestCase):
@@ -19,11 +11,11 @@ class ClosestMeaningAdapterTests(TestCase):
     def setUp(self):
         self.adapter = ClosestMeaningAdapter()
 
-        # Add a mock storage adapter to the context
-        self.adapter.set_context(MockContext())
+        # Add a mock storage adapter to the logic adapter
+        self.adapter.set_chatbot(MockChatBot())
 
     def test_no_choices(self):
-        self.adapter.context.storage.filter = MagicMock(return_value=[])
+        self.adapter.chatbot.storage.filter = MagicMock(return_value=[])
         statement = Statement('Hello')
 
         with self.assertRaises(ClosestMeaningAdapter.EmptyDatasetException):
@@ -40,7 +32,7 @@ class ClosestMeaningAdapterTests(TestCase):
             Statement('This is a beautiful swamp.', in_response_to=[Response('This is a beautiful swamp.')]),
             Statement('It smells like a swamp.', in_response_to=[Response('It smells like a swamp.')])
         ]
-        self.adapter.context.storage.filter = MagicMock(
+        self.adapter.chatbot.storage.filter = MagicMock(
             return_value=possible_choices
         )
 
@@ -55,7 +47,7 @@ class ClosestMeaningAdapterTests(TestCase):
             Statement('Are you good?'),
             Statement('You are good')
         ]
-        self.adapter.context.storage.get_response_statements = MagicMock(
+        self.adapter.chatbot.storage.get_response_statements = MagicMock(
             return_value=possible_choices
         )
 
@@ -70,15 +62,15 @@ class ClosestMeaningAdapterTests(TestCase):
         In this case a random response will be returned, but the confidence
         should be zero because it is a random choice.
         """
-        self.adapter.context.storage.update = MagicMock()
-        self.adapter.context.storage.filter = MagicMock(
+        self.adapter.chatbot.storage.update = MagicMock()
+        self.adapter.chatbot.storage.filter = MagicMock(
             return_value=[]
         )
-        self.adapter.context.storage.get_random = MagicMock(
-            return_value=Statement("Random")
+        self.adapter.chatbot.storage.get_random = MagicMock(
+            return_value=Statement('Random')
         )
 
-        confidence, match = self.adapter.process(Statement("Blah"))
+        confidence, match = self.adapter.process(Statement('Blah'))
 
         self.assertEqual(confidence, 0)
-        self.assertEqual(match.text, "Random")
+        self.assertEqual(match.text, 'Random')

--- a/tests/logic_adapter_tests/test_data_cache.py
+++ b/tests/logic_adapter_tests/test_data_cache.py
@@ -1,8 +1,7 @@
+import os
 from tests.base_case import ChatBotTestCase
 from chatterbot.adapters.logic import LogicAdapter
-from chatterbot.conversation import Statement
 from chatterbot.trainers import ListTrainer
-import os
 
 
 class DummyMutatorLogicAdapter(LogicAdapter):
@@ -14,7 +13,7 @@ class DummyMutatorLogicAdapter(LogicAdapter):
     def process(self, statement):
         statement.add_extra_data('pos_tags', 'NN')
 
-        self.context.storage.update(statement)
+        self.chatbot.storage.update(statement)
 
         return 1, statement
 
@@ -25,7 +24,7 @@ class DataCachingTests(ChatBotTestCase):
         super(DataCachingTests, self).setUp()
 
         self.chatbot.logic = DummyMutatorLogicAdapter()
-        self.chatbot.logic.set_context(self.chatbot)
+        self.chatbot.logic.set_chatbot(self.chatbot)
 
         self.chatbot.set_trainer(ListTrainer)
 

--- a/tests/logic_adapter_tests/test_low_confidence_adapter.py
+++ b/tests/logic_adapter_tests/test_low_confidence_adapter.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from mock import MagicMock
 from chatterbot.adapters.logic import LowConfidenceAdapter
 from chatterbot.conversation import Statement, Response
-from .test_closest_match import MockContext
+from .test_closest_match import MockChatBot
 
 
 class LowConfidenceAdapterTestCase(TestCase):
@@ -14,8 +14,8 @@ class LowConfidenceAdapterTestCase(TestCase):
         super(LowConfidenceAdapterTestCase, self).setUp()
         self.adapter = LowConfidenceAdapter()
 
-        # Add a mock storage adapter to the context
-        self.adapter.set_context(MockContext())
+        # Add a mock storage adapter to the logic adapter
+        self.adapter.set_chatbot(MockChatBot())
 
         possible_choices = [
             Statement('Who do you love?', in_response_to=[
@@ -37,7 +37,7 @@ class LowConfidenceAdapterTestCase(TestCase):
                 Response('Who do you love?')
             ]),
         ]
-        self.adapter.context.storage.filter = MagicMock(return_value=possible_choices)
+        self.adapter.chatbot.storage.filter = MagicMock(return_value=possible_choices)
 
     def test_high_confidence(self):
         """

--- a/tests/logic_adapter_tests/test_multi_adapter.py
+++ b/tests/logic_adapter_tests/test_multi_adapter.py
@@ -27,7 +27,7 @@ class MultiLogicAdapterTestCase(ChatBotTestCase):
     def setUp(self):
         super(MultiLogicAdapterTestCase, self).setUp()
         self.adapter = MultiLogicAdapter()
-        self.adapter.set_context(self.chatbot)
+        self.adapter.set_chatbot(self.chatbot)
 
     def test_sub_adapter_agreement(self):
         """
@@ -63,13 +63,13 @@ class MultiLogicAdapterTestCase(ChatBotTestCase):
 
         self.assertEqual(adapter_count_after, adapter_count_before + 1)
 
-    def test_set_context(self):
+    def test_set_chatbot(self):
         adapter = MultiLogicAdapter()
-        adapter.set_context(self.chatbot)
+        adapter.set_chatbot(self.chatbot)
 
-        # Test that the multi adapter's context is set
-        self.assertEqual(adapter.context, self.chatbot)
+        # Test that the multi adapter has acccess to the chat bot
+        self.assertEqual(adapter.chatbot, self.chatbot)
 
-        # Test that all sub adapters have the context set
+        # Test that all sub adapters have the chatbot set
         for sub_adapter in adapter.adapters:
-            self.assertEqual(sub_adapter.context, self.chatbot)
+            self.assertEqual(sub_adapter.chatbot, self.chatbot)

--- a/tests/logic_adapter_tests/test_sentiment.py
+++ b/tests/logic_adapter_tests/test_sentiment.py
@@ -11,7 +11,7 @@ class SentimentAdapterTests(ChatBotTestCase):
 
         self.chatbot.set_trainer(ListTrainer)
         self.adapter = SentimentAdapter()
-        self.adapter.set_context(self.chatbot)
+        self.adapter.set_chatbot(self.chatbot)
 
     def test_exact_input(self):
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,18 +1,17 @@
 from .base_case import ChatBotTestCase
 
 
-class ContextTests(ChatBotTestCase):
+class AdapterTests(ChatBotTestCase):
 
     def setUp(self):
-        super(ContextTests, self).setUp()
+        super(AdapterTests, self).setUp()
 
-    def test_modify_context(self):
+    def test_modify_chatbot(self):
         """
-        When one adapter changes the context,
-        the change should be the same in all
-        other adapters.
+        When one adapter modifies its chatbot instance,
+        the change should be the same in all other adapters.
         """
-        self.chatbot.input.context.recent_statements = [5]
-        data = self.chatbot.output.context.recent_statements
+        self.chatbot.input.chatbot.recent_statements = [5]
+        data = self.chatbot.output.chatbot.recent_statements
 
         self.assertIn(5, data)


### PR DESCRIPTION
This variable is being renamed to help stop developers from being confused. The new name is more accurate and better describes what the content of the variable actually is.

Closes #281