### PR TITLE
Keep a reference to a single session in SQL alchemy adapter

### DIFF
--- a/chatterbot/storage/sqlalchemy_storage.py
+++ b/chatterbot/storage/sqlalchemy_storage.py
@@ -103,7 +103,7 @@ class SQLAlchemyDatabaseAdapter(StorageAdapter):
         if not self.read_only and create:
             self.create()
 
-        Session = sessionmaker(bind=self.engine)
+        Session = sessionmaker(bind=self.engine, expire_on_commit=True)
         self.session = Session()
 
     def count(self):

--- a/chatterbot/storage/sqlalchemy_storage.py
+++ b/chatterbot/storage/sqlalchemy_storage.py
@@ -11,57 +11,56 @@ Base = None
 try:
     from sqlalchemy.ext.declarative import declarative_base
     Base = declarative_base()
+
+    class StatementTable(Base):
+        from sqlalchemy import Column, Integer, String, PickleType
+        from sqlalchemy.orm import relationship
+
+        __tablename__ = 'StatementTable'
+
+        def get_statement(self):
+            stmt = Statement(self.text, **self.extra_data)
+            for resp in self.in_response_to:
+                stmt.add_response(resp.get_response())
+            return stmt
+
+        def get_statement_serialized(context):
+            params = context.current_parameters
+            del params['text_search']
+            return json.dumps(params)
+
+        id = Column(Integer)
+        text = Column(String, primary_key=True)
+        extra_data = Column(PickleType)
+        # relationship:
+        in_response_to = relationship("ResponseTable", back_populates="statement_table")
+        text_search = Column(String, primary_key=True, default=get_statement_serialized)
+
+    class ResponseTable(Base):
+        from sqlalchemy import Column, Integer, String, ForeignKey
+        from sqlalchemy.orm import relationship
+
+        __tablename__ = 'ResponseTable'
+
+        def get_reponse_serialized(context):
+            params = context.current_parameters
+            del params['text_search']
+            return json.dumps(params)
+
+        id = Column(Integer)
+        text = Column(String, primary_key=True)
+        occurrence = Column(Integer)
+        statement_text = Column(String, ForeignKey('StatementTable.text'))
+
+        statement_table = relationship("StatementTable", back_populates="in_response_to", cascade="all", uselist=False)
+        text_search = Column(String, primary_key=True, default=get_reponse_serialized)
+
+        def get_response(self):
+            occ = {"occurrence": self.occurrence}
+            return Response(text=self.text, **occ)
+
 except ImportError:
     pass
-
-
-class StatementTable(Base):
-    from sqlalchemy import Column, Integer, String, PickleType
-    from sqlalchemy.orm import relationship
-
-    __tablename__ = 'StatementTable'
-
-    def get_statement(self):
-        stmt = Statement(self.text, **self.extra_data)
-        for resp in self.in_response_to:
-            stmt.add_response(resp.get_response())
-        return stmt
-
-    def get_statement_serialized(context):
-        params = context.current_parameters
-        del params['text_search']
-        return json.dumps(params)
-
-    id = Column(Integer)
-    text = Column(String, primary_key=True)
-    extra_data = Column(PickleType)
-    # relationship:
-    in_response_to = relationship("ResponseTable", back_populates="statement_table")
-    text_search = Column(String, primary_key=True, default=get_statement_serialized)
-
-
-class ResponseTable(Base):
-    from sqlalchemy import Column, Integer, String, ForeignKey
-    from sqlalchemy.orm import relationship
-
-    __tablename__ = 'ResponseTable'
-
-    def get_reponse_serialized(context):
-        params = context.current_parameters
-        del params['text_search']
-        return json.dumps(params)
-
-    id = Column(Integer)
-    text = Column(String, primary_key=True)
-    occurrence = Column(Integer)
-    statement_text = Column(String, ForeignKey('StatementTable.text'))
-
-    statement_table = relationship("StatementTable", back_populates="in_response_to", cascade="all", uselist=False)
-    text_search = Column(String, primary_key=True, default=get_reponse_serialized)
-
-    def get_response(self):
-        occ = {"occurrence": self.occurrence}
-        return Response(text=self.text, **occ)
 
 
 def get_statement_table(statement):

