### PR TITLE
Deprecate OutputFormatAdapter

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -26,7 +26,7 @@ class ChatBot(object):
 
         input_adapter = kwargs.get('input_adapter', 'chatterbot.input.VariableInputTypeAdapter')
 
-        output_adapter = kwargs.get('output_adapter', 'chatterbot.output.OutputFormatAdapter')
+        output_adapter = kwargs.get('output_adapter', 'chatterbot.output.OutputAdapter')
 
         # Check that each adapter is a valid subclass of it's respective parent
         utils.validate_adapter_class(storage_adapter, StorageAdapter)

--- a/chatterbot/ext/django_chatterbot/settings.py
+++ b/chatterbot/ext/django_chatterbot/settings.py
@@ -10,8 +10,7 @@ CHATTERBOT_DEFAULTS = {
     'name': 'ChatterBot',
     'storage_adapter': 'chatterbot.storage.DjangoStorageAdapter',
     'input_adapter': 'chatterbot.input.VariableInputTypeAdapter',
-    'output_adapter': 'chatterbot.output.OutputFormatAdapter',
-    'output_format': 'json'
+    'output_adapter': 'chatterbot.output.OutputAdapter'
 }
 
 CHATTERBOT = CHATTERBOT_DEFAULTS.copy()

--- a/chatterbot/ext/django_chatterbot/views.py
+++ b/chatterbot/ext/django_chatterbot/views.py
@@ -64,7 +64,8 @@ class ChatterBotView(ChatterBotViewMixin, View):
 
         chat_session = self.get_chat_session(request)
 
-        response_data = self.chatterbot.get_response(input_data, chat_session.id_string)
+        response = self.chatterbot.get_response(input_data, chat_session.id_string)
+        response_data = response.serialize()
 
         return JsonResponse(response_data, status=200)
 

--- a/chatterbot/output/output_adapter.py
+++ b/chatterbot/output/output_adapter.py
@@ -3,13 +3,21 @@ from chatterbot.adapters import Adapter
 
 class OutputAdapter(Adapter):
     """
-    This is an abstract class that represents the
-    interface that all output adapters should implement.
+    A generic class that can be overridden by a subclass to provide extended
+    functionality, such as delivering a response to an API endpoint.
     """
 
-    def process_response(self, input_value, confidence, session_id=None):
+    def process_response(self, statement, confidence, session_id=None):
         """
-        Takes an input value.
-        Returns an output value.
+        Override this method in a subclass to implement customized functionality.
+
+        :param statement: The statement that the chat bot has produced in response to some input.
+
+        :param confidence: The confidence with which the chat bot 'thinks' the
+                           given statement is the correct response.
+
+        :param session_id: The unique id of the current chat session.
+
+        :returns: The response statement.
         """
-        raise self.AdapterMethodNotImplementedError()
+        return statement

--- a/chatterbot/output/output_format_adapter.py
+++ b/chatterbot/output/output_format_adapter.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import warnings
 from .output_adapter import OutputAdapter
 
 
@@ -19,7 +20,22 @@ class OutputFormatAdapter(OutputAdapter):
         super(OutputFormatAdapter, self).__init__(**kwargs)
         self.format = kwargs.get('output_format', 'object')
 
