### PR TITLE
Cache results from can_process method in math adapter

### DIFF
--- a/chatterbot/logic/mathematical_evaluation.py
+++ b/chatterbot/logic/mathematical_evaluation.py
@@ -82,7 +82,9 @@ class MathematicalEvaluation(LogicAdapter):
 
         # Returning important information
         try:
-            expression += "= " + str(eval(expression, {f: getattr(numpy, f) for f in self.functions}))
+            expression += "= " + str(
+                eval(expression, {f: getattr(numpy, f) for f in self.functions})
+            )
 
             # return a confidence of 1 if the expression could be evaluated
             return 1, Statement(expression)

--- a/chatterbot/logic/mathematical_evaluation.py
+++ b/chatterbot/logic/mathematical_evaluation.py
@@ -29,6 +29,7 @@ class MathematicalEvaluation(LogicAdapter):
 
         language = kwargs.get('math_words_language', 'english')
         self.math_words = self.get_language_data(language)
+        self.cache = {}
 
     def get_language_data(self, language):
         """
@@ -59,6 +60,7 @@ class MathematicalEvaluation(LogicAdapter):
         adapter to respond to the user input.
         """
         confidence, response = self.process(statement)
+        self.cache[statement.text] = (confidence, response)
         return confidence == 1
 
     def process(self, statement):
@@ -68,6 +70,12 @@ class MathematicalEvaluation(LogicAdapter):
         with the mathematical terms "solved".
         """
         input_text = statement.text
+
+        # Use the result cached by the process method if it exists
+        if input_text in self.cache:
+            cached_result = self.cache[input_text]
+            self.cache = {}
+            return cached_result
 
         # Getting the mathematical terms within the input statement
         expression = str(self.simplify_chunks(self.normalize(input_text)))
@@ -231,9 +239,7 @@ class MathematicalEvaluation(LogicAdapter):
         return ' '.join(condensed_string)
 
     class UnrecognizedLanguageException(Exception):
-
-        def __init__(self, value='The specified language was not recognized'):
-            self.value = value
-
-        def __str__(self):
-            return repr(self.value)
+        """
+        Exception raised when the specified language is not known.
+        """
+        pass


### PR DESCRIPTION
This makes changes so that if a value is processed by the 'can_process' method of the math adapter, the
result can be reused when the 'process' method is called. This reduces redundant operations and increases the efficiency of this method.