### PR TITLE
Make callable classes for comparing statements

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -91,9 +91,8 @@ class ChatBot(object):
 
         # Download required NLTK corpora if they have not already been downloaded
         nltk_download_corpus('corpora/stopwords')
-        nltk_download_corpus('corpora/wordnet')
-        nltk_download_corpus('tokenizers/punkt')
-        nltk_download_corpus('sentiment/vader_lexicon')
+
+        self.logic.initialize()
 
     def get_response(self, input_item, session_id=None):
         """

--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -6,210 +6,289 @@ designed to compare one statement to another.
 """
 
 
-def levenshtein_distance(statement, other_statement):
-    """
-    Compare two statements based on the Levenshtein distance
-    of each statement's text.
+class Comparator:
 
-    For example, there is a 65% similarity between the statements
-    "where is the post office?" and "looking for the post office"
-    based on the Levenshtein distance algorithm.
+    def __call__(self, statement_a, statement_b):
+        return self.compare(statement_a, statement_b)
 
-    :return: The percent of similarity between the text of the statements.
-    :rtype: float
-    """
-    import sys
-
-    # Use python-Levenshtein if available
-    try:
-        from Levenshtein.StringMatcher import StringMatcher as SequenceMatcher
-    except ImportError:
-        from difflib import SequenceMatcher
-
-    PYTHON = sys.version_info[0]
-
-    # Return 0 if either statement has a falsy text value
-    if not statement.text or not other_statement.text:
+    def compare(self, statement_a, statement_b):
         return 0
 
-    # Get the lowercase version of both strings
-    if PYTHON < 3:
-        statement_text = unicode(statement.text.lower()) # NOQA
-        other_statement_text = unicode(other_statement.text.lower()) # NOQA
-    else:
-        statement_text = str(statement.text.lower())
-        other_statement_text = str(other_statement.text.lower())
-
-    similarity = SequenceMatcher(
-        None,
-        statement_text,
-        other_statement_text
-    )
-
-    # Calculate a decimal percent of the similarity
-    percent = round(similarity.ratio(), 2)
-
-    return percent
+    def get_initialization_functions(self):
+        return {}
 
 
-def synset_distance(statement, other_statement):
-    """
-    Calculate the similarity of two statements.
-    This is based on the total maximum synset similarity between each word in each sentence.
+class LevenshteinDistance(Comparator):
 
-    This algorithm uses the `wordnet`_ functionality of `NLTK`_ to determine the similarity
-    of two statements based on the path similarity between each token of each statement.
-    This is essentially an evaluation of the closeness of synonyms.
+    def compare(self, statement, other_statement):
+        """
+        Compare two statements based on the Levenshtein distance
+        of each statement's text.
 
-    :return: The percent of similarity between the closest synset distance.
-    :rtype: float
+        For example, there is a 65% similarity between the statements
+        "where is the post office?" and "looking for the post office"
+        based on the Levenshtein distance algorithm.
 
-    .. _wordnet: http://www.nltk.org/howto/wordnet.html
-    .. _NLTK: http://www.nltk.org/
-    """
-    from nltk.corpus import wordnet
-    from nltk import word_tokenize
-    from chatterbot import utils
-    import itertools
+        :return: The percent of similarity between the text of the statements.
+        :rtype: float
+        """
+        import sys
 
-    tokens1 = word_tokenize(statement.text.lower())
-    tokens2 = word_tokenize(other_statement.text.lower())
+        # Use python-Levenshtein if available
+        try:
+            from Levenshtein.StringMatcher import StringMatcher as SequenceMatcher
+        except ImportError:
+            from difflib import SequenceMatcher
 
-    # Remove all stop words from the list of word tokens
-    tokens1 = utils.remove_stopwords(tokens1, language='english')
-    tokens2 = utils.remove_stopwords(tokens2, language='english')
+        PYTHON = sys.version_info[0]
 
