### PR TITLE
Rename SessionManager to ConversationSessionManager

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -12,7 +12,7 @@ class ChatBot(object):
     """
 
     def __init__(self, name, **kwargs):
-        from .conversation.session import SessionManager
+        from .conversation.session import ConversationSessionManager
         from .logic import MultiLogicAdapter
 
         self.name = name
@@ -62,7 +62,7 @@ class ChatBot(object):
         self.trainer = TrainerClass(self.storage, **kwargs)
         self.training_data = kwargs.get('training_data')
 
-        self.conversation_sessions = SessionManager()
+        self.conversation_sessions = ConversationSessionManager()
         self.default_session = self.conversation_sessions.new()
 
         self.logger = kwargs.get('logger', logging.getLogger(__name__))

--- a/chatterbot/conversation/session.py
+++ b/chatterbot/conversation/session.py
@@ -16,7 +16,7 @@ class Session(object):
         self.conversation = ResponseQueue(maxsize=10)
 
 
-class SessionManager(object):
+class ConversationSessionManager(object):
     """
     Object to hold and manage multiple chat sessions.
     """

--- a/docs/sessions.rst
+++ b/docs/sessions.rst
@@ -10,7 +10,7 @@ conversations with different people at the same time.
 .. autoclass:: chatterbot.conversation.session.Session
    :members:
 
-.. autoclass:: chatterbot.conversation.session.SessionManager
+.. autoclass:: chatterbot.conversation.session.ConversationSessionManager
    :members:
 
 Each session object holds a queue of the most recent communications that have

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from chatterbot.conversation.session import Session, SessionManager
+from chatterbot.conversation.session import Session, ConversationSessionManager
 
 
 class SessionTestCase(TestCase):
@@ -8,11 +8,12 @@ class SessionTestCase(TestCase):
         session = Session()
         self.assertEqual(str(session.uuid), session.id_string)
 
-class SessionManagerTestCase(TestCase):
+
+class ConversationSessionManagerTestCase(TestCase):
 
     def setUp(self):
-        super(SessionManagerTestCase, self).setUp()
-        self.manager = SessionManager()
+        super(ConversationSessionManagerTestCase, self).setUp()
+        self.manager = ConversationSessionManager()
 
     def test_new(self):
         session = self.manager.new()


### PR DESCRIPTION
Because this class is just used internally, it should be safe to rename without any issues. The name change is being made to make the class name more descriptive.