### PR TITLE
Add warning about Ubuntu dialog corpus

### DIFF
--- a/docs/training.rst
+++ b/docs/training.rst
@@ -152,6 +152,12 @@ Twitter training example
 Training with the Ubuntu dialog corpus
 --------------------------------------
 
+.. warning::
+
+   The Ubuntu dialog corpus is a massive data set. Developers will currently
+   experience significant performance in the form of delayed training and
+   response times from the chat bot when using this corpus.
+
 .. autofunction:: chatterbot.trainers.UbuntuCorpusTrainer
 
 This training class makes it possible to train your chat bot using the Ubuntu

--- a/docs/training.rst
+++ b/docs/training.rst
@@ -155,8 +155,8 @@ Training with the Ubuntu dialog corpus
 .. warning::
 
    The Ubuntu dialog corpus is a massive data set. Developers will currently
-   experience significant performance in the form of delayed training and
-   response times from the chat bot when using this corpus.
+   experience significantly decreased performance in the form of delayed
+   training and response times from the chat bot when using this corpus.
 
 .. autofunction:: chatterbot.trainers.UbuntuCorpusTrainer
 


### PR DESCRIPTION
This adds a warning message in the documentation due to the performance issues when training with the Ubuntu dialog corpus.

CC @peterel