-    # The maximum possible similarity is an exact match
-    # Because path_similarity returns a value between 0 and 1,
-    # max_possible_similarity is the number of words in the longer
-    # of the two input statements.
-    max_possible_similarity = max(
-        len(statement.text.split()),
-        len(other_statement.text.split())
-    )
+        # Return 0 if either statement has a falsy text value
+        if not statement.text or not other_statement.text:
+            return 0
 
-    max_similarity = 0.0
-
-    # Get the highest matching value for each possible combination of words
-    for combination in itertools.product(*[tokens1, tokens2]):
-
-        synset1 = wordnet.synsets(combination[0])
-        synset2 = wordnet.synsets(combination[1])
-
-        if synset1 and synset2:
-
-            # Get the highest similarity for each combination of synsets
-            for synset in itertools.product(*[synset1, synset2]):
-                similarity = synset[0].path_similarity(synset[1])
-
-                if similarity and (similarity > max_similarity):
-                    max_similarity = similarity
-
-    if max_possible_similarity == 0:
-        return 0
-
-    return max_similarity / max_possible_similarity
-
-
-def sentiment_comparison(statement, other_statement):
-    """
-    Calculate the similarity of two statements based on the closeness of
-    the sentiment value calculated for each statement.
-
-    :return: The percent of similarity between the sentiment value.
-    :rtype: float
-    """
-    from nltk.sentiment.vader import SentimentIntensityAnalyzer
-
-    sentiment_analyzer = SentimentIntensityAnalyzer()
-    statement_polarity = sentiment_analyzer.polarity_scores(statement.text.lower())
-    statement2_polarity = sentiment_analyzer.polarity_scores(other_statement.text.lower())
-
-    statement_greatest_polarity = 'neu'
-    statement_greatest_score = -1
-    for polarity in sorted(statement_polarity):
-        if statement_polarity[polarity] > statement_greatest_score:
-            statement_greatest_polarity = polarity
-            statement_greatest_score = statement_polarity[polarity]
-
-    statement2_greatest_polarity = 'neu'
-    statement2_greatest_score = -1
-    for polarity in sorted(statement2_polarity):
-        if statement2_polarity[polarity] > statement2_greatest_score:
-            statement2_greatest_polarity = polarity
-            statement2_greatest_score = statement2_polarity[polarity]
-
-    # Check if the polarity if of a different type
-    if statement_greatest_polarity != statement2_greatest_polarity:
-        return 0
-
-    values = [statement_greatest_score, statement2_greatest_score]
-    difference = max(values) - min(values)
-
-    return 1.0 - difference
-
-
-def jaccard_similarity(statement, other_statement, threshold=0.5):
-    """
-    Calculates the similarity of two statements based on the Jaccard index.
-
-    The Jaccard index is composed of a numerator and denominator.
-    In the numerator, we count the number of items that are shared between the sets.
-    In the denominator, we count the total number of items across both sets.
-    Let's say we define sentences to be equivalent if 50% or more of their tokens are equivalent.
-    Here are two sample sentences:
-
-        The young cat is hungry.
-        The cat is very hungry.
-
-    When we parse these sentences to remove stopwords, we end up with the following two sets:
-
-        {young, cat, hungry}
-        {cat, very, hungry}
-
-    In our example above, our intersection is {cat, hungry}, which has count of two.
-    The union of the sets is {young, cat, very, hungry}, which has a count of four.
-    Therefore, our `Jaccard similarity index`_ is two divided by four, or 50%.
-    Given our threshold above, we would consider this to be a match.
-
-    .. _`Jaccard similarity index`: https://en.wikipedia.org/wiki/Jaccard_index
-    """
-    from nltk.corpus import wordnet
-    import nltk
-    import string
-
-    a = statement.text.lower()
-    b = other_statement.text.lower()
-
-    # Get default English stopwords and extend with punctuation
-    stopwords = nltk.corpus.stopwords.words('english')
-    stopwords.extend(string.punctuation)
-    stopwords.append('')
-    lemmatizer = nltk.stem.wordnet.WordNetLemmatizer()
-
-    def get_wordnet_pos(pos_tag):
-        if pos_tag[1].startswith('J'):
-            return (pos_tag[0], wordnet.ADJ)
-        elif pos_tag[1].startswith('V'):
-            return (pos_tag[0], wordnet.VERB)
-        elif pos_tag[1].startswith('N'):
-            return (pos_tag[0], wordnet.NOUN)
-        elif pos_tag[1].startswith('R'):
-            return (pos_tag[0], wordnet.ADV)
+        # Get the lowercase version of both strings
+        if PYTHON < 3:
+            statement_text = unicode(statement.text.lower()) # NOQA
+            other_statement_text = unicode(other_statement.text.lower()) # NOQA
         else:
