### PR TITLE
fixed split databases usage for django

### DIFF
--- a/chatterbot/ext/django_chatterbot/settings.py
+++ b/chatterbot/ext/django_chatterbot/settings.py
@@ -10,7 +10,8 @@ CHATTERBOT_DEFAULTS = {
     'name': 'ChatterBot',
     'storage_adapter': 'chatterbot.storage.DjangoStorageAdapter',
     'input_adapter': 'chatterbot.input.VariableInputTypeAdapter',
-    'output_adapter': 'chatterbot.output.OutputAdapter'
+    'output_adapter': 'chatterbot.output.OutputAdapter',
+    'use_django_models': True
 }
 
 CHATTERBOT = CHATTERBOT_DEFAULTS.copy()

--- a/chatterbot/storage/storage_adapter.py
+++ b/chatterbot/storage/storage_adapter.py
@@ -24,13 +24,15 @@ class StorageAdapter(object):
         import os
 
         if 'DJANGO_SETTINGS_MODULE' in os.environ:
-            from chatterbot.ext.django_chatterbot.models import Statement
-            return Statement
-        else:
-            from chatterbot.conversation.statement import Statement
-            statement = Statement
-            statement.storage = self
-            return statement
+            django_project = __import__(os.environ['DJANGO_SETTINGS_MODULE'])
+            if django_project.settings.CHATTERBOT['use_django_models'] is True:
+                from chatterbot.ext.django_chatterbot.models import Statement
+                return Statement
+
+        from chatterbot.conversation.statement import Statement
+        statement = Statement
+        statement.storage = self
+        return statement
 
     def generate_base_query(self, chatterbot, session_id):
         """


### PR DESCRIPTION
Added boolean `use_django_models` option for ChatterBot settings to avoid problems with splitted databases usage.