### PR TITLE
Rename SQL Alchemy Database Adapter

### DIFF
--- a/chatterbot/storage/__init__.py
+++ b/chatterbot/storage/__init__.py
@@ -2,7 +2,7 @@ from .storage_adapter import StorageAdapter
 from .django_storage import DjangoStorageAdapter
 from .jsonfile import JsonFileStorageAdapter
 from .mongodb import MongoDatabaseAdapter
-from .sqlalchemy_storage import SQLAlchemyDatabaseAdapter
+from .sql_storage import SQLStorageAdapter
 
 
 __all__ = (
@@ -10,5 +10,5 @@ __all__ = (
     'DjangoStorageAdapter',
     'JsonFileStorageAdapter',
     'MongoDatabaseAdapter',
-    'SQLAlchemyDatabaseAdapter',
+    'SQLStorageAdapter',
 )

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -72,10 +72,10 @@ def get_response_table(response):
     return ResponseTable(text=response.text, occurrence=response.occurrence)
 
 
-class SQLAlchemyDatabaseAdapter(StorageAdapter):
+class SQLStorageAdapter(StorageAdapter):
 
     def __init__(self, **kwargs):
-        super(SQLAlchemyDatabaseAdapter, self).__init__(**kwargs)
+        super(SQLStorageAdapter, self).__init__(**kwargs)
 
         from sqlalchemy import create_engine
         from sqlalchemy.orm import sessionmaker

--- a/tests/base_case.py
+++ b/tests/base_case.py
@@ -76,5 +76,5 @@ class ChatBotSQLTestCase(ChatBotTestCase):
     def get_kwargs(self):
         kwargs = super(ChatBotSQLTestCase, self).get_kwargs()
         del kwargs['database']
-        kwargs['storage_adapter'] = 'chatterbot.storage.SQLAlchemyDatabaseAdapter'
+        kwargs['storage_adapter'] = 'chatterbot.storage.SQLStorageAdapter'
         return kwargs

--- a/tests/storage_adapter_tests/integration_tests/sqlalchemy_integration_tests.py
+++ b/tests/storage_adapter_tests/integration_tests/sqlalchemy_integration_tests.py
@@ -1,7 +1,7 @@
 from tests.base_case import ChatBotSQLTestCase
 
 
-class SqlAlchemyStorageIntegrationTests(ChatBotSQLTestCase):
+class SqlStorageIntegrationTests(ChatBotSQLTestCase):
 
     def test_database_is_updated(self):
         """

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from chatterbot.conversation import Statement, Response
-from chatterbot.storage.sqlalchemy_storage import SQLAlchemyDatabaseAdapter
+from chatterbot.storage.sql_storage import SQLStorageAdapter
 
 
 class SQLAlchemyAdapterTestCase(TestCase):
@@ -10,7 +10,7 @@ class SQLAlchemyAdapterTestCase(TestCase):
         """
         Instantiate the adapter before any tests in the test case run.
         """
-        cls.adapter = SQLAlchemyDatabaseAdapter()
+        cls.adapter = SQLStorageAdapter()
 
     def setUp(self):
         """
@@ -25,7 +25,7 @@ class SQLAlchemyAdapterTestCase(TestCase):
         self.adapter.drop()
 
 
-class SQLAlchemyDatabaseAdapterTestCase(SQLAlchemyAdapterTestCase):
+class SQLStorageAdapterTestCase(SQLAlchemyAdapterTestCase):
 
     def test_count_returns_zero(self):
         """
@@ -340,13 +340,13 @@ class SQLAlchemyStorageAdapterFilterTestCase(SQLAlchemyAdapterTestCase):
         self.assertIsInstance(found[0].in_response_to[0], Response)
 
 
-class ReadOnlySQLAlchemyDatabaseAdapterTestCase(SQLAlchemyAdapterTestCase):
+class ReadOnlySQLStorageAdapterTestCase(SQLAlchemyAdapterTestCase):
 
     def setUp(self):
         """
         Make the adapter writable before every test.
         """
-        super(ReadOnlySQLAlchemyDatabaseAdapterTestCase, self).setUp()
+        super(ReadOnlySQLStorageAdapterTestCase, self).setUp()
         self.adapter.read_only = False
 
     def test_update_does_not_add_new_statement(self):


### PR DESCRIPTION
This changes the class name from `SQLAlchemyDatabaseAdapter` to `SQLStorageAdapter`. This change is because we abstract the inner workings of the SQL adapter. As a result the user never really needs to
know what library is being used internally.