-            return (pos_tag[0], wordnet.NOUN)
+            statement_text = str(statement.text.lower())
+            other_statement_text = str(other_statement.text.lower())
 
-    ratio = 0
-    pos_a = map(get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(a)))
-    pos_b = map(get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(b)))
-    lemma_a = [lemmatizer.lemmatize(token.strip(string.punctuation), pos) for token, pos in pos_a
-               if pos == wordnet.NOUN and token.strip(string.punctuation) not in stopwords]
-    lemma_b = [lemmatizer.lemmatize(token.strip(string.punctuation), pos) for token, pos in pos_b
-               if pos == wordnet.NOUN and token.strip(string.punctuation) not in stopwords]
+        similarity = SequenceMatcher(
+            None,
+            statement_text,
+            other_statement_text
+        )
 
-    # Calculate Jaccard similarity
-    try:
-        ratio = len(set(lemma_a).intersection(lemma_b)) / float(len(set(lemma_a).union(lemma_b)))
-    except Exception as e:
-        print('Error', e)
-    return ratio >= threshold
+        # Calculate a decimal percent of the similarity
+        percent = round(similarity.ratio(), 2)
+
+        return percent
+
+
+class SynsetDistance(Comparator):
+
+    def download_nltk_wordnet(self):
+        """
+        Download required NLTK corpora if they have not already been downloaded.
+        """
+        from .utils import nltk_download_corpus
+
+        nltk_download_corpus('corpora/wordnet')
+
+    def download_nltk_punkt(self):
+        """
+        Download required NLTK corpora if they have not already been downloaded.
+        """
+        from .utils import nltk_download_corpus
+
+        nltk_download_corpus('tokenizers/punkt')
+
+    def get_initialization_functions(self):
+        return {
+            'download_nltk_wordnet': self.download_nltk_wordnet,
+            'download_nltk_punkt': self.download_nltk_punkt
+        }
+
+    def compare(self, statement, other_statement):
+        """
+        Calculate the similarity of two statements.
+        This is based on the total maximum synset similarity between each word in each sentence.
+
+        This algorithm uses the `wordnet`_ functionality of `NLTK`_ to determine the similarity
+        of two statements based on the path similarity between each token of each statement.
+        This is essentially an evaluation of the closeness of synonyms.
+
+        :return: The percent of similarity between the closest synset distance.
+        :rtype: float
+
+        .. _wordnet: http://www.nltk.org/howto/wordnet.html
+        .. _NLTK: http://www.nltk.org/
+        """
+        from nltk.corpus import wordnet
+        from nltk import word_tokenize
+        from chatterbot import utils
+        import itertools
+
+        tokens1 = word_tokenize(statement.text.lower())
+        tokens2 = word_tokenize(other_statement.text.lower())
+
+        # Remove all stop words from the list of word tokens
+        tokens1 = utils.remove_stopwords(tokens1, language='english')
+        tokens2 = utils.remove_stopwords(tokens2, language='english')
+
+        # The maximum possible similarity is an exact match
+        # Because path_similarity returns a value between 0 and 1,
+        # max_possible_similarity is the number of words in the longer
+        # of the two input statements.
+        max_possible_similarity = max(
+            len(statement.text.split()),
+            len(other_statement.text.split())
+        )
+
+        max_similarity = 0.0
+
+        # Get the highest matching value for each possible combination of words
+        for combination in itertools.product(*[tokens1, tokens2]):
+
+            synset1 = wordnet.synsets(combination[0])
+            synset2 = wordnet.synsets(combination[1])
+
+            if synset1 and synset2:
+
+                # Get the highest similarity for each combination of synsets
+                for synset in itertools.product(*[synset1, synset2]):
+                    similarity = synset[0].path_similarity(synset[1])
+
+                    if similarity and (similarity > max_similarity):
+                        max_similarity = similarity
+
+        if max_possible_similarity == 0:
+            return 0
+
+        return max_similarity / max_possible_similarity
+
+
+class SentimentComparison(Comparator):
+
+    def download_nltk_vader_lexicon(self):
+        """
+        Download required NLTK corpora if they have not already been downloaded.
+        """
+        from .utils import nltk_download_corpus
+
+        nltk_download_corpus('sentiment/vader_lexicon')
+
+    def get_initialization_functions(self):
+        return {
+            'download_nltk_vader_lexicon': self.download_nltk_vader_lexicon
+        }
+
+    def compare(self, statement, other_statement):
+        """
+        Calculate the similarity of two statements based on the closeness of
+        the sentiment value calculated for each statement.
+
+        :return: The percent of similarity between the sentiment value.
+        :rtype: float
+        """
+        from nltk.sentiment.vader import SentimentIntensityAnalyzer
+
+        sentiment_analyzer = SentimentIntensityAnalyzer()
+        statement_polarity = sentiment_analyzer.polarity_scores(statement.text.lower())
+        statement2_polarity = sentiment_analyzer.polarity_scores(other_statement.text.lower())
+
+        statement_greatest_polarity = 'neu'
+        statement_greatest_score = -1
+        for polarity in sorted(statement_polarity):
+            if statement_polarity[polarity] > statement_greatest_score:
+                statement_greatest_polarity = polarity
+                statement_greatest_score = statement_polarity[polarity]
+
+        statement2_greatest_polarity = 'neu'
+        statement2_greatest_score = -1
+        for polarity in sorted(statement2_polarity):
+            if statement2_polarity[polarity] > statement2_greatest_score:
+                statement2_greatest_polarity = polarity
+                statement2_greatest_score = statement2_polarity[polarity]
+
+        # Check if the polarity if of a different type
+        if statement_greatest_polarity != statement2_greatest_polarity:
+            return 0
+
+        values = [statement_greatest_score, statement2_greatest_score]
+        difference = max(values) - min(values)
+
+        return 1.0 - difference
+
+
+class JaccardSimilarity(Comparator):
+
+    SIMILARITY_THRESHOLD = 0.5
+
+    def download_nltk_wordnet(self):
+        """
+        Download required NLTK corpora if they have not already been downloaded.
+        """
+        from .utils import nltk_download_corpus
+
+        nltk_download_corpus('corpora/wordnet')
+
+    def get_initialization_functions(self):
+        return {
+            'download_nltk_wordnet': self.download_nltk_wordnet
+        }
+
+    def compare(self, statement, other_statement):
+        """
+        Calculates the similarity of two statements based on the Jaccard index.
+
+        The Jaccard index is composed of a numerator and denominator.
+        In the numerator, we count the number of items that are shared between the sets.
+        In the denominator, we count the total number of items across both sets.
+        Let's say we define sentences to be equivalent if 50% or more of their tokens are equivalent.
+        Here are two sample sentences:
+
+            The young cat is hungry.
+            The cat is very hungry.
+
+        When we parse these sentences to remove stopwords, we end up with the following two sets:
+
+            {young, cat, hungry}
+            {cat, very, hungry}
+
+        In our example above, our intersection is {cat, hungry}, which has count of two.
+        The union of the sets is {young, cat, very, hungry}, which has a count of four.
+        Therefore, our `Jaccard similarity index`_ is two divided by four, or 50%.
+        Given our similarity threshold above, we would consider this to be a match.
+
+        .. _`Jaccard similarity index`: https://en.wikipedia.org/wiki/Jaccard_index
+        """
+        from nltk.corpus import wordnet
+        import nltk
+        import string
+
+        a = statement.text.lower()
+        b = other_statement.text.lower()
+
+        # Get default English stopwords and extend with punctuation
+        stopwords = nltk.corpus.stopwords.words('english')
+        stopwords.extend(string.punctuation)
+        stopwords.append('')
+        lemmatizer = nltk.stem.wordnet.WordNetLemmatizer()
+
+        def get_wordnet_pos(pos_tag):
+            if pos_tag[1].startswith('J'):
+                return (pos_tag[0], wordnet.ADJ)
+            elif pos_tag[1].startswith('V'):
+                return (pos_tag[0], wordnet.VERB)
+            elif pos_tag[1].startswith('N'):
+                return (pos_tag[0], wordnet.NOUN)
+            elif pos_tag[1].startswith('R'):
+                return (pos_tag[0], wordnet.ADV)
+            else:
+                return (pos_tag[0], wordnet.NOUN)
+
+        ratio = 0
+        pos_a = map(get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(a)))
+        pos_b = map(get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(b)))
+        lemma_a = [lemmatizer.lemmatize(token.strip(string.punctuation), pos) for token, pos in pos_a
+                   if pos == wordnet.NOUN and token.strip(string.punctuation) not in stopwords]
+        lemma_b = [lemmatizer.lemmatize(token.strip(string.punctuation), pos) for token, pos in pos_b
+                   if pos == wordnet.NOUN and token.strip(string.punctuation) not in stopwords]
+
+        # Calculate Jaccard similarity
+        try:
+            ratio = len(set(lemma_a).intersection(lemma_b)) / float(len(set(lemma_a).union(lemma_b)))
+        except Exception as e:
+            print('Error', e)
+        return ratio >= self.SIMILARITY_THRESHOLD
+
+
+# ---------------------------------------- #
+
+
+levenshtein_distance = LevenshteinDistance()
+synset_distance = SynsetDistance()
+sentiment_comparison = SentimentComparison()
+jaccard_similarity = JaccardSimilarity()

