### PR TITLE
Change logic adapters to just return one value

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -135,9 +135,9 @@ class ChatBot(object):
         self.storage.generate_base_query(self, session_id)
 
         # Select a response to the input statement
-        confidence, response = self.logic.process(input_statement)
+        response = self.logic.process(input_statement)
 
-        return input_statement, response, confidence
+        return input_statement, response, response.confidence
 
     def learn_response(self, statement, previous_statement):
         """

--- a/chatterbot/logic/best_match.py
+++ b/chatterbot/logic/best_match.py
@@ -81,4 +81,4 @@ class BestMatch(LogicAdapter):
             # Set confidence to zero because a random response is selected
             response.confidence = 0
 
-        return response.confidence, response
+        return response

--- a/chatterbot/logic/logic_adapter.py
+++ b/chatterbot/logic/logic_adapter.py
@@ -63,9 +63,17 @@ class LogicAdapter(Adapter):
         :param statement: An input statement to be processed by the logic adapter.
         :type statement: Statement
 
-        :rtype: float, Statement
+        :rtype: Statement
         """
         raise self.AdapterMethodNotImplementedError()
+
+    @property
+    def class_name(self):
+        """
+        Return the name of the current logic adapter class.
+        This is typically used for logging and debugging.
+        """
+        return str(self.__class__.__name__)
 
     class EmptyDatasetException(Exception):
 

--- a/chatterbot/logic/low_confidence.py
+++ b/chatterbot/logic/low_confidence.py
@@ -34,4 +34,4 @@ class LowConfidenceAdapter(BestMatch):
         else:
             self.default_response.confidence = 0
 
-        return self.default_response.confidence, self.default_response
+        return self.default_response

--- a/chatterbot/logic/mathematical_evaluation.py
+++ b/chatterbot/logic/mathematical_evaluation.py
@@ -64,9 +64,9 @@ class MathematicalEvaluation(LogicAdapter):
         Determines whether it is appropriate for this
         adapter to respond to the user input.
         """
-        confidence, response = self.process(statement)
-        self.cache[statement.text] = (confidence, response)
-        return confidence == 1
+        response = self.process(statement)
+        self.cache[statement.text] = response
+        return response.confidence == 1
 
     def process(self, statement):
         """
@@ -100,7 +100,7 @@ class MathematicalEvaluation(LogicAdapter):
         except:
             response.confidence = 0
 