--- a/chatterbot/storage/sqlalchemy_storage.py
+++ b/chatterbot/storage/sqlalchemy_storage.py
@@ -74,7 +74,6 @@ def get_response_table(response):
 
 class SQLAlchemyDatabaseAdapter(StorageAdapter):
     read_only = False
-    drop_create = False
 
     def __init__(self, **kwargs):
         super(SQLAlchemyDatabaseAdapter, self).__init__(**kwargs)
@@ -99,12 +98,9 @@ class SQLAlchemyDatabaseAdapter(StorageAdapter):
             "read_only", False
         )
 
-        self.drop_create = self.kwargs.get(
-            "drop_create", False
-        )
+        create = self.kwargs.get("create", False)
 
-        if not self.read_only and self.drop_create:
-            Base.metadata.drop_all(self.engine)
+        if not self.read_only and create:
             Base.metadata.create_all(self.engine)
 
     def count(self):

--- a/chatterbot/storage/sqlalchemy_storage.py
+++ b/chatterbot/storage/sqlalchemy_storage.py
@@ -5,14 +5,14 @@ from chatterbot.storage import StorageAdapter
 from chatterbot.conversation import Response
 from chatterbot.conversation import Statement
 
-_base = None
+Base = None
 
 try:
     from sqlalchemy.ext.declarative import declarative_base
 
-    _base = declarative_base()
+    Base = declarative_base()
 
-    class StatementTable(_base):
+    class StatementTable(Base):
         from sqlalchemy import Column, Integer, String, PickleType
         from sqlalchemy.orm import relationship
 
@@ -26,7 +26,7 @@ try:
 
         def get_statement_serialized(context):
             params = context.current_parameters
-            del (params['text_search'])
+            del params['text_search']
             return json.dumps(params)
 
         id = Column(Integer)
@@ -36,7 +36,7 @@ try:
         in_response_to = relationship("ResponseTable", back_populates="statement_table")
         text_search = Column(String, primary_key=True, default=get_statement_serialized)
 
-    class ResponseTable(_base):
+    class ResponseTable(Base):
         from sqlalchemy import Column, Integer, String, ForeignKey
         from sqlalchemy.orm import relationship
         __tablename__ = 'ResponseTable'
@@ -103,8 +103,8 @@ class SQLAlchemyDatabaseAdapter(StorageAdapter):
         )
 
         if not self.read_only and self.drop_create:
-            _base.metadata.drop_all(self.engine)
-            _base.metadata.create_all(self.engine)
+            Base.metadata.drop_all(self.engine)
+            Base.metadata.create_all(self.engine)
 
     def count(self):
         """
@@ -258,7 +258,7 @@ class SQLAlchemyDatabaseAdapter(StorageAdapter):
         """
         Drop the database attached to a given adapter.
         """
-        _base.metadata.drop_all(self.engine)
+        Base.metadata.drop_all(self.engine)
 
     def _session_finish(self, session, statement_text=None):
         from sqlalchemy.exc import DatabaseError

--- a/chatterbot/storage/sqlalchemy_storage.py
+++ b/chatterbot/storage/sqlalchemy_storage.py
@@ -244,6 +244,7 @@ class SQLAlchemyDatabaseAdapter(StorageAdapter):
         Drop the database attached to a given adapter.
         """
         Base.metadata.drop_all(self.engine)
+        self.session.close()
 
     def _session_finish(self, session, statement_text=None):
         from sqlalchemy.exc import DatabaseError

--- a/chatterbot/storage/sqlalchemy_storage.py
+++ b/chatterbot/storage/sqlalchemy_storage.py
@@ -5,61 +5,62 @@ from chatterbot.storage import StorageAdapter
 from chatterbot.conversation import Response
 from chatterbot.conversation import Statement
 
