### PR TITLE
Docs and Example updation about SQLStorageAdapter 

### DIFF
--- a/chatterbot/__main__.py
+++ b/chatterbot/__main__.py
@@ -2,9 +2,10 @@ import sys
 
 
 if __name__ == '__main__':
-    import chatterbot
+    import importlib
 
     if '--version' in sys.argv:
+        chatterbot = importlib.import_module('chatterbot')
         print(chatterbot.__version__)
 
     if 'list_nltk_data' in sys.argv:

--- a/docs/chatterbot.rst
+++ b/docs/chatterbot.rst
@@ -162,7 +162,7 @@ Then, :code:`self.chatbot.storage` refers to the storage adapter, :code:`self.ch
 Adapter defaults
 ----------------
 
-By default, ChatterBot uses the `JsonFileStorageAdapter` adapter for storage,
+By default, ChatterBot uses the `SQLStorageAdapter` adapter for storage,
 the `BestMatch` for logic, the `VariableInputTypeAdapter` for input
 and the `OutputAdapter` for output.
 
@@ -172,7 +172,7 @@ Each adapter can be set by passing in the dot-notated import path to the constru
 
    bot = ChatBot(
        "Elsie",
-       storage_adapter="chatterbot.storage.JsonFileStorageAdapter",
+       storage_adapter="chatterbot.storage.SQLStorageAdapter",
        input_adapter="chatterbot.input.VariableInputTypeAdapter",
        output_adapter="chatterbot.output.OutputAdapter",
        logic_adapters=[

--- a/docs/storage/index.rst
+++ b/docs/storage/index.rst
@@ -18,15 +18,14 @@ storage adapter you want to use.
 
    chatbot = ChatBot(
        "My ChatterBot",
-       storage_adapter="chatterbot.storage.JsonFileStorageAdapter"
+       storage_adapter="chatterbot.storage.SQLStorageAdapter"
    )
 
-Json File Storage Adapter
-=========================
+SQL Alchemy Storage Adapter
+===========================
 
-.. autoclass:: chatterbot.storage.JsonFileStorageAdapter
+.. autoclass:: chatterbot.storage.SQLStorageAdapter
    :members:
-   :special-members: AdapterUnsuitableForProductionWarning
 
 Mongo Database Adapter
 ======================

--- a/examples/default_response_example.py
+++ b/examples/default_response_example.py
@@ -5,7 +5,7 @@ from chatterbot import ChatBot
 # Create a new instance of a ChatBot
 bot = ChatBot(
     'Default Response Example Bot',
-    storage_adapter='chatterbot.storage.JsonFileStorageAdapter',
+    storage_adapter='chatterbot.storage.SQLStorageAdapter',
     logic_adapters=[
         {
             'import_path': 'chatterbot.logic.BestMatch'

--- a/examples/learning_feedback_example.py
+++ b/examples/learning_feedback_example.py
@@ -14,7 +14,7 @@ element from the user.
 # Create a new instance of a ChatBot
 bot = ChatBot(
     'Feedback Learning Bot',
-    storage_adapter='chatterbot.storage.JsonFileStorageAdapter',
+    storage_adapter='chatterbot.storage.SQLStorageAdapter',
     logic_adapters=[
         'chatterbot.logic.BestMatch'
     ],

--- a/examples/mailgun.py
+++ b/examples/mailgun.py
@@ -24,7 +24,7 @@ bot = ChatBot(
     mailgun_recipients=RECIPIENTS,
     input_adapter="chatterbot.input.Mailgun",
     output_adapter="chatterbot.output.Mailgun",
-    storage_adapter="chatterbot.storage.JsonFileStorageAdapter",
+    storage_adapter="chatterbot.storage.SQLStorageAdapter",
     database="../database.db"
 )
 

--- a/examples/specific_response_example.py
+++ b/examples/specific_response_example.py
@@ -5,7 +5,7 @@ from chatterbot import ChatBot
 # Create a new instance of a ChatBot
 bot = ChatBot(
     'Exact Response Example Bot',
-    storage_adapter='chatterbot.storage.JsonFileStorageAdapter',
+    storage_adapter='chatterbot.storage.SQLStorageAdapter',
     logic_adapters=[
         {
             'import_path': 'chatterbot.logic.BestMatch'

--- a/examples/terminal_example.py
+++ b/examples/terminal_example.py
@@ -9,7 +9,7 @@ from chatterbot import ChatBot
 # Create a new instance of a ChatBot
 bot = ChatBot(
     "Terminal",
-    storage_adapter="chatterbot.storage.JsonFileStorageAdapter",
+    storage_adapter="chatterbot.storage.SQLStorageAdapter",
     logic_adapters=[
         "chatterbot.logic.MathematicalEvaluation",
         "chatterbot.logic.TimeLogicAdapter",

--- a/examples/tkinter_gui.py
+++ b/examples/tkinter_gui.py
@@ -20,7 +20,7 @@ class TkinterGUIExample(tk.Tk):
 
         self.chatbot = ChatBot(
             "GUI Bot",
-            storage_adapter="chatterbot.storage.JsonFileStorageAdapter",
+            storage_adapter="chatterbot.storage.SQLStorageAdapter",
             logic_adapters=[
                 "chatterbot.logic.BestMatch"
             ],

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -24,8 +24,7 @@ CONFIGURATIONS = [
             }
         ],
         'storage_adapter': {
-            'import_path': 'chatterbot.storage.JsonFileStorageAdapter',
-            'silence_performance_warning': True
+            'import_path': 'chatterbot.storage.SQLStorageAdapter'
         },
     },
     {
@@ -38,8 +37,7 @@ CONFIGURATIONS = [
             }
         ],
         'storage_adapter': {
-            'import_path': 'chatterbot.storage.JsonFileStorageAdapter',
-            'silence_performance_warning': True
+            'import_path': 'chatterbot.storage.SQLStorageAdapter'
         },
     }
 ]


### PR DESCRIPTION
This PR will address 

***

Import version from command line https://github.com/gunthercox/ChatterBot/issues/795
Documentation updation about default ``SQLStorageAdapter`` storage adapter 
Replaced ``JsonStorageAdapter`` to ``SQLStorageAdapter`` in all examples