--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -15,7 +15,21 @@ class Comparator:
         return 0
 
     def get_initialization_functions(self):
-        return {}
+        """
+        Return all initialization methods for the comparison algorithm.
+        Initialization methods must start with 'initialize_' and
+        take no parameters.
+        """
+        initialization_methods = [
+            (
+                method,
+                getattr(self, method),
+            ) for method in dir(self) if method.startswith('initialize_')
+        ]
+
+        return {
+            key: value for (key, value) in initialization_methods
+        }
 
 
 class LevenshteinDistance(Comparator):
@@ -68,7 +82,7 @@ class LevenshteinDistance(Comparator):
 
 class SynsetDistance(Comparator):
 
-    def download_nltk_wordnet(self):
+    def initialize_nltk_wordnet(self):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
@@ -76,19 +90,13 @@ class SynsetDistance(Comparator):
 
         nltk_download_corpus('corpora/wordnet')
 
-    def download_nltk_punkt(self):
+    def initialize_nltk_punkt(self):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
         from .utils import nltk_download_corpus
 
         nltk_download_corpus('tokenizers/punkt')
-
-    def get_initialization_functions(self):
-        return {
-            'download_nltk_wordnet': self.download_nltk_wordnet,
-            'download_nltk_punkt': self.download_nltk_punkt
-        }
 
     def compare(self, statement, other_statement):
         """
@@ -151,18 +159,13 @@ class SynsetDistance(Comparator):
 
 class SentimentComparison(Comparator):
 
-    def download_nltk_vader_lexicon(self):
+    def initialize_nltk_vader_lexicon(self):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
         from .utils import nltk_download_corpus
 
         nltk_download_corpus('sentiment/vader_lexicon')
-
-    def get_initialization_functions(self):
-        return {
-            'download_nltk_vader_lexicon': self.download_nltk_vader_lexicon
-        }
 
     def compare(self, statement, other_statement):
         """