+
 Base = None
 
 try:
     from sqlalchemy.ext.declarative import declarative_base
-
     Base = declarative_base()
-
-    class StatementTable(Base):
-        from sqlalchemy import Column, Integer, String, PickleType
-        from sqlalchemy.orm import relationship
-
-        __tablename__ = 'StatementTable'
-
-        def get_statement(self):
-            stmt = Statement(self.text, **self.extra_data)
-            for resp in self.in_response_to:
-                stmt.add_response(resp.get_response())
-            return stmt
-
-        def get_statement_serialized(context):
-            params = context.current_parameters
-            del params['text_search']
-            return json.dumps(params)
-
-        id = Column(Integer)
-        text = Column(String, primary_key=True)
-        extra_data = Column(PickleType)
-        # relationship:
-        in_response_to = relationship("ResponseTable", back_populates="statement_table")
-        text_search = Column(String, primary_key=True, default=get_statement_serialized)
-
-    class ResponseTable(Base):
-        from sqlalchemy import Column, Integer, String, ForeignKey
-        from sqlalchemy.orm import relationship
-        __tablename__ = 'ResponseTable'
-
-        def get_reponse_serialized(context):
-            params = context.current_parameters
-            del params['text_search']
-            return json.dumps(params)
-
-        id = Column(Integer)
-        text = Column(String, primary_key=True)
-        occurrence = Column(Integer)
-        statement_text = Column(String, ForeignKey('StatementTable.text'))
-
-        statement_table = relationship("StatementTable", back_populates="in_response_to", cascade="all", uselist=False)
-        text_search = Column(String, primary_key=True, default=get_reponse_serialized)
-
-        def get_response(self):
-            occ = {"occurrence": self.occurrence}
-            return Response(text=self.text, **occ)
-
 except ImportError:
     pass
+
+
+class StatementTable(Base):
+    from sqlalchemy import Column, Integer, String, PickleType
+    from sqlalchemy.orm import relationship
+
+    __tablename__ = 'StatementTable'
+
+    def get_statement(self):
+        stmt = Statement(self.text, **self.extra_data)
+        for resp in self.in_response_to:
+            stmt.add_response(resp.get_response())
+        return stmt
+
+    def get_statement_serialized(context):
+        params = context.current_parameters
+        del params['text_search']
+        return json.dumps(params)
+
+    id = Column(Integer)
+    text = Column(String, primary_key=True)
+    extra_data = Column(PickleType)
+    # relationship:
+    in_response_to = relationship("ResponseTable", back_populates="statement_table")
+    text_search = Column(String, primary_key=True, default=get_statement_serialized)
+
+
+class ResponseTable(Base):
+    from sqlalchemy import Column, Integer, String, ForeignKey
+    from sqlalchemy.orm import relationship
+    __tablename__ = 'ResponseTable'
+
+    def get_reponse_serialized(context):
+        params = context.current_parameters
+        del params['text_search']
+        return json.dumps(params)
+
+    id = Column(Integer)
+    text = Column(String, primary_key=True)
+    occurrence = Column(Integer)
+    statement_text = Column(String, ForeignKey('StatementTable.text'))
+
+    statement_table = relationship("StatementTable", back_populates="in_response_to", cascade="all", uselist=False)
+    text_search = Column(String, primary_key=True, default=get_reponse_serialized)
+
+    def get_response(self):
+        occ = {"occurrence": self.occurrence}
+        return Response(text=self.text, **occ)
 
 
 def get_statement_table(statement):

--- a/chatterbot/storage/sqlalchemy_storage.py
+++ b/chatterbot/storage/sqlalchemy_storage.py
@@ -102,7 +102,7 @@ class SQLAlchemyDatabaseAdapter(StorageAdapter):
         create = self.kwargs.get("create", False)
 
         if not self.read_only and create:
-            Base.metadata.create_all(self.engine)
+            self.create()
 
         Session = sessionmaker(bind=self.engine)
         self.session = Session()
