### PR TITLE
Add warnings about module rename

### DIFF
--- a/chatterbot/conversation/comparisons.py
+++ b/chatterbot/conversation/comparisons.py
@@ -1,8 +1,15 @@
 """
 This file provides proxy methods for backwards compatability.
 """
+import warnings
 
 from chatterbot.comparisons import levenshtein_distance
 from chatterbot.comparisons import synset_distance
 from chatterbot.comparisons import sentiment_comparison
 from chatterbot.comparisons import jaccard_similarity
+
+warnings.warn(
+    'The module "chatterbot.conversation.comparisons has moved." ' +
+    'Use "chatterbot.comparisons" instead.',
+    DeprecationWarning
+)

--- a/chatterbot/conversation/response_selection.py
+++ b/chatterbot/conversation/response_selection.py
@@ -1,7 +1,14 @@
 """
 This file provides proxy methods for backwards compatability.
 """
+import warnings
 
 from chatterbot.response_selection import get_most_frequent_response
 from chatterbot.response_selection import get_first_response
 from chatterbot.response_selection import get_random_response
+
+warnings.warn(
+    'The module "chatterbot.conversation.response_selection has moved." ' +
+    'Use "chatterbot.response_selection" instead.',
+    DeprecationWarning
+)


### PR DESCRIPTION
In this future these two files will be removed completely. For now, imports will continue to work to support backwards compatibility.