### PR TITLE
Correct integrity error by checking for existing responses

### DIFF
--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -352,13 +352,13 @@ class SQLStorageAdapter(StorageAdapter):
         Base.metadata.create_all(self.engine)
 
     def _session_finish(self, session, statement_text=None):
-        from sqlalchemy.exc import DatabaseError
+        from sqlalchemy.exc import InvalidRequestError
         try:
             if not self.read_only:
                 session.commit()
             else:
                 session.rollback()
-        except DatabaseError:
+        except InvalidRequestError:
             # Log the statement text and the exception
             self.logger.exception(statement_text)
         finally:

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -9,10 +9,11 @@ Base = None
 
 try:
     from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy_mixins import ActiveRecordMixin, SmartQueryMixin
 
     Base = declarative_base()
 
-    class StatementTable(Base):
+    class StatementTable(Base, ActiveRecordMixin, SmartQueryMixin):
         """
         StatementTable, placeholder for a sentence or phrase.
         """
@@ -46,7 +47,7 @@ try:
             default=get_statement_serialized
         )
 
-    class ResponseTable(Base):
+    class ResponseTable(Base, ActiveRecordMixin, SmartQueryMixin):
         """
         ResponseTable, contains responses related to a givem statment.
         """
@@ -63,7 +64,7 @@ try:
 
         id = Column(Integer)
         text = Column(String, primary_key=True)
-        occurrence = Column(Integer)
+        occurrence = Column(Integer, default=1)
         statement_text = Column(String, ForeignKey('StatementTable.text'))
 
         statement_table = relationship(
@@ -84,6 +85,19 @@ try:
 
 except ImportError:
     pass
+
+
+def get_or_create(session, model, defaults=None, **kwargs):
+    from sqlalchemy.sql.expression import ClauseElement
+    instance = session.query(model).filter_by(**kwargs).first()
+    if instance:
+        return instance, False
+    else:
+        params = dict((k, v) for k, v in kwargs.iteritems() if not isinstance(v, ClauseElement))
+        params.update(defaults or {})
+        instance = model(**params)
+        session.add(instance)
+        return instance, True
 
 
 def get_statement_table(statement):
@@ -271,7 +285,9 @@ class SQLStorageAdapter(StorageAdapter):
         """
         if statement:
             session = self.Session()
+            ResponseTable.set_session(session)
             query = self.__statement_filter(session, **{"text": statement.text})
+            # TODO: This should be a get
             record = query.first()
 
             if record:
@@ -281,9 +297,25 @@ class SQLStorageAdapter(StorageAdapter):
                 if statement.extra_data:
                     record.extra_data = dict(statement.extra_data)
                 if statement.in_response_to:
-                    record.in_response_to = list(
-                        map(get_response_table, statement.in_response_to)
-                    )
+
+                    responses = []
+
+                    # Get or create the response records as needed
+                    for response in statement.in_response_to:
+                        _response = ResponseTable.where(
+                            text=statement.text,
+                            statement_text=response.text
+                        ).first()
+
+                        if _response:
+                            _response.occurrence += 1
+                        else:
+                            # Create the record
+                            _response = get_response_table(response)
+
+                        responses.append(_response)
+
+                    record.in_response_to = responses
                 session.add(record)
             else:
                 session.add(get_statement_table(statement))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ nltk>=3.2.0,<4.0.0
 pymongo>=3.3.0,<4.0.0
 python-twitter>=3.0.0,<4.0.0
 sqlalchemy>=1.1,<1.2
-sqlalchemy_mixins>=0.2.2,<0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ jsondatabase>=0.1.7,<1.0.0
 nltk>=3.2.0,<4.0.0
 pymongo>=3.3.0,<4.0.0
 python-twitter>=3.0.0,<4.0.0
-SQLAlchemy>=1.1,<1.2
+sqlalchemy>=1.1,<1.2
+sqlalchemy_mixins>=0.2.2,<0.3

--- a/tests/training_tests/test_list_training.py
+++ b/tests/training_tests/test_list_training.py
@@ -150,6 +150,7 @@ class ListTrainingTests(ChatBotTestCase):
         self.assertEqual(response1.text, "C")
         self.assertEqual(response2.text, "D")
 
+
 class ChatterBotResponseTests(ChatBotTestCase):
 
     def setUp(self):

--- a/tests/training_tests/test_list_training.py
+++ b/tests/training_tests/test_list_training.py
@@ -137,6 +137,18 @@ class ListTrainingTests(ChatBotTestCase):
         self.assertEqual(response_to_trained_set, response1)
         self.assertEqual(response1, response2)
 
+    def test_consecutive_trainings_same_responses_different_inputs(self):
+        """
+        Test consecutive trainings with the same responses to different inputs.
+        """
+        self.chatbot.train(["A", "B" "C"])
+        self.chatbot.train(["B", "C", "D"])
+
+        response1 = self.chatbot.get_response("B")
+        response2 = self.chatbot.get_response("C")
+
+        self.assertEqual(response1.text, "C")
+        self.assertEqual(response2.text, "D")
 
 class ChatterBotResponseTests(ChatBotTestCase):
 


### PR DESCRIPTION
This issue was occurring because a new response was *trying* to be created in the database each time a statement with responses was updated. This operation fails if that response already exists.

Closes #831
Closes #842
Closes #844