### PR TITLE
dump instead dumps

### DIFF
--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -64,7 +64,7 @@ class Trainer(object):
         import json
         export = {'conversations': self._generate_export_data()}
         with open(file_path, 'w+') as jsonfile:
-            json.dumps(export, jsonfile, ensure_ascii=False)
+            json.dump(export, jsonfile, ensure_ascii=False)
 
 
 class ListTrainer(Trainer):


### PR DESCRIPTION
closes: https://github.com/gunthercox/ChatterBot/issues/912

***

json.dump()

    Serialize obj as a JSON formatted stream to fp (a .write()-supporting file-like object

    If ensure_ascii is False, some chunks written to fp may be unicode instances

json.dumps()

    Serialize obj to a JSON formatted str

    If ensure_ascii is False, the result may contain non-ASCII characters and the return value may be a unicode instance
