### PR TITLE
Add save method to statements

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -138,7 +138,7 @@ class ChatBot(object):
                 previous_statement.text
             ))
 
-        # Update the database after selecting a response
+        # Save the statement after selecting a response
         self.storage.update(statement)
 
     def set_trainer(self, training_class, **kwargs):

--- a/chatterbot/conversation/statement.py
+++ b/chatterbot/conversation/statement.py
@@ -13,6 +13,8 @@ class Statement(object):
         self.in_response_to = kwargs.pop('in_response_to', [])
         self.extra_data = kwargs.pop('extra_data', {})
 
+        self.storage = None
+
     def __str__(self):
         return self.text
 
@@ -30,6 +32,12 @@ class Statement(object):
             return self.text == other.text
 
         return self.text == other
+
+    def save(self):
+        """
+        Save the statement in the database.
+        """
+        self.storage.update(self)
 
     def add_extra_data(self, key, value):
         """

--- a/chatterbot/storage/jsonfile.py
+++ b/chatterbot/storage/jsonfile.py
@@ -1,6 +1,6 @@
 import warnings
 from chatterbot.storage import StorageAdapter
-from chatterbot.conversation import Statement, Response
+from chatterbot.conversation import Response
 
 
 class JsonFileStorageAdapter(StorageAdapter):
@@ -69,7 +69,7 @@ class JsonFileStorageAdapter(StorageAdapter):
         Takes the list of response items and returns
         the list converted to Response objects.
         """
-        proxy_statement = Statement('')
+        proxy_statement = self.Statement('')
 
         for response in response_list:
             data = response.copy()
@@ -98,7 +98,7 @@ class JsonFileStorageAdapter(StorageAdapter):
         # Remove the text attribute from the values
         text = statement_data.pop('text')
 
-        return Statement(text, **statement_data)
+        return self.Statement(text, **statement_data)
 
     def _all_kwargs_match_values(self, kwarguments, values):
         for kwarg in kwarguments:
@@ -159,7 +159,7 @@ class JsonFileStorageAdapter(StorageAdapter):
             for response_statement in statement.in_response_to:
                 response = self.find(response_statement.text)
                 if not response:
-                    response = Statement(response_statement.text)
+                    response = self.Statement(response_statement.text)
                     self.update(response)
 
         return statement

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -1,5 +1,5 @@
 from chatterbot.storage import StorageAdapter
-from chatterbot.conversation import Statement, Response
+from chatterbot.conversation import Response
 
 
 class Query(object):
@@ -126,14 +126,14 @@ class MongoDatabaseAdapter(StorageAdapter):
             values.get('in_response_to', [])
         )
 
-        return Statement(statement_text, **values)
+        return self.Statement(statement_text, **values)
 
     def deserialize_responses(self, response_list):
         """
         Takes the list of response items and returns
         the list converted to Response objects.
         """
-        proxy_statement = Statement('')
+        proxy_statement = self.Statement('')
 
         for response in response_list:
             text = response['text']
@@ -157,7 +157,7 @@ class MongoDatabaseAdapter(StorageAdapter):
             statement_data.get('in_response_to', [])
         )
 
-        return Statement(statement_text, **statement_data)
+        return self.Statement(statement_text, **statement_data)
 
     def filter(self, **kwargs):
         """

--- a/chatterbot/storage/storage_adapter.py
+++ b/chatterbot/storage/storage_adapter.py
@@ -18,6 +18,22 @@ class StorageAdapter(Adapter):
         self.adapter_supports_queries = True
         self.base_query = None
 
+    @property
+    def Statement(self):
+        """
+        Create a storage-aware statement.
+        """
+        import os
+
+        if 'DJANGO_SETTINGS_MODULE' in os.environ:
+            from chatterbot.ext.django_chatterbot.models import Statement
+            return Statement
+        else:
+            from chatterbot.conversation.statement import Statement
+            statement = Statement
+            statement.storage = self
+            return statement
+
     def generate_base_query(self, chatterbot, session_id):
         """
         Create a base query for the storage adapter.


### PR DESCRIPTION
Calling `.save()` should be more intuitive than passing the statement to the update method of the storage adapter.