### PR TITLE
Require session id for generate_response method

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -124,14 +124,10 @@ class ChatBot(object):
         # Process the response output with the output adapter
         return self.output.process_response(response, session_id)
 
-    def generate_response(self, input_statement, session_id=None):
+    def generate_response(self, input_statement, session_id):
         """
         Return a response based on a given input statement.
         """
-        if not session_id:
-            session = self.conversation_sessions.get(self.default_session.id_string)
-            session_id = str(session.uuid)
-
         self.storage.generate_base_query(self, session_id)
 
         # Select a response to the input statement

--- a/chatterbot/conversation/session.py
+++ b/chatterbot/conversation/session.py
@@ -11,6 +11,7 @@ class Session(object):
         # A unique identifier for the chat session
         self.uuid = uuid.uuid1()
         self.id_string = str(self.uuid)
+        self.id = str(self.uuid)
 
         # The last 10 statement inputs and outputs
         self.conversation = ResponseQueue(maxsize=10)

--- a/examples/learning_feedback_example.py
+++ b/examples/learning_feedback_example.py
@@ -22,6 +22,9 @@ bot = ChatBot(
     output_adapter='chatterbot.output.TerminalAdapter'
 )
 
+DEFAULT_SESSION_ID = bot.default_session.id
+
+
 def get_feedback():
     from chatterbot.utils import input_function
 
@@ -35,13 +38,14 @@ def get_feedback():
         print('Please type either "Yes" or "No"')
         return get_feedback()
 
+
 print('Type something to begin...')
 
 # The following loop will execute each time the user enters input
 while True:
     try:
         input_statement = bot.input.process_input_statement()
-        statement, response = bot.generate_response(input_statement)
+        statement, response = bot.generate_response(input_statement, DEFAULT_SESSION_ID)
 
         print('\n Is "{}" this a coherent response to "{}"? \n'.format(response, input_statement))
 

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -108,7 +108,10 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
 
     def test_generate_response(self):
         statement = Statement('Many insects adopt a tripedal gait for rapid yet stable walking.')
-        input_statement, response = self.chatbot.generate_response(statement)
+        input_statement, response = self.chatbot.generate_response(
+            statement,
+            self.chatbot.default_session.id
+        )
 
         self.assertEqual(input_statement, statement)
         self.assertEqual(response, statement)


### PR DESCRIPTION
This change is being made to cut down on the amount of code that depends on the default session existing. The goal is to _eventually_ remove this attribute and to create the session _when_ it is needed, instead of during initialization.