### PR TITLE
Handle the case that a chat session does not exist

### DIFF
--- a/chatterbot/conversation/session.py
+++ b/chatterbot/conversation/session.py
@@ -30,15 +30,15 @@ class SessionManager(object):
         """
         session = Session()
 
-        self.sessions[str(session.uuid)] = session
+        self.sessions[session.id_string] = session
 
         return session
 
-    def get(self, session_id):
+    def get(self, session_id, default=None):
         """
         Return a session given a unique identifier.
         """
-        return self.sessions[str(session_id)]
+        return self.sessions.get(str(session_id), default)
 
     def update(self, session_id, conversance):
         """

--- a/examples/django_app/tests/test_views.py
+++ b/examples/django_app/tests/test_views.py
@@ -3,6 +3,12 @@ from django.core.exceptions import ValidationError
 from chatterbot.ext.django_chatterbot.views import ChatterBotView
 
 
+class MockResponse(object):
+
+    def __init__(self, id_string):
+        self.session = {'chat_session_id': id_string}
+
+
 class ViewTestCase(TestCase):
 
     def setUp(self):
@@ -22,3 +28,23 @@ class ViewTestCase(TestCase):
             self.view.validate({
                 'type': 'classmethod'
             })
+
+    def test_get_chat_session(self):
+        session = self.view.chatterbot.conversation_sessions.new()
+        mock_response = MockResponse(session.id_string)
+        get_session = self.view.get_chat_session(mock_response)
+
+        self.assertEqual(session.id_string, get_session.id_string)
+
+    def test_get_chat_session_invalid(self):
+        mock_response = MockResponse('--invalid--')
+        session = self.view.get_chat_session(mock_response)
+
+        self.assertNotEqual(session.id_string, 'test-session-id')
+
+    def test_get_chat_session_no_session(self):
+        mock_response = MockResponse(None)
+        mock_response.session = {}
+        session = self.view.get_chat_session(mock_response)
+
+        self.assertNotEqual(session.id_string, 'test-session-id')

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -27,6 +27,16 @@ class SessionManagerTestCase(TestCase):
 
         self.assertEqual(session.id_string, returned_session.id_string)
 
+    def test_get_invalid_id(self):
+        returned_session = self.manager.get('--invalid--')
+
+        self.assertIsNone(returned_session)
+
+    def test_get_invalid_id_with_deafult(self):
+        returned_session = self.manager.get('--invalid--', 'default_value')
+
+        self.assertEqual(returned_session, 'default_value')
+
     def test_update(self):
         session = self.manager.new()
         self.manager.update(session.id_string, ('A', 'B', ))


### PR DESCRIPTION
This fixes a problem where a chat id could be provided, but a chat session for it did not exist.

Closes #453