### PR TITLE
App label is enough for migrate

### DIFF
--- a/docs/django/index.rst
+++ b/docs/django/index.rst
@@ -55,7 +55,7 @@ Sync your database
 
 .. sourcecode:: sh
 
-   python manage.py migrate chatterbot.ext.django_chatterbot
+   python manage.py migrate django_chatterbot
 
 .. note::
 


### PR DESCRIPTION
Executing migrate thorws error when follows Chatterbot Django docs.  Django migrate needs `app_label`. So I updated the docs. 

Actual Error
```
$ python manage.py migrate chatterbot.ext.django_chatterbot
CommandError: App 'chatterbot.ext.django_chatterbot' does not have migrations.
```