@@ -206,18 +209,13 @@ class JaccardSimilarity(Comparator):
 
     SIMILARITY_THRESHOLD = 0.5
 
-    def download_nltk_wordnet(self):
+    def initialize_nltk_wordnet(self):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
         from .utils import nltk_download_corpus
 
         nltk_download_corpus('corpora/wordnet')
-
-    def get_initialization_functions(self):
-        return {
-            'download_nltk_wordnet': self.download_nltk_wordnet
-        }
 
     def compare(self, statement, other_statement):
         """

--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -33,15 +33,18 @@ class Comparator:
 
 
 class LevenshteinDistance(Comparator):
+    """
+    Compare two statements based on the Levenshtein distance
+    of each statement's text.
+
+    For example, there is a 65% similarity between the statements
+    "where is the post office?" and "looking for the post office"
+    based on the Levenshtein distance algorithm.
+    """
 
     def compare(self, statement, other_statement):
         """
-        Compare two statements based on the Levenshtein distance
-        of each statement's text.
-
-        For example, there is a 65% similarity between the statements
-        "where is the post office?" and "looking for the post office"
-        based on the Levenshtein distance algorithm.
+        Compare the two input statements.
 
         :return: The percent of similarity between the text of the statements.
         :rtype: float
@@ -81,6 +84,14 @@ class LevenshteinDistance(Comparator):
 
 
 class SynsetDistance(Comparator):
