### PR TITLE
Prevent possible edge case when adding inserting logic adapters

### DIFF
--- a/chatterbot/logic/multi_adapter.py
+++ b/chatterbot/logic/multi_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from collections import Counter
+from chatterbot import utils
 from .logic_adapter import LogicAdapter
 
 
@@ -14,7 +15,11 @@ class MultiLogicAdapter(LogicAdapter):
     def __init__(self, **kwargs):
         super(MultiLogicAdapter, self).__init__(**kwargs)
 
+        # Logic adapters added by the chat bot
         self.adapters = []
+
+        # Requied logic adapters that must always be present
+        self.system_adapters = []
 
     def process(self, statement):
         """
@@ -27,14 +32,14 @@ class MultiLogicAdapter(LogicAdapter):
         result = None
         max_confidence = -1
 
-        for adapter in self.adapters:
+        for adapter in self.get_adapters():
             if adapter.can_process(statement):
                 confidence, output = adapter.process(statement)
                 results.append((confidence, output, ))
 
                 self.logger.info(
                     '{} selected "{}" as a response with a confidence of {}'.format(
-                         str(adapter.__class__), output.text, confidence
+                        str(adapter.__class__), output.text, confidence
                     )
                 )
 
@@ -75,14 +80,57 @@ class MultiLogicAdapter(LogicAdapter):
 
         return max(values)
 
-    def add_adapter(self, adapter):
+    def get_adapters(self):
+        """
+        Return a list of all logic adapters being used, including system logic adapters.
+        """
+        adapters = []
+        adapters.extend(self.adapters)
+        adapters.extend(self.system_adapters)
+        return adapters
+
+    def add_adapter(self, adapter, **kwargs):
         """
         Appends a logic adapter to the list of logic adapters being used.
 
         :param adapter: The logic adapter to be added.
         :type adapter: LogicAdapter
         """
+        utils.validate_adapter_class(adapter, LogicAdapter)
+        adapter = utils.initialize_class(adapter, **kwargs)
         self.adapters.append(adapter)
+
+    def insert_logic_adapter(self, logic_adapter, insert_index, **kwargs):
+        """
+        Adds a logic adapter at a specified index.
+
+        :param logic_adapter: The string path to the logic adapter to add.
+        :type logic_adapter: class
+
+        :param insert_index: The index to insert the logic adapter into the list at.
+        :type insert_index: int
+
+        :raises: InvalidAdapterException
+        """
+        utils.validate_adapter_class(logic_adapter, LogicAdapter)
+
+        NewAdapter = utils.import_module(logic_adapter)
+        adapter = NewAdapter(**kwargs)
+
+        self.adapters.insert(insert_index, adapter)
+
+    def remove_logic_adapter(self, adapter_name):
+        """
+        Removes a logic adapter from the chat bot.
+
+        :param adapter_name: The class name of the adapter to remove.
+        :type adapter_name: str
+        """
+        for index, adapter in enumerate(self.adapters):
+            if adapter_name == type(adapter).__name__:
+                del self.adapters[index]
+                return True
+        return False
 
     def set_chatbot(self, chatbot):
         """
@@ -90,5 +138,5 @@ class MultiLogicAdapter(LogicAdapter):
         """
         super(MultiLogicAdapter, self).set_chatbot(chatbot)
 
-        for adapter in self.adapters:
+        for adapter in self.get_adapters():
             adapter.set_chatbot(chatbot)

--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -65,6 +65,67 @@ def import_module(dotted_path):
     return getattr(module, module_parts[-1])
 
 
+def initialize_class(data, **kwargs):
+    """
+    :param data: A string or dictionary containing a import_path attribute.
+    """
+    if isinstance(data, dict):
+        import_path = data.pop('import_path')
+        data.update(kwargs)
+        Class = import_module(import_path)
+
+        return Class(**data)
+    else:
+        Class = import_module(data)
+
+        return Class(**kwargs)
+
+
+def validate_adapter_class(validate_class, adapter_class):
+    """
+    Raises an exception if validate_class is not a
+    subclass of adapter_class.
+
+    :param validate_class: The class to be validated.
+    :type validate_class: class
+
+    :param adapter_class: The class type to check against.
+    :type adapter_class: class
+
+    :raises: InvalidAdapterException
+    """
+    from .adapters import Adapter
+    from .chatterbot import ChatBot
+
+    # If a dictionary was passed in, check if it has an import_path attribute
+    if isinstance(validate_class, dict):
+        origional_data = validate_class.copy()
+        validate_class = validate_class.get('import_path')
+
+        if not validate_class:
+            raise ChatBot.InvalidAdapterException(
+                'The dictionary {} must contain a value for "import_path"'.format(
+                    str(origional_data)
+                )
+            )
+
+    if not issubclass(import_module(validate_class), Adapter):
+        raise ChatBot.InvalidAdapterException(
+            '{} must be a subclass of {}'.format(
+                validate_class,
+                Adapter.__name__
+            )
+        )
+
+    if not issubclass(import_module(validate_class), adapter_class):
+        raise ChatBot.InvalidAdapterException(
+            '{} must be a subclass of {}'.format(
+                validate_class,
+                adapter_class.__name__
+            )
+        )
+
+
 def input_function():
     """
     Normalizes reading input between python 2 and 3.

