### PR TITLE
Switch to SQL adapter as default database adapter for ChatterBot

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -18,7 +18,7 @@ class ChatBot(object):
         self.name = name
         kwargs['name'] = name
 
-        storage_adapter = kwargs.get('storage_adapter', 'chatterbot.storage.JsonFileStorageAdapter')
+        storage_adapter = kwargs.get('storage_adapter', 'chatterbot.storage.SQLStorageAdapter')
 
         logic_adapters = kwargs.get('logic_adapters', [
             'chatterbot.logic.BestMatch'

--- a/tests/base_case.py
+++ b/tests/base_case.py
@@ -27,9 +27,8 @@ class ChatBotTestCase(TestCase):
         return {
             'input_adapter': 'chatterbot.input.VariableInputTypeAdapter',
             'output_adapter': 'chatterbot.output.OutputAdapter',
-            # None runs the JSON database in-memory
-            'database': None,
-            'silence_performance_warning': True
+            # None runs the test database in-memory
+            'database': None
         }
 
     def random_string(self, start=0, end=9000):

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -12,8 +12,8 @@ class StringInitalizationTestCase(ChatBotTestCase):
         }
 
     def test_storage_initialized(self):
-        from chatterbot.storage import JsonFileStorageAdapter
-        self.assertTrue(isinstance(self.chatbot.storage, JsonFileStorageAdapter))
+        from chatterbot.storage import SQLStorageAdapter
+        self.assertTrue(isinstance(self.chatbot.storage, SQLStorageAdapter))
 
     def test_logic_initialized(self):
         from chatterbot.logic import BestMatch
@@ -34,9 +34,8 @@ class DictionaryInitalizationTestCase(ChatBotTestCase):
     def get_kwargs(self):
         return {
             'storage_adapter': {
-                'import_path': 'chatterbot.storage.JsonFileStorageAdapter',
-                'database': None,
-                'silence_performance_warning': True
+                'import_path': 'chatterbot.storage.SQLStorageAdapter',
+                'database': None
             },
             'input_adapter': {
                 'import_path': 'chatterbot.input.VariableInputTypeAdapter'
@@ -55,8 +54,8 @@ class DictionaryInitalizationTestCase(ChatBotTestCase):
         }
 
     def test_storage_initialized(self):
-        from chatterbot.storage import JsonFileStorageAdapter
-        self.assertTrue(isinstance(self.chatbot.storage, JsonFileStorageAdapter))
+        from chatterbot.storage import SQLStorageAdapter
+        self.assertTrue(isinstance(self.chatbot.storage, SQLStorageAdapter))
 
     def test_logic_initialized(self):
         from chatterbot.logic import BestMatch


### PR DESCRIPTION
This pull request reveals what tests fail after setting the SQL storage adapter as the default for ChatterBot. These failures will need to be corrected before the adapter can be used in production.

**Updates:**
- After merging in #800 there are only a few errors remaining.
- After commit 49900b9c0933c2ef876d96fd426ff5b7600f5fb9 an additional dictionary casting error was removed.

***

```
======================================================================
FAIL: Test that an additional data attribute can be added to the statement
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/gcox/GitHub/ChatterBot/tests/logic_adapter_tests/test_data_cache.py", line 46, in test_additional_attributes_saved
    self.assertIn('pos_tags', data['extra_data'])
AssertionError: 'pos_tags' not found in {}
-------------------- >> begin captured logging << --------------------
chatterbot.adapters: INFO: Recieved input statement: Hello
chatterbot.adapters: INFO: "Hello" is a known statement
--------------------- >> end captured logging << ---------------------

======================================================================
FAIL: If an input statement has data contained in the
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/gcox/GitHub/ChatterBot/tests/test_chatbot.py", line 106, in test_response_extra_data
    self.assertIn('test', saved_statement.extra_data)
AssertionError: 'test' not found in {}
-------------------- >> begin captured logging << --------------------
chatterbot.adapters: INFO: Recieved input statement: Hello
chatterbot.adapters: INFO: "Hello" is not a known statement
chatterbot.adapters: INFO: Not processing the statement using BestMatch
chatterbot.adapters: INFO: NoKnowledgeAdapter selected "Hello" as a response with a confidence of 1
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 341 tests in 20.285s

FAILED (SKIP=35, failures=2)
```