### PR TITLE
Best match adapter to support other languages

### DIFF
--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -52,15 +52,15 @@ def levenshtein_distance(statement, other_statement):
     return percent
 
 
-def synset_distance(statement, other_statement):
+def synset_distance(statement, other_statement, lang='eng', language='english'):
     """
     Calculate the similarity of two statements.
     This is based on the total maximum synset similarity between each word in each sentence.
 
+
     This algorithm uses the `wordnet`_ functionality of `NLTK`_ to determine the similarity
     of two statements based on the path similarity between each token of each statement.
     This is essentially an evaluation of the closeness of synonyms.
-
     :return: The percent of similarity between the closest synset distance.
     :rtype: float
 
@@ -76,8 +76,8 @@ def synset_distance(statement, other_statement):
     tokens2 = word_tokenize(other_statement.text.lower())
 
     # Remove all stop words from the list of word tokens
-    tokens1 = utils.remove_stopwords(tokens1, language='english')
-    tokens2 = utils.remove_stopwords(tokens2, language='english')
+    tokens1 = utils.remove_stopwords(tokens1, language=language)
+    tokens2 = utils.remove_stopwords(tokens2, language=language)
 
     # The maximum possible similarity is an exact match
     # Because path_similarity returns a value between 0 and 1,
@@ -93,8 +93,8 @@ def synset_distance(statement, other_statement):
     # Get the highest matching value for each possible combination of words
     for combination in itertools.product(*[tokens1, tokens2]):
 
-        synset1 = wordnet.synsets(combination[0])
-        synset2 = wordnet.synsets(combination[1])
+        synset1 = wordnet.synsets(combination[0], lang=lang)
+        synset2 = wordnet.synsets(combination[1], lang=lang)
 
         if synset1 and synset2:
 

--- a/chatterbot/logic/__init__.py
+++ b/chatterbot/logic/__init__.py
@@ -1,5 +1,6 @@
 from .logic_adapter import LogicAdapter
 from .best_match import BestMatch
+from .best_match_lang import BestMatchLang
 from .low_confidence import LowConfidenceAdapter
 from .mathematical_evaluation import MathematicalEvaluation
 from .multi_adapter import MultiLogicAdapter

--- a/chatterbot/logic/best_match_lang.py
+++ b/chatterbot/logic/best_match_lang.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals
+from .best_match import BestMatch
+
+
+class BestMatchLang(BestMatch):
+    """
+    A logic adater that returns a response based on known responses to
+    the closest matches to the input statement.  Comparision methods need two
+    parameters, lang and language.
+
+    """
+
+    def __init__(self, **kwargs):
+        super(BestMatchLang, self).__init__(**kwargs)
+        self.language = kwargs.get('language', 'english')
+        self.lang = kwargs.get('lang', 'eng')
+
+    def get(self, input_statement):
+        """
+        Takes a statement string and a list of statement strings.
+        Returns the closest matching statement from the list.
+        """
+        statement_list = self.chatbot.storage.get_response_statements()
+
+        if not statement_list:
+            if self.chatbot.storage.count():
+                # Use a randomly picked statement
+                self.logger.info(
+                    'No statements have known responses. ' +
+                    'Choosing a random response to return.'
+                )
+                random_response = self.chatbot.storage.get_random()
+                random_response.confidence = 0
+                return random_response
+            else:
+                raise self.EmptyDatasetException()
+
+        closest_match = input_statement
+        closest_match.confidence = 0
+
+        # Find the closest matching known statement
+        for statement in statement_list:
+            confidence = self.compare_statements(input_statement, statement, lang=self.lang, language=self.language)
+
+            if confidence > closest_match.confidence:
+                statement.confidence = confidence
+                closest_match = statement
+
+        return closest_match

--- a/examples/other_languages_example.py
+++ b/examples/other_languages_example.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from chatterbot import ChatBot
+
+
+# Create a new instance of a ChatBot.
+bot = ChatBot(
+    'Other Languages Example Bot',
+    storage_adapter='chatterbot.storage.JsonFileStorageAdapter',
+    logic_adapters=[
+        {
+            'import_path': 'chatterbot.logic.BestMatchLang',
+            'statement_comparison_function': 'chatterbot.comparisons.synset_distance',
+            'language': 'spanish',
+            'lang': 'spa'
+        }
+    ],
+    trainer='chatterbot.trainers.ListTrainer'
+)
+
+# Train the chat bot with a few responses
+bot.train([
+            "Hola",
+            "Hola",
+            "¿Cómo estás?",
+            "Estoy bien.",
+            "Me da gusto",
+            "Sí, lo es.",
+            "¿Puedo ayudarte en algo?",
+            "Sí, tengo una pregunta.",
+            "¿Cuál es tu pregunta?",
+            "¿Puedo pedir prestada una taza de azúcar?",
+            "Lo siento, pero no tengo ninguna.",
+            "Gracias de todas formas.",
+            "No hay problema."
+])
+
+# Get a response for some unexpected input
+response = bot.get_response('¿Cómo estás?')
+print(response)


### PR DESCRIPTION
Current synset comparer only works with english language.  I have made some changes to allow set the language using a best match logic adapter extension by two parameters lang and languages.

