### PR TITLE
Add web deployment section to FAQ

### DIFF
--- a/docs/django/wsgi.rst
+++ b/docs/django/wsgi.rst
@@ -1,12 +1,28 @@
 Webservices
 ===========
 
-If you want to host your example_app, you need to use either `Heroku`_ or `PythonAnyWhere`_.
-You would also need to install `gunicorn`_ and `whitenoise`_.
+If you want to host your Django app, you need to choose a method through
+which it will be hosted. There are a few free services that you can use
+to do this shuch as `Heroku`_ and `PythonAnyWhere`_.
 
-Please follow the installation instructions as specified.
+WSGI
+----
+
+A common method for serving Python web applications involves using a
+Web Server Gateway Interface (`WSGI`_) package.
+
+`Gunicorn`_ is a great choice for a WSGI server. They have detailed
+documentation and installation instructions on their website.
+
+Hosting static files
+--------------------
+
+There are numerous ways to host static files for your Django application.
+One extreemly easy way to do this is by using `WhiteNoise`_, a python package
+designed to make it possible to serve static files from just about any web application.
 
 .. _Heroku: https://dashboard.heroku.com/
 .. _PythonAnyWhere: https://www.pythonanywhere.com/details/django_hosting
-.. _gunicorn: http://gunicorn.org/
-.. _whitenoise: http://whitenoise.evans.io/en/stable/
+.. _Gunicorn: http://gunicorn.org/
+.. _WhiteNoise: http://whitenoise.evans.io/en/stable/
+.. _WSGI: http://wsgi.readthedocs.io/en/latest/what.html

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -26,3 +26,6 @@ There are a number of existing examples that show how to do this.
 
 1. An example using Django: https://github.com/gunthercox/ChatterBot/tree/master/examples/django_app
 2. An example using Flask: https://github.com/chamkank/flask-chatterbot/blob/master/app.py
+
+Additional details and recommendations for configuring Django can be found
+in the :ref:`Webservices` section of ChatterBot's Django documentation.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -2,7 +2,27 @@
 Frequently Asked Questions
 ==========================
 
+This document is comprised of questions that are frequently
+asked about ChatterBot and chat bots in general.
+
 .. toctree::
    :maxdepth: 2
 
    encoding
+
+How do I deploy my chat bot to the web?
+---------------------------------------
+
+There are a number of excellent web frameworks for creating
+Python projects out there. Django and Flask are two excellent
+examples of these. ChatterBot is designed to be agnostic to
+the platform it is deployed on and it is very easy to get set up.
+
+To run ChatterBot inside of a web application you just need a way
+for your application to receive incoming data and to return data.
+You can do this any way you want, HTTP requests, web sockets, etc.
+
+There are a number of existing examples that show how to do this.
+
+1. An example using Django: https://github.com/gunthercox/ChatterBot/tree/master/examples/django_app
+2. An example using Flask: https://github.com/chamkank/flask-chatterbot/blob/master/app.py


### PR DESCRIPTION
This adds general documentation on how to deploy a chat bot as a web application. It might be much too general at the moment so any feedback on how it could be improved would be greatly appreciated.

Closes #884