### PR TITLE
Fix "empty generator" bug in ChatBot.filters

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -39,7 +39,7 @@ class ChatBot(object):
         self.output = utils.initialize_class(output_adapter, **kwargs)
 
         filters = kwargs.get('filters', tuple())
-        self.filters = (utils.import_module(F)() for F in filters)
+        self.filters = tuple([utils.import_module(F)() for F in filters])
 
         # Add required system logic adapter
         self.logic.system_adapters.append(


### PR DESCRIPTION
This fixes a bug with the assignment of the filters attribute, whereby a
generator, rather than it's result is assigned to the ChatBot.filters
attribute. Subsequent iterations of the attribute will return an empty
result.

This fix just assigns the result to the filters attribute as a tuple.