### PR TITLE
Remove tested constraint for response objects in filter method

### DIFF
--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -55,7 +55,7 @@ class DjangoStorageAdapter(StorageAdapter):
             if responses:
                 kwargs['in_response__response__text__in'] = []
                 for response in responses:
-                    kwargs['in_response__response__text__in'].append(response.response.text)
+                    kwargs['in_response__response__text__in'].append(response)
             else:
                 kwargs['in_response'] = None
 

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -170,7 +170,7 @@ class MongoDatabaseAdapter(StorageAdapter):
         if 'in_response_to' in kwargs:
             serialized_responses = []
             for response in kwargs['in_response_to']:
-                serialized_responses.append({'text': response.text})
+                serialized_responses.append({'text': response})
 
             query = query.statement_response_list_equals(serialized_responses)
             del kwargs['in_response_to']

--- a/tests/storage_adapter_tests/test_json_file_storage_adapter.py
+++ b/tests/storage_adapter_tests/test_json_file_storage_adapter.py
@@ -250,7 +250,7 @@ class JsonFileStorageAdapterFilterTestCase(JsonAdapterTestCase):
         self.adapter.update(self.statement1)
 
         results = self.adapter.filter(
-            in_response_to=[Response("Maybe")]
+            in_response_to="Maybe"
         )
         self.assertEqual(len(results), 0)
 

--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -277,9 +277,7 @@ class MongoAdapterFilterTestCase(MongoAdapterTestCase):
     def test_filter_in_response_to_no_matches(self):
         self.adapter.update(self.statement1)
 
-        results = self.adapter.filter(
-            in_response_to=[Response("Maybe")]
-        )
+        results = self.adapter.filter(in_response_to="Maybe")
         self.assertEqual(len(results), 0)
 
     def test_filter_equal_results(self):

--- a/tests/storage_adapter_tests/test_storage_adapter.py
+++ b/tests/storage_adapter_tests/test_storage_adapter.py
@@ -20,7 +20,7 @@ class StorageAdapterTestCase(TestCase):
 
     def test_find(self):
         with self.assertRaises(StorageAdapter.AdapterMethodNotImplementedError):
-            self.adapter.find("")
+            self.adapter.find('')
 
     def test_filter(self):
         with self.assertRaises(StorageAdapter.AdapterMethodNotImplementedError):
@@ -28,11 +28,11 @@ class StorageAdapterTestCase(TestCase):
 
     def test_remove(self):
         with self.assertRaises(StorageAdapter.AdapterMethodNotImplementedError):
-            self.adapter.remove("")
+            self.adapter.remove('')
 
     def test_update(self):
         with self.assertRaises(StorageAdapter.AdapterMethodNotImplementedError):
-            self.adapter.update("")
+            self.adapter.update('')
 
     def test_get_random(self):
         with self.assertRaises(StorageAdapter.AdapterMethodNotImplementedError):

--- a/tests_django/test_django_adapter.py
+++ b/tests_django/test_django_adapter.py
@@ -203,9 +203,7 @@ class DjangoAdapterFilterTestCase(DjangoAdapterTestCase):
     def test_filter_in_response_to_no_matches(self):
         self.adapter.update(self.statement1)
 
-        results = self.adapter.filter(
-            in_response_to__contains="Maybe"
-        )
+        results = self.adapter.filter(in_response_to="Maybe")
         self.assertEqual(len(results), 0)
 
     def test_filter_equal_results(self):


### PR DESCRIPTION
This removes a strange constraint that was being enforced in tests. For some reason response objects were being expected for parts of values in storage adapter filter methods. This pull request removes those constraints because simpler variable types should used to help make storage adapters simpler.