@@ -244,7 +244,9 @@ class SQLAlchemyDatabaseAdapter(StorageAdapter):
         Drop the database attached to a given adapter.
         """
         Base.metadata.drop_all(self.engine)
-        self.session.close()
+
+    def create(self):
+        Base.metadata.create_all(self.engine)
 
     def _session_finish(self, session, statement_text=None):
         from sqlalchemy.exc import DatabaseError

--- a/chatterbot/storage/storage_adapter.py
+++ b/chatterbot/storage/storage_adapter.py
@@ -147,4 +147,3 @@ class StorageAdapter(object):
         Typically this indicates that the method should be implement in a subclass.
         """
         pass
-

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -17,7 +17,6 @@ class SQLAlchemyAdapterTestCase(TestCase):
     @classmethod
     def tearDownClass(cls):
         import os
-        cls.adapter.session.close()
         os.remove('testdb.db')
 
     def setUp(self):

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -7,7 +7,7 @@ class SQLAlchemyAdapterTestCase(TestCase):
 
     def setUp(self):
         """
-        Instantiate the adapter before any tests in the test case run.
+        Instantiate the adapter.
         """
         self.adapter = SQLAlchemyDatabaseAdapter(
             database='testdb',
@@ -18,7 +18,9 @@ class SQLAlchemyAdapterTestCase(TestCase):
         """
         Remove the test database.
         """
+        import os
         self.adapter.drop()
+        os.remove('testdb.db')
 
 
 class SQLAlchemyDatabaseAdapterTestCase(SQLAlchemyAdapterTestCase):

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -5,22 +5,29 @@ from chatterbot.storage.sqlalchemy_storage import SQLAlchemyDatabaseAdapter
 
 class SQLAlchemyAdapterTestCase(TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """
-        Instantiate the adapter.
+        Instantiate the adapter before any tests in the test case run.
         """
-        self.adapter = SQLAlchemyDatabaseAdapter(
-            database='testdb',
-            create=True
+        cls.adapter = SQLAlchemyDatabaseAdapter(
+            database='testdb'
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        import os
+        cls.adapter.session.close()
+        os.remove('testdb.db')
+
+    def setUp(self):
+        self.adapter.create()
 
     def tearDown(self):
         """
-        Remove the test database.
+        Remove the content of the test database after every test.
         """
-        import os
         self.adapter.drop()
-        os.remove('testdb.db')
 
 
 class SQLAlchemyDatabaseAdapterTestCase(SQLAlchemyAdapterTestCase):
@@ -338,6 +345,13 @@ class SQLAlchemyStorageAdapterFilterTestCase(SQLAlchemyAdapterTestCase):
 
 
 class ReadOnlySQLAlchemyDatabaseAdapterTestCase(SQLAlchemyAdapterTestCase):
+
+    def setUp(self):
+        """
+        Make the adapter writable before every test.
+        """
+        super(ReadOnlySQLAlchemyDatabaseAdapterTestCase, self).setUp()
+        self.adapter.read_only = False
 
     def test_update_does_not_add_new_statement(self):
         self.adapter.read_only = True

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -20,11 +20,14 @@ class SQLAlchemyAdapterTestCase(TestCase):
         os.remove('testdb.db')
 
     def setUp(self):
+        """
+        Create the tables in the database before each test is run.
+        """
         self.adapter.create()
 
     def tearDown(self):
         """
-        Remove the content of the test database after every test.
+        Drop the tables in the database after each test is run.
         """
         self.adapter.drop()
 

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -11,7 +11,7 @@ class SQLAlchemyAdapterTestCase(TestCase):
         """
         self.adapter = SQLAlchemyDatabaseAdapter(
             database='testdb',
-            drop_create=True
+            create=True
         )
 
     def tearDown(self):


### PR DESCRIPTION
This change makes it possible to close the session and delete the test database file when unit tests have finished running.

A few other minor changes have been made as well (see commit messages).

***

For testing, I've made changes so that a single database file is created before the set of test cases are run and then it is deleted after. The database is cleared for each test case. These changes should make it more efficient to run the tests. Closes #707