### PR TITLE
Set query support to false in SQL storage adapter

### DIFF
--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -127,6 +127,9 @@ class SQLStorageAdapter(StorageAdapter):
 
         self.Session = sessionmaker(bind=self.engine, expire_on_commit=True)
 
+        # ChatterBot's internal query builder is not yet supported for this adapter
+        self.adapter_supports_queries = False
+
     def count(self):
         """
         Return the number of entries in the database.


### PR DESCRIPTION
This prevents the issues seen in #867. Query support (using ChatterBot's query builder) still needs to be added for this adapter.

Closes #867