-        return response.confidence, response
+        return response
 
     def simplify_chunks(self, input_text):
         """

--- a/chatterbot/logic/no_knowledge_adapter.py
+++ b/chatterbot/logic/no_knowledge_adapter.py
@@ -23,4 +23,4 @@ class NoKnowledgeAdapter(LogicAdapter):
         else:
             statement.confidence = 1
 
-        return statement.confidence, statement
+        return statement

--- a/chatterbot/logic/specific_response.py
+++ b/chatterbot/logic/specific_response.py
@@ -29,4 +29,4 @@ class SpecificResponseAdapter(LogicAdapter):
         else:
             self.response_statement.confidence = 0
 
-        return self.response_statement.confidence, self.response_statement
+        return self.response_statement

--- a/chatterbot/logic/time_adapter.py
+++ b/chatterbot/logic/time_adapter.py
@@ -63,4 +63,4 @@ class TimeLogicAdapter(LogicAdapter):
         response = Statement('The current time is ' + now.strftime('%I:%M %p'))
 
         response.confidence = confidence
-        return confidence, response
+        return response

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_levenshtein_distance.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_levenshtein_distance.py
@@ -87,8 +87,7 @@ class BestMatchLevenshteinDistanceTestCase(ChatBotTestCase):
             return_value=Statement('Random')
         )
 
-        confidence, match = self.adapter.process(Statement('Blah'))
+        match = self.adapter.process(Statement('Blah'))
 
-        self.assertEqual(confidence, 0)
         self.assertEqual(match.confidence, 0)
         self.assertEqual(match.text, 'Random')

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_sentiment_comparison.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_sentiment_comparison.py
@@ -29,9 +29,8 @@ class BestMatchSentimentComparisonTestCase(ChatBotTestCase):
         ])
 
         happy_statement = Statement('I enjoy raspberry ice cream.')
-        confidence, response = self.adapter.process(happy_statement)
+        response = self.adapter.process(happy_statement)
 
-        self.assertEqual(confidence, 1)
         self.assertEqual(response.confidence, 1)
         self.assertEqual(response.text, 'I am glad to hear that.')
 
@@ -45,8 +44,7 @@ class BestMatchSentimentComparisonTestCase(ChatBotTestCase):
         ])
 
         happy_statement = Statement('I enjoy raspberry.')
-        confidence, response = self.adapter.process(happy_statement)
+        response = self.adapter.process(happy_statement)
 
         self.assertEqual(response.text, 'I am glad to hear that.')
-        self.assertAlmostEqual(confidence, 0.75, places=1)
         self.assertAlmostEqual(response.confidence, 0.75, places=1)

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_synset_distance.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_synset_distance.py
@@ -73,8 +73,7 @@ class BestMatchSynsetDistanceTestCase(ChatBotTestCase):
             return_value=Statement('Random')
         )
 
-        confidence, match = self.adapter.process(Statement('Blah'))
+        match = self.adapter.process(Statement('Blah'))
 
-        self.assertEqual(confidence, 0)
         self.assertEqual(match.confidence, 0)
         self.assertEqual(match.text, 'Random')

--- a/tests/logic_adapter_tests/test_data_cache.py
+++ b/tests/logic_adapter_tests/test_data_cache.py
@@ -14,8 +14,8 @@ class DummyMutatorLogicAdapter(LogicAdapter):
         statement.add_extra_data('pos_tags', 'NN')
 
         self.chatbot.storage.update(statement)
-
-        return 1, statement
+        statement.confidence = 1
+        return statement
 
 
 class DataCachingTests(ChatBotTestCase):

--- a/tests/logic_adapter_tests/test_logic_adapter.py
+++ b/tests/logic_adapter_tests/test_logic_adapter.py
@@ -14,15 +14,21 @@ class LogicAdapterTestCase(TestCase):
         super(LogicAdapterTestCase, self).setUp()
         self.adapter = LogicAdapter()
 
+    def test_class_name(self):
+        """
+        Test that the logic adapter can return its own class name.
+        """
+        self.assertEqual(self.adapter.class_name, 'LogicAdapter')
+
     def test_can_process(self):
         """
         This method should return true by default.
         """
-        self.assertTrue(self.adapter.can_process(""))
+        self.assertTrue(self.adapter.can_process(''))
 
     def test_process(self):
         with self.assertRaises(LogicAdapter.AdapterMethodNotImplementedError):
-            self.adapter.process("")
+            self.adapter.process('')
 
     def test_set_statement_comparison_function_string(self):
         adapter = LogicAdapter(

--- a/tests/logic_adapter_tests/test_low_confidence_adapter.py
+++ b/tests/logic_adapter_tests/test_low_confidence_adapter.py
@@ -44,9 +44,8 @@ class LowConfidenceAdapterTestCase(ChatBotTestCase):
         Test the case that a high confidence response is known.
         """
         statement = Statement('What is your quest?')
-        confidence, match = self.adapter.process(statement)
+        match = self.adapter.process(statement)
 
-        self.assertEqual(confidence, 0)
         self.assertEqual(match.confidence, 0)
         self.assertEqual(match, self.adapter.default_response)
 