--- a/tests/logic_adapter_tests/test_multi_adapter.py
+++ b/tests/logic_adapter_tests/test_multi_adapter.py
@@ -35,9 +35,9 @@ class MultiLogicAdapterTestCase(ChatBotTestCase):
         statement, this statement should be returned with the
         highest confidence available from these matching options.
         """
-        self.adapter.add_adapter(TestAdapterA())
-        self.adapter.add_adapter(TestAdapterB())
-        self.adapter.add_adapter(TestAdapterC())
+        self.adapter.add_adapter('tests.logic_adapter_tests.test_multi_adapter.TestAdapterA')
+        self.adapter.add_adapter('tests.logic_adapter_tests.test_multi_adapter.TestAdapterB')
+        self.adapter.add_adapter('tests.logic_adapter_tests.test_multi_adapter.TestAdapterC')
 
         confidence, statement = self.adapter.process(Statement('Howdy!'))
 
@@ -56,9 +56,8 @@ class MultiLogicAdapterTestCase(ChatBotTestCase):
         self.assertEqual(value, 0.85)
 
     def test_add_adapter(self):
-        sub_adapter = TestAdapterA()
         adapter_count_before = len(self.adapter.adapters)
-        self.adapter.add_adapter(sub_adapter)
+        self.adapter.add_adapter('tests.logic_adapter_tests.test_multi_adapter.TestAdapterA')
         adapter_count_after = len(self.adapter.adapters)
 
         self.assertEqual(adapter_count_after, adapter_count_before + 1)

--- a/tests/test_adapter_validation.py
+++ b/tests/test_adapter_validation.py
@@ -88,16 +88,16 @@ class MultiAdapterTests(ChatBotTestCase):
     def test_add_logic_adapter(self):
         count_before = len(self.chatbot.logic.adapters)
 
-        self.chatbot.add_logic_adapter(
+        self.chatbot.logic.add_adapter(
             'chatterbot.logic.ClosestMatchAdapter'
         )
         self.assertEqual(len(self.chatbot.logic.adapters), count_before + 1)
 
     def test_insert_logic_adapter(self):
-        self.chatbot.add_logic_adapter('chatterbot.logic.TimeLogicAdapter')
-        self.chatbot.add_logic_adapter('chatterbot.logic.ClosestMatchAdapter')
+        self.chatbot.logic.add_adapter('chatterbot.logic.TimeLogicAdapter')
+        self.chatbot.logic.add_adapter('chatterbot.logic.ClosestMatchAdapter')
 
-        self.chatbot.insert_logic_adapter('chatterbot.logic.MathematicalEvaluation', 1)
+        self.chatbot.logic.insert_logic_adapter('chatterbot.logic.MathematicalEvaluation', 1)
 
         self.assertEqual(
             type(self.chatbot.logic.adapters[1]).__name__,
@@ -105,22 +105,22 @@ class MultiAdapterTests(ChatBotTestCase):
         )
 
     def test_remove_logic_adapter(self):
-        self.chatbot.add_logic_adapter('chatterbot.logic.TimeLogicAdapter')
-        self.chatbot.add_logic_adapter('chatterbot.logic.MathematicalEvaluation')
+        self.chatbot.logic.add_adapter('chatterbot.logic.TimeLogicAdapter')
+        self.chatbot.logic.add_adapter('chatterbot.logic.MathematicalEvaluation')
 
         adapter_count = len(self.chatbot.logic.adapters)
 
-        removed = self.chatbot.remove_logic_adapter('MathematicalEvaluation')
+        removed = self.chatbot.logic.remove_logic_adapter('MathematicalEvaluation')
 
         self.assertTrue(removed)
         self.assertEqual(len(self.chatbot.logic.adapters), adapter_count - 1)
 
     def test_remove_logic_adapter_not_found(self):
-        self.chatbot.add_logic_adapter('chatterbot.logic.TimeLogicAdapter')
+        self.chatbot.logic.add_adapter('chatterbot.logic.TimeLogicAdapter')
 
         adapter_count = len(self.chatbot.logic.adapters)
 
-        removed = self.chatbot.remove_logic_adapter('MathematicalEvaluation')
+        removed = self.chatbot.logic.remove_logic_adapter('MathematicalEvaluation')
 
         self.assertFalse(removed)
         self.assertEqual(len(self.chatbot.logic.adapters), adapter_count)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -17,7 +17,8 @@ class StringInitalizationTestCase(ChatBotTestCase):
 
     def test_logic_initialized(self):
         from chatterbot.logic import ClosestMatchAdapter
-        self.assertTrue(isinstance(self.chatbot.logic.adapters[1], ClosestMatchAdapter))
+        self.assertEqual(len(self.chatbot.logic.adapters), 1)
+        self.assertTrue(isinstance(self.chatbot.logic.adapters[0], ClosestMatchAdapter))
 
     def test_input_initialized(self):
         from chatterbot.input import VariableInputTypeAdapter
@@ -61,8 +62,9 @@ class DictionaryInitalizationTestCase(ChatBotTestCase):
     def test_logic_initialized(self):
         from chatterbot.logic import ClosestMatchAdapter
         from chatterbot.logic import MathematicalEvaluation
-        self.assertTrue(isinstance(self.chatbot.logic.adapters[1], ClosestMatchAdapter))
-        self.assertTrue(isinstance(self.chatbot.logic.adapters[2], MathematicalEvaluation))
+        self.assertEqual(len(self.chatbot.logic.adapters), 2)
+        self.assertTrue(isinstance(self.chatbot.logic.adapters[0], ClosestMatchAdapter))
+        self.assertTrue(isinstance(self.chatbot.logic.adapters[1], MathematicalEvaluation))
 
     def test_input_initialized(self):
         from chatterbot.input import VariableInputTypeAdapter


### PR DESCRIPTION
The MultiLogicAdapter which handles the process of checking the generated responses of other logic adapters, could return just the user's input if other logic adapters are added after the chat bot is initialized. This was fixed by adding a separate list for system logic adapters that are required to be present at all times.

Closes #431