### PR TITLE
Add command line utility to list NLTK data directories

### DIFF
--- a/chatterbot/__main__.py
+++ b/chatterbot/__main__.py
@@ -8,6 +8,15 @@ if __name__ == '__main__':
         print(chatterbot.__version__)
 
     if 'list_nltk_data' in sys.argv:
+        import os
         import nltk.data
 
-        print('\n'.join(nltk.data.path))
+        data_directories = []
+
+        # Find each data directory in the NLTK path that has content
+        for path in nltk.data.path:
+            if os.path.exists(path):
+                if os.listdir(path):
+                    data_directories.append(path)
+
+        print(os.linesep.join(data_directories))

--- a/chatterbot/__main__.py
+++ b/chatterbot/__main__.py
@@ -6,3 +6,8 @@ if __name__ == '__main__':
 
     if '--version' in sys.argv:
         print(chatterbot.__version__)
+
+    if 'list_nltk_data' in sys.argv:
+        import nltk.data
+
+        print('\n'.join(nltk.data.path))


### PR DESCRIPTION
**Usage:**

```bash
python -m chatterbot list_nltk_data
```

**Output:**

Lists all NLTK data directories that contain files.

For #802 and the many related issues where problems with downloading the data happen. Adding this command will hopefully help find the NLTK data to delete is so that it will be re-downloaded.