-        if self.format not in self.VALID_FORMATS:
+        if self.format == self.TEXT:
+            warnings.warn(
+                'OutputFormatAdapter is deprecated. Use OutputAdapter instead and get `.text` from the returned object.',
+                DeprecationWarning
+            )
+        elif self.format == self.JSON:
+            warnings.warn(
+                'OutputFormatAdapter is deprecated. Use OutputAdapter instead and call `.serialize()` from the returned object.',
+                DeprecationWarning
+            )
+        elif self.format == self.OBJECT:
+            warnings.warn(
+                'OutputFormatAdapter is deprecated. Use OutputAdapter instead.',
+                DeprecationWarning
+            )
+        elif self.format not in self.VALID_FORMATS:
             raise self.UnrecognizedOutputFormatException(
                 'The output type {} is not a known valid format'.format(
                     self.format

--- a/examples/math_and_time.py
+++ b/examples/math_and_time.py
@@ -9,7 +9,7 @@ bot = ChatBot(
         "chatterbot.logic.TimeLogicAdapter"
     ],
     input_adapter="chatterbot.input.VariableInputTypeAdapter",
-    output_adapter="chatterbot.output.OutputFormatAdapter"
+    output_adapter="chatterbot.output.OutputAdapter"
 )
 
 # Print an example of getting one math based response

--- a/examples/tkinter_gui.py
+++ b/examples/tkinter_gui.py
@@ -13,9 +13,9 @@ from chatterbot import ChatBot
 class TkinterGUIExample(tk.Tk):
 
     def __init__(self, *args, **kwargs):
-        '''
+        """
         Create & set window variables.
-        '''
+        """
         tk.Tk.__init__(self, *args, **kwargs)
 
         self.chatbot = ChatBot("No Output",
@@ -24,7 +24,7 @@ class TkinterGUIExample(tk.Tk):
                 "chatterbot.logic.BestMatch"
             ],
             input_adapter="chatterbot.input.VariableInputTypeAdapter",
-            output_adapter="chatterbot.output.OutputFormatAdapter",
+            output_adapter="chatterbot.output.OutputAdapter",
             database="../database.db"
         )
 
@@ -33,9 +33,9 @@ class TkinterGUIExample(tk.Tk):
         self.initialize()
 
     def initialize(self):
-        '''
+        """
         Set window layout.
-        '''
+        """
         self.grid()
 
         self.respond = ttk.Button(self, text='Get Response', command=self.get_response)
@@ -51,10 +51,9 @@ class TkinterGUIExample(tk.Tk):
         self.conversation.grid(column=0, row=2, columnspan=2, sticky='nesw', padx=3, pady=3)
 
     def get_response(self):
-        '''
-        Get a response from the chatbot &
-        display it.
-        '''
+        """
+        Get a response from the chatbot and display it.
+        """
         user_input = self.usr_input.get()
         self.usr_input.delete(0, tk.END)
 

--- a/tests/base_case.py
+++ b/tests/base_case.py
@@ -12,7 +12,7 @@ class ChatBotTestCase(TestCase):
     def get_kwargs(self):
         return {
             'input_adapter': 'chatterbot.input.VariableInputTypeAdapter',
-            'output_adapter': 'chatterbot.output.OutputFormatAdapter',
+            'output_adapter': 'chatterbot.output.OutputAdapter',
             'database': None, # None runs the database in-memory
             'silence_performance_warning': True
         }

--- a/tests/output_adapter_tests/test_output_adapter.py
+++ b/tests/output_adapter_tests/test_output_adapter.py
@@ -15,5 +15,8 @@ class OutputAdapterTestCase(TestCase):
         self.adapter = OutputAdapter()
 
     def test_process_response(self):
-        with self.assertRaises(OutputAdapter.AdapterMethodNotImplementedError):
-            self.adapter.process_response('', 0)
+        """
+        The value passed in for the statement parameter should be returned.
+        """
+        statement = self.adapter.process_response('_', 0)
+        self.assertEqual(statement, '_')

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -6,7 +6,7 @@ class StringInitalizationTestCase(ChatBotTestCase):
     def get_kwargs(self):
         return {
             'input_adapter': 'chatterbot.input.VariableInputTypeAdapter',
-            'output_adapter': 'chatterbot.output.OutputFormatAdapter',
+            'output_adapter': 'chatterbot.output.OutputAdapter',
             'database': None,
             'silence_performance_warning': True
         }
@@ -25,8 +25,8 @@ class StringInitalizationTestCase(ChatBotTestCase):
         self.assertTrue(isinstance(self.chatbot.input, VariableInputTypeAdapter))
 
     def test_output_initialized(self):
-        from chatterbot.output import OutputFormatAdapter
-        self.assertTrue(isinstance(self.chatbot.output, OutputFormatAdapter))
+        from chatterbot.output import OutputAdapter
+        self.assertTrue(isinstance(self.chatbot.output, OutputAdapter))
 
 
 class DictionaryInitalizationTestCase(ChatBotTestCase):
@@ -38,12 +38,11 @@ class DictionaryInitalizationTestCase(ChatBotTestCase):
                 'database': None,
                 'silence_performance_warning': True
             },
-
             'input_adapter': {
                 'import_path': 'chatterbot.input.VariableInputTypeAdapter'
             },
             'output_adapter': {
-                'import_path': 'chatterbot.output.OutputFormatAdapter'
+                'import_path': 'chatterbot.output.OutputAdapter'
             },
             'logic_adapters': [
                 {
@@ -71,5 +70,5 @@ class DictionaryInitalizationTestCase(ChatBotTestCase):
         self.assertTrue(isinstance(self.chatbot.input, VariableInputTypeAdapter))
 
     def test_output_initialized(self):
-        from chatterbot.output import OutputFormatAdapter
-        self.assertTrue(isinstance(self.chatbot.output, OutputFormatAdapter))
+        from chatterbot.output import OutputAdapter
+        self.assertTrue(isinstance(self.chatbot.output, OutputAdapter))


### PR DESCRIPTION
This removes the need to replicate basic methods and properties that are available on the statement object. The `OutputFormatAdapter` will eventually be removed.