+    """
+    Calculate the similarity of two statements.
+    This is based on the total maximum synset similarity between each word in each sentence.
+
+    This algorithm uses the `wordnet`_ functionality of `NLTK`_ to determine the similarity
+    of two statements based on the path similarity between each token of each statement.
+    This is essentially an evaluation of the closeness of synonyms.
+    """
 
     def initialize_nltk_wordnet(self):
         """
@@ -100,12 +111,7 @@ class SynsetDistance(Comparator):
 
     def compare(self, statement, other_statement):
         """
-        Calculate the similarity of two statements.
-        This is based on the total maximum synset similarity between each word in each sentence.
-
-        This algorithm uses the `wordnet`_ functionality of `NLTK`_ to determine the similarity
-        of two statements based on the path similarity between each token of each statement.
-        This is essentially an evaluation of the closeness of synonyms.
+        Compare the two input statements.
 
         :return: The percent of similarity between the closest synset distance.
         :rtype: float
@@ -158,10 +164,15 @@ class SynsetDistance(Comparator):
 
 
 class SentimentComparison(Comparator):
+    """
+    Calculate the similarity of two statements based on the closeness of
+    the sentiment value calculated for each statement.
+    """
 
     def initialize_nltk_vader_lexicon(self):
         """
-        Download required NLTK corpora if they have not already been downloaded.
+        Download the NLTK vader lexicon for sentiment analysis
+        that is required for this algorithm to run.
         """
         from .utils import nltk_download_corpus
 