@@ -55,8 +54,7 @@ class LowConfidenceAdapterTestCase(ChatBotTestCase):
         Test the case that a high confidence response is not known.
         """
         statement = Statement('Is this a tomato?')
-        confidence, match = self.adapter.process(statement)
+        match = self.adapter.process(statement)
 
-        self.assertEqual(confidence, 1)
         self.assertEqual(match.confidence, 1)
         self.assertEqual(match, self.adapter.default_response)

--- a/tests/logic_adapter_tests/test_mathematical_evaluation.py
+++ b/tests/logic_adapter_tests/test_mathematical_evaluation.py
@@ -63,25 +63,25 @@ class MathematicalEvaluationOperationTests(TestCase):
 
     def test_addition_operator(self):
         statement = Statement('What is 100 + 54?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( 100 + 54 ) = 154')
         self.assertEqual(response.confidence, 1)
 
     def test_subtraction_operator(self):
         statement = Statement('What is 100 - 58?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( 100 - 58 ) = 42')
         self.assertEqual(response.confidence, 1)
 
     def test_multiplication_operator(self):
         statement = Statement('What is 100 * 20')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( 100 * 20 ) = 2000')
         self.assertEqual(response.confidence, 1)
 
     def test_division_operator(self):
         statement = Statement('What is 100 / 20')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.confidence, 1)
 
         if self.python_version <= 2:
@@ -91,31 +91,31 @@ class MathematicalEvaluationOperationTests(TestCase):
 
     def test_exponent_operator(self):
         statement = Statement('What is 2 ^ 10')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( 2 ^ 10 ) = 1024')
         self.assertEqual(response.confidence, 1)
 
     def test_parenthesized_multiplication_and_addition(self):
         statement = Statement('What is 100 + ( 1000 * 2 )?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( 100 + ( ( 1000 * ( 2 ) ) ) ) = 2100')
         self.assertEqual(response.confidence, 1)
 
     def test_parenthesized_with_words(self):
         statement = Statement('What is four plus 100 + ( 100 * 2 )?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( 4 + ( 100 + ( ( 100 * ( 2 ) ) ) ) ) = 304')
         self.assertEqual(response.confidence, 1)
 
     def test_word_numbers_addition(self):
         statement = Statement('What is one hundred + four hundred?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( 100 + 400 ) = 500')
         self.assertEqual(response.confidence, 1)
 
     def test_word_division_operator(self):
         statement = Statement('What is 100 divided by 100?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
 
         if self.python_version <= 2:
             self.assertEqual(response.text, '( 100 / 100 ) = 1')
@@ -126,7 +126,7 @@ class MathematicalEvaluationOperationTests(TestCase):
 
     def test_large_word_division_operator(self):
         statement = Statement('What is one thousand two hundred four divided by one hundred?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
 
         if self.python_version <= 2:
             self.assertEqual(response.text, '( 1000 + 200 + 4 ) / ( 100 ) = 12')
@@ -137,37 +137,37 @@ class MathematicalEvaluationOperationTests(TestCase):
 
     def test_negative_multiplication(self):
         statement = Statement('What is -105 * 5')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( -105 * 5 ) = -525')
         self.assertEqual(response.confidence, 1)
 
     def test_negative_decimal_multiplication(self):
         statement = Statement('What is -100.5 * 20?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '( -100.5 * 20 ) = -2010.0')
         self.assertEqual(response.confidence, 1)
 
     def test_pi_constant(self):
         statement = Statement('What is pi plus one ?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '3.141693 + ( 1 ) = 4.141693')
         self.assertEqual(response.confidence, 1)
 
     def test_e_constant(self):
         statement = Statement('What is e plus one ?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, '2.718281 + ( 1 ) = 3.718281')
         self.assertEqual(response.confidence, 1)
 
     def test_log_function(self):
         statement = Statement('What is log 100 ?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, 'log ( 100 ) = 2.0')
         self.assertEqual(response.confidence, 1)
 
     def test_square_root_function(self):
         statement = Statement('What is the sqrt 144 ?')
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
         self.assertEqual(response.text, 'sqrt ( 144 ) = 12.0')
         self.assertEqual(response.confidence, 1)
 

--- a/tests/logic_adapter_tests/test_multi_adapter.py
+++ b/tests/logic_adapter_tests/test_multi_adapter.py
@@ -45,9 +45,8 @@ class MultiLogicAdapterTestCase(ChatBotTestCase):
         self.adapter.add_adapter('tests.logic_adapter_tests.test_multi_adapter.TestAdapterB')
         self.adapter.add_adapter('tests.logic_adapter_tests.test_multi_adapter.TestAdapterC')
 
-        confidence, statement = self.adapter.process(Statement('Howdy!'))
+        statement = self.adapter.process(Statement('Howdy!'))
 
-        self.assertEqual(confidence, 0.5)
         self.assertEqual(statement.confidence, 0.5)
         self.assertEqual(statement, 'Good morning.')
 

--- a/tests/logic_adapter_tests/test_specific_response.py
+++ b/tests/logic_adapter_tests/test_specific_response.py
@@ -20,9 +20,8 @@ class SpecificResponseAdapterTestCase(TestCase):
         Test the case that an exact match is given.
         """
         statement = Statement('Open sesame!')
