### PR TITLE
Add a base class for SQL Alchemy models

### DIFF
--- a/chatterbot/ext/sqlalchemy_app/models.py
+++ b/chatterbot/ext/sqlalchemy_app/models.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Column, Integer
+from sqlalchemy.ext.declarative import (
+    declared_attr, declarative_base
+)
+
+
+class ModelBase(object):
+    """
+    An augmented base class for SqlAlchemy models.
+    """
+
+    @declared_attr
+    def __tablename__(cls):
+        """
+        Return the lowercase class name as the name of the table.
+        """
+        return cls.__name__.lower()
+
+    id = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True
+    )
+
+
+Base = declarative_base(cls=ModelBase)

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -8,9 +8,7 @@ from chatterbot.conversation import Statement
 Base = None
 
 try:
-    from sqlalchemy.ext.declarative import declarative_base
-
-    Base = declarative_base()
+    from chatterbot.ext.sqlalchemy_app.models import Base
 
     class StatementTable(Base):
         """
@@ -32,7 +30,6 @@ try:
             del params['text_search']
             return json.dumps(params)
 
-        id = Column(Integer, primary_key=True, autoincrement=True)
         text = Column(String, unique=True)
         extra_data = Column(PickleType)
 
@@ -60,7 +57,6 @@ try:
             del params['text_search']
             return json.dumps(params)
 
-        id = Column(Integer, primary_key=True, autoincrement=True)
         text = Column(String)
         occurrence = Column(Integer, default=1)
         statement_text = Column(String, ForeignKey('StatementTable.text'))

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'chatterbot.corpus',
         'chatterbot.conversation',
         'chatterbot.ext',
+        'chatterbot.ext.sqlalchemy_app',
         'chatterbot.ext.django_chatterbot',
         'chatterbot.ext.django_chatterbot.migrations',
         'chatterbot.ext.django_chatterbot.management',


### PR DESCRIPTION
This adds a base class with an `id` attribute that each of the SQL alchemy models can inherit from.