### PR TITLE
Add regression test to make sure confidence does not get stored in database

### DIFF
--- a/tests_django/test_api.py
+++ b/tests_django/test_api.py
@@ -1,6 +1,6 @@
+import json
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-import json
 
 
 class ApiTestCase(TestCase):

--- a/tests_django/test_api_view.py
+++ b/tests_django/test_api_view.py
@@ -1,9 +1,7 @@
+import json
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.utils.encoding import force_text
 from chatterbot.ext.django_chatterbot.views import ChatterBotView
-import unittest
-import json
 
 
 class ApiIntegrationTestCase(TestCase):
@@ -26,6 +24,7 @@ class ApiIntegrationTestCase(TestCase):
         ).conversation.flush()
 
     def _get_json(self, response):
+        from django.utils.encoding import force_text
         return json.loads(force_text(response.content))
 
     def test_get_conversation_empty(self):

--- a/tests_django/test_django_adapter.py
+++ b/tests_django/test_django_adapter.py
@@ -307,6 +307,22 @@ class DjangoAdapterFilterTestCase(DjangoAdapterTestCase):
         self.assertEqual(len(found[0].in_response_to), 1)
         self.assertEqual(type(found[0].in_response_to[0]), ResponseModel)
 
+    def test_confidence(self):
+        """
+        Test that the confidence value is not saved to the database.
+        The confidence attribute on statements is intended to just hold
+        the confidence of the statement when it returned as a response to
+        some input. Because of that, the value of the confidence score
+        should never be stored in the database with the statement.
+        """
+        statement = StatementModel(text='Test statement')
+        statement.confidence = 0.5
+        statement.save()
+
+        statement_updated = StatementModel.objects.get(pk=statement.id)
+
+        self.assertEqual(statement_updated.confidence, 0)
+
 
 class DjangoOrderingTestCase(DjangoStorageAdapterTestCase):
     """


### PR DESCRIPTION
The confidence value should never be stored in the database, it is just a temporary value that gets returned with the statement.