### PR TITLE
Fix logging statement in sql adapter

### DIFF
--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -274,7 +274,8 @@ class SQLStorageAdapter(StorageAdapter):
                 session.commit()
             else:
                 session.rollback()
-        except DatabaseError as e:
-            self.logger.error(statement_text, str(e.orig))
+        except DatabaseError:
+            # Log the statement text and the exception
+            self.logger.exception(statement_text)
         finally:
             session.close()


### PR DESCRIPTION
This pull request fixes a logging statement in the SQL adapter that was triggering errors. I've replaced it with an `exception` logging statement that has some useful functionality (It records the exception when the method is called within the scope of an `except` block.

> Logger.exception(msg, *args, **kwargs)
>
> Logs a message with level ERROR on this logger. The arguments are interpreted as for debug(). Exception info is added to the logging message. This method should only be called from an exception handler.
>
> ~ https://docs.python.org/3/library/logging.html#logging.Logger.exception