### PR TITLE
Don't append .db to sql database name

### DIFF
--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -52,7 +52,7 @@ class SQLStorageAdapter(StorageAdapter):
 
         # Create a sqlite file if a database name is provided
         if database_name:
-            self.database_uri = "sqlite:///" + database_name + ".db"
+            self.database_uri = "sqlite:///" + database_name
 
         self.engine = create_engine(self.database_uri, convert_unicode=True)
 

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -32,8 +32,8 @@ class SQLStorageAdapterTestCase(SQLAlchemyAdapterTestCase):
         self.assertEqual(adapter.database_uri, 'sqlite://')
 
     def test_set_database_name(self):
-        adapter = SQLStorageAdapter(database='test')
-        self.assertEqual(adapter.database_uri, 'sqlite:///test.db')
+        adapter = SQLStorageAdapter(database='test.sqlite3')
+        self.assertEqual(adapter.database_uri, 'sqlite:///test.sqlite3')
 
     def test_set_database_uri(self):
         adapter = SQLStorageAdapter(database_uri='sqlite:///db.sqlite3')


### PR DESCRIPTION
This updates the SQL storage adapter so that it won't automatically append ".db" to the end of the database name.

Closes #914