@@ -169,8 +180,8 @@ class SentimentComparison(Comparator):
 
     def compare(self, statement, other_statement):
         """
-        Calculate the similarity of two statements based on the closeness of
-        the sentiment value calculated for each statement.
+        Return the similarity of two statements based on
+        their calculated sentiment values.
 
         :return: The percent of similarity between the sentiment value.
         :rtype: float
@@ -206,12 +217,37 @@ class SentimentComparison(Comparator):
 
 
 class JaccardSimilarity(Comparator):
+    """
+    Calculates the similarity of two statements based on the Jaccard index.
+
+    The Jaccard index is composed of a numerator and denominator.
+    In the numerator, we count the number of items that are shared between the sets.
+    In the denominator, we count the total number of items across both sets.
+    Let's say we define sentences to be equivalent if 50% or more of their tokens are equivalent.
+    Here are two sample sentences:
+
+        The young cat is hungry.
+        The cat is very hungry.
+
+    When we parse these sentences to remove stopwords, we end up with the following two sets:
+
+        {young, cat, hungry}
+        {cat, very, hungry}
+
+    In our example above, our intersection is {cat, hungry}, which has count of two.
+    The union of the sets is {young, cat, very, hungry}, which has a count of four.
+    Therefore, our `Jaccard similarity index`_ is two divided by four, or 50%.
+    Given our similarity threshold above, we would consider this to be a match.
+
+    .. _`Jaccard similarity index`: https://en.wikipedia.org/wiki/Jaccard_index
+    """
 
     SIMILARITY_THRESHOLD = 0.5
 
     def initialize_nltk_wordnet(self):
         """
-        Download required NLTK corpora if they have not already been downloaded.
+        Download the NLTK wordnet corpora that is required for this algorithm
+        to run only if the corpora has not already been downloaded.
         """
         from .utils import nltk_download_corpus
 
@@ -219,28 +255,8 @@ class JaccardSimilarity(Comparator):
 
     def compare(self, statement, other_statement):
         """
-        Calculates the similarity of two statements based on the Jaccard index.
-
-        The Jaccard index is composed of a numerator and denominator.
-        In the numerator, we count the number of items that are shared between the sets.
-        In the denominator, we count the total number of items across both sets.
-        Let's say we define sentences to be equivalent if 50% or more of their tokens are equivalent.
-        Here are two sample sentences:
-
-            The young cat is hungry.
-            The cat is very hungry.
-
-        When we parse these sentences to remove stopwords, we end up with the following two sets:
-
-            {young, cat, hungry}
-            {cat, very, hungry}
-
-        In our example above, our intersection is {cat, hungry}, which has count of two.
-        The union of the sets is {young, cat, very, hungry}, which has a count of four.
-        Therefore, our `Jaccard similarity index`_ is two divided by four, or 50%.
-        Given our similarity threshold above, we would consider this to be a match.
-
-        .. _`Jaccard similarity index`: https://en.wikipedia.org/wiki/Jaccard_index
+        Return the calculated similarity of two
+        statements based on the Jaccard index.
         """
         from nltk.corpus import wordnet
         import nltk
@@ -270,10 +286,22 @@ class JaccardSimilarity(Comparator):
         ratio = 0
         pos_a = map(get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(a)))
         pos_b = map(get_wordnet_pos, nltk.pos_tag(nltk.tokenize.word_tokenize(b)))
-        lemma_a = [lemmatizer.lemmatize(token.strip(string.punctuation), pos) for token, pos in pos_a
-                   if pos == wordnet.NOUN and token.strip(string.punctuation) not in stopwords]
-        lemma_b = [lemmatizer.lemmatize(token.strip(string.punctuation), pos) for token, pos in pos_b
-                   if pos == wordnet.NOUN and token.strip(string.punctuation) not in stopwords]
+        lemma_a = [
+            lemmatizer.lemmatize(
+                token.strip(string.punctuation),
+                pos
+            ) for token, pos in pos_a if pos == wordnet.NOUN and token.strip(
+                string.punctuation
+            ) not in stopwords
+        ]
+        lemma_b = [
+            lemmatizer.lemmatize(
+                token.strip(string.punctuation),
+                pos
+            ) for token, pos in pos_b if pos == wordnet.NOUN and token.strip(
+                string.punctuation
+            ) not in stopwords
+        ]
 
         # Calculate Jaccard similarity
         try:

--- a/chatterbot/logic/logic_adapter.py
+++ b/chatterbot/logic/logic_adapter.py
@@ -37,6 +37,16 @@ class LogicAdapter(Adapter):
             get_first_response
         )
 
+    def get_initialization_functions(self):
+        """
+        Return a dictionary of functions to be run once when the chat bot is instantiated.
+        """
+        return self.compare_statements.get_initialization_functions()
+
+    def initialize(self):
+        for function in self.get_initialization_functions().values():
+            function()
+
     def can_process(self, statement):
         """
         A preliminary check that is called to determine if a

