### PR TITLE
Only check if MongoDB is running once per test case

### DIFF
--- a/tests/base_case.py
+++ b/tests/base_case.py
@@ -42,7 +42,8 @@ class ChatBotTestCase(TestCase):
 
 class ChatBotMongoTestCase(ChatBotTestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         from pymongo.errors import ServerSelectionTimeoutError
         from pymongo import MongoClient
 
@@ -55,8 +56,6 @@ class ChatBotMongoTestCase(ChatBotTestCase):
 
         except ServerSelectionTimeoutError:
             raise SkipTest('Unable to connect to Mongo DB.')
-
-        super(ChatBotMongoTestCase, self).setUp()
 
     def get_kwargs(self):
         kwargs = super(ChatBotMongoTestCase, self).get_kwargs()


### PR DESCRIPTION
This should increase the speed of the unit test process because it changes the check for if MongoDB is running from every time a test case is run, to only once per test case.

(The improvement is less than a second)