### PR TITLE
Allow specification of ssl verification for hipchat adapters.

### DIFF
--- a/chatterbot/input/hipchat.py
+++ b/chatterbot/input/hipchat.py
@@ -18,6 +18,10 @@ class HipChat(InputAdapter):
         self.hipchat_room = kwargs.get('hipchat_room')
         self.session_id = str(self.chatbot.default_session.uuid)
 
+        import requests
+        self.session = requests.Session()
+        self.session.verify = kwargs.get('ssl_verify', True)
+
         authorization_header = 'Bearer {}'.format(self.hipchat_access_token)
 
         self.headers = {
@@ -48,7 +52,6 @@ class HipChat(InputAdapter):
         """
         https://www.hipchat.com/docs/apiv2/method/view_recent_room_history
         """
-        import requests
 
         recent_histroy_url = '{}/v2/room/{}/history?max-results={}'.format(
             self.hipchat_host,
@@ -56,7 +59,7 @@ class HipChat(InputAdapter):
             max_results
         )
 
-        response = requests.get(
+        response = self.session.get(
             recent_histroy_url,
             headers=self.headers
         )

--- a/chatterbot/output/hipchat.py
+++ b/chatterbot/output/hipchat.py
@@ -23,19 +23,21 @@ class HipChat(OutputAdapter):
             'Content-Type': 'application/json'
         }
 
+        import requests
+        self.session = requests.Session()
+        self.session.verify = kwargs.get('ssl_verify', True)
+
     def send_message(self, room_id_or_name, message):
         """
         Send a message to a HipChat room.
         https://www.hipchat.com/docs/apiv2/method/send_message
         """
-        import requests
-
         message_url = "{}/v2/room/{}/message".format(
             self.hipchat_host,
             room_id_or_name
         )
 
-        response = requests.post(
+        response = self.session.post(
             message_url,
             headers=self.headers,
             data=json.dumps({


### PR DESCRIPTION
Allow specification of ssl verification for hipchat adapters by adding an optional config variable to the chatbot instance.