### PR TITLE
Partially fix SQL adapter tests

### DIFF
--- a/chatterbot/storage/sqlalchemy_storage.py
+++ b/chatterbot/storage/sqlalchemy_storage.py
@@ -43,7 +43,7 @@ try:
 
         def get_reponse_serialized(context):
             params = context.current_parameters
-            del (params['text_search'])
+            del params['text_search']
             return json.dumps(params)
 
         id = Column(Integer)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ jsondatabase>=0.1.7,<1.0.0
 nltk>=3.2.0,<4.0.0
 pymongo>=3.3.0,<4.0.0
 python-twitter>=3.0.0,<4.0.0
-SQLAlchemy==1.1.7
+SQLAlchemy>=1.1,<1.2

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -1,26 +1,28 @@
 from unittest import TestCase
-
 from chatterbot.conversation import Statement, Response
 from chatterbot.storage.sqlalchemy_storage import SQLAlchemyDatabaseAdapter
 
 
 class SQLAlchemyAdapterTestCase(TestCase):
+
     def setUp(self):
         """
-        Instantiate the adapter.
+        Instantiate the adapter before any tests in the test case run.
         """
-        from random import randint
-
-        # Generate a random name for the database
-        database_name = str(randint(0, 9000))
-
         self.adapter = SQLAlchemyDatabaseAdapter(
-            database='sqlite_' + database_name,
+            database='testdb',
             drop_create=True
         )
 
+    def tearDown(self):
+        """
+        Remove the test database.
+        """
+        self.adapter.drop()
+
 
 class SQLAlchemyDatabaseAdapterTestCase(SQLAlchemyAdapterTestCase):
+
     def test_count_returns_zero(self):
         """
         The count method should return a value of 0
@@ -334,6 +336,7 @@ class SQLAlchemyStorageAdapterFilterTestCase(SQLAlchemyAdapterTestCase):
 
 
 class ReadOnlySQLAlchemyDatabaseAdapterTestCase(SQLAlchemyAdapterTestCase):
+
     def test_update_does_not_add_new_statement(self):
         self.adapter.read_only = True
 


### PR DESCRIPTION
This makes a change so that a new sqlite database isn't created for
every test case. There are currently issues with disconnecting from
sessions in the beta version of the SQL adapter and these are
preventing the test database file from being able to be deleted
after the tests have completed.