### PR TITLE
nltk.data.find argument needs to be a path, not just a filename

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -77,10 +77,10 @@ class ChatBot(object):
         from .utils import nltk_download_corpus
 
         # Download required NLTK corpora if they have not already been downloaded
-        nltk_download_corpus('stopwords')
-        nltk_download_corpus('wordnet')
-        nltk_download_corpus('punkt')
-        nltk_download_corpus('vader_lexicon')
+        nltk_download_corpus('corpora/stopwords')
+        nltk_download_corpus('corpora/wordnet')
+        nltk_download_corpus('tokenizers/punkt')
+        nltk_download_corpus('sentiment/vader_lexicon')
 
     def get_response(self, input_item, session_id=None):
         """

--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -146,7 +146,7 @@ def input_function():
     return user_input
 
 
-def nltk_download_corpus(corpus_name):
+def nltk_download_corpus(resource_path):
     """
     Download the specified NLTK corpus file
     unless it has already been downloaded.
@@ -155,13 +155,24 @@ def nltk_download_corpus(corpus_name):
     """
     from nltk.data import find
     from nltk import download
+    from os.path import split
 
     # Download the wordnet data only if it is not already downloaded
-    zip_file = '{}.zip'.format(corpus_name)
+    _, corpus_name = split(resource_path)
+
+    ## From http://www.nltk.org/api/nltk.html ##
+    # When using find() to locate a directory contained in a zipfile,
+    # the resource name must end with the forward slash character.
+    # Otherwise, find() will not locate the directory.
+    ####
+    # Helps when resource_path=='sentiment/vader_lexicon''
+    if not resource_path.endswith('/'):
+        resource_path = resource_path + '/'
+
     downloaded = False
 
     try:
-        find(zip_file)
+        find(resource_path)
     except LookupError:
         download(corpus_name)
         downloaded = True


### PR DESCRIPTION
`nltk_download_corpus` always downloads nltk resources even if it's already there.

It's because neither `nltk.data.find('stopwords.zip')` nor `nltk.data.find('stopwords')` finds the resource. Maybe `nltk_data` directory tree was flat at some point in the past, but right now it gets populated like this: 

```bash
- corpora
  |- stopwords
  |- stopwords.zip
  |- wordnet
  |- wordnet.zip
- sentiment
  |- vader_lexicon.zip
- tokenizers
  |- punkt
  |- punkt.zip
```

and so only a call like `nltk.data.find('corpora/stopwords')` works.