### PR TITLE
Do not update extra data from kwargs

### DIFF
--- a/chatterbot/conversation/statement.py
+++ b/chatterbot/conversation/statement.py
@@ -13,8 +13,6 @@ class Statement(object):
         self.in_response_to = kwargs.pop('in_response_to', [])
         self.extra_data = kwargs.pop('extra_data', {})
 
-        self.extra_data.update(kwargs)
-
     def __str__(self):
         return self.text
 


### PR DESCRIPTION
Doing this update from the remaining kwargs entails confusing functionality of the statement arguments. Removing this line and having `extra_data` set explicitly is better than having it implicitly gain any left over kwargs. 