### PR TITLE
Getting recent response from the database.

### DIFF
--- a/chatterbot/response_selection.py
+++ b/chatterbot/response_selection.py
@@ -51,6 +51,23 @@ def get_first_response(input_statement, response_list):
     ))
     return response_list[0]
 
+def get_recent_response(input_statement,response_list):
+    """
+    :param input_statement: A statement, that closely matches an input to the chat bot.
+    :type input_statement: Statement
+
+    :param response_list: A list of statement options to choose a response from.
+    :type response_list: list
+
+    :return: Return the latest statement in the response list.
+    :rtype: Statement
+    """
+    logger = logging.getLogger(__name__)
+    logger.info(u'Selecting the more recent response from the list of {} options.'.format(
+        len(response_list)
+    ))
+    return response_list[len(response_list) - 1]
+
 
 def get_random_response(input_statement, response_list):
     """

--- a/tests/test_response_selection.py
+++ b/tests/test_response_selection.py
@@ -31,6 +31,17 @@ class ResponseSelectionTests(TestCase):
 
         self.assertEqual('What... is your quest?', output)
 
+    def test_get_recent_response(self):
+        statement_list = [
+               Statement('What... is your quest?'),
+               Statement('A what?'),
+               Statement('A quest.')
+           ]
+
+        output = response_selection.get_recent_response(Statement('Hello'), statement_list)
+
+        self.assertEqual('A quest.',output)
+
     def test_get_random_response(self):
         statement_list = [
             Statement('This is a phone.'),


### PR DESCRIPTION
Hi,

I had a use case where i need to get the latest response of the same message. For instance, for the text 'hi' there are two responses 'hello' and 'hey' in the database. What i want is, I need to get the response which has been included recently (say 'hey' in this example). 

I checked out the response_selection  method and it seems to have get_first_response and other kind of methods but this one is not included. So i created a new method called get_recent_response in chatterbot.response_selection.py file and it seems to fulfill my use case. 

I thought may be we can add this to our chatterbot module. So this is the reason why i created this pull request.  Please checkout the code and if any queries feel free to ask. 

Thank you.