-        confidence, match = self.adapter.process(statement)
+        match = self.adapter.process(statement)
 
-        self.assertEqual(confidence, 1)
         self.assertEqual(match.confidence, 1)
         self.assertEqual(match, self.adapter.response_statement)
 
@@ -31,8 +30,7 @@ class SpecificResponseAdapterTestCase(TestCase):
         Test the case that an exact match is not given.
         """
         statement = Statement('Open says me!')
-        confidence, match = self.adapter.process(statement)
+        match = self.adapter.process(statement)
 
-        self.assertEqual(confidence, 0)
         self.assertEqual(match.confidence, 0)
         self.assertEqual(match, self.adapter.response_statement)

--- a/tests/logic_adapter_tests/test_time.py
+++ b/tests/logic_adapter_tests/test_time.py
@@ -10,17 +10,15 @@ class TimeAdapterTests(TestCase):
 
     def test_positive_input(self):
         statement = Statement("Do you know what time it is?")
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
 
-        self.assertEqual(confidence, 1)
         self.assertEqual(response.confidence, 1)
         self.assertIn("The current time is ", response.text)
 
     def test_negative_input(self):
         statement = Statement("What is an example of a pachyderm?")
-        confidence, response = self.adapter.process(statement)
+        response = self.adapter.process(statement)
 
-        self.assertEqual(confidence, 0)
         self.assertEqual(response.confidence, 0)
         self.assertIn("The current time is ", response.text)
 

--- a/tests_django/integration_tests/test_logic_adapter_integration.py
+++ b/tests_django/integration_tests/test_logic_adapter_integration.py
@@ -32,11 +32,10 @@ class LogicIntegrationTestCase(TestCase):
         response = Response(statement=statement1, response=statement2)
         response.save()
 
-        confidence, response = adapter.process(statement1)
+        response = adapter.process(statement1)
 
         self.assertEqual(response.text, 'Yes')
         self.assertEqual(response.confidence, 1)
-        self.assertEqual(confidence, 1)
 
     def test_low_confidence(self):
         from chatterbot.logic import LowConfidenceAdapter
@@ -46,7 +45,7 @@ class LogicIntegrationTestCase(TestCase):
 
         statement = Statement(text='Why is the sky blue?')
 
-        confidence, response = adapter.process(statement)
+        response = adapter.process(statement)
 
         self.assertEqual(response.text, adapter.default_response)
 
@@ -58,7 +57,7 @@ class LogicIntegrationTestCase(TestCase):
 
         statement = Statement(text='What is 6 + 6?')
 
-        confidence, response = adapter.process(statement)
+        response = adapter.process(statement)
 
         self.assertEqual(response.text, '( 6 + 6 ) = 12')
         self.assertEqual(response.confidence, 1)
@@ -71,7 +70,7 @@ class LogicIntegrationTestCase(TestCase):
 
         statement = Statement(text='What time is it?')
 
-        confidence, response = adapter.process(statement)
+        response = adapter.process(statement)
 
         self.assertIn('The current time is', response.text)
         self.assertEqual(response.confidence, 1)


### PR DESCRIPTION
This change is being made to simplify logic adapters and to remove redundant data since the confidence score is now being stored on the statement object.

Closes #566