--- a/chatterbot/logic/multi_adapter.py
+++ b/chatterbot/logic/multi_adapter.py
@@ -22,6 +22,19 @@ class MultiLogicAdapter(LogicAdapter):
         # Requied logic adapters that must always be present
         self.system_adapters = []
 
+    def get_initialization_functions(self):
+        """
+        Get the initialization functions for each logic adapter.
+        """
+        functions_dict = {}
+
+        # Interate over each adapter and get its initialization functions
+        for logic_adapter in self.get_adapters():
+            functions = logic_adapter.get_initialization_functions()
+            functions_dict.update(functions)
+
+        return functions_dict
+
     def process(self, statement):
         """
         Returns the output of a selection of logic adapters

--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -101,7 +101,7 @@ def nltk_download_corpus(resource_path):
     from os.path import split, sep
     from zipfile import BadZipfile
 
-    # Download the wordnet data only if it is not already downloaded
+    # Download the NLTK data only if it is not already downloaded
     _, corpus_name = split(resource_path)
 
     # From http://www.nltk.org/api/nltk.html

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_sentiment_comparison.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_sentiment_comparison.py
@@ -19,6 +19,7 @@ class BestMatchSentimentComparisonTestCase(ChatBotTestCase):
             statement_comparison_function=sentiment_comparison
         )
         self.adapter.set_chatbot(self.chatbot)
+        self.adapter.initialize()
 
     def test_exact_input(self):
         self.chatbot.train([

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_synset_distance.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_synset_distance.py
@@ -12,16 +12,13 @@ class BestMatchSynsetDistanceTestCase(ChatBotTestCase):
 
     def setUp(self):
         super(BestMatchSynsetDistanceTestCase, self).setUp()
-        from chatterbot.utils import nltk_download_corpus
         from chatterbot.comparisons import synset_distance
-
-        nltk_download_corpus('stopwords')
-        nltk_download_corpus('wordnet')
-        nltk_download_corpus('punkt')
 
         self.adapter = BestMatch(
             statement_comparison_function=synset_distance
         )
+
+        self.adapter.initialize()
 
         # Add a mock storage adapter to the logic adapter
         self.adapter.set_chatbot(self.chatbot)

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -73,6 +73,11 @@ class SentimentComparisonTestCase(TestCase):
         statement = Statement('Hi HoW ArE yOu?')
         other_statement = Statement('hI hOw are YoU?')
 
+        # Prepare to do the comparison
+        functions = comparisons.sentiment_comparison.get_initialization_functions()
+        for function in functions.values():
+            function()
+
         value = comparisons.sentiment_comparison(statement, other_statement)
 
         self.assertEqual(value, 1)

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -57,6 +57,14 @@ class LevenshteinDistanceTestCase(TestCase):
 
 class SynsetDistanceTestCase(TestCase):
 
+    def test_get_initialization_functions(self):
+        """
+        Test that the initialization functions are returned.
+        """
+        functions = comparisons.synset_distance.get_initialization_functions()
+
+        self.assertIn('initialize_nltk_wordnet', functions)
+
     def test_exact_match_different_capitalization(self):
         """
         Test that text capitalization is ignored.


### PR DESCRIPTION
This corrects the issue where the ChatBot class always downloads NLTK assets even if it doesn't need them. Now, each statement comparison algorithm will be responsible for its own dependencies.

The design of this new setup maintains efficiency by ensuring that functions with the same name (they should do the same things) are only called once, even when multiple logic adapters use them.