### PR TITLE
Use improved mathparse library for math evaluation logic adapter

### DIFF
--- a/chatterbot/logic/mathematical_evaluation.py
+++ b/chatterbot/logic/mathematical_evaluation.py
@@ -1,62 +1,28 @@
 from __future__ import unicode_literals
 from chatterbot.logic import LogicAdapter
 from chatterbot.conversation import Statement
-import re
-import json
-import math
-import decimal
 
 
 class MathematicalEvaluation(LogicAdapter):
     """
-    The MathematicalEvaluation logic adapter parses input to
-    determine whether the user is asking a question that requires
-    math to be done. If so, MathematicalEvaluation goes through a
-    set of steps to parse the input and extract the equation that
-    must be solved. The steps, in order, are:
+    The MathematicalEvaluation logic adapter parses input to determine
+    whether the user is asking a question that requires math to be done.
+    If so, the equation is extracted from the input and returned with
+    the evaluated result.
 
-    1) Normalize input: Remove punctuation and other irrelevant data
-    2) Convert words to numbers
-    3) Extract the equation
-    4) Simplify the equation
-    5) Solve the equation & return result
+    For example:
+        User: 'What is three plus five?'
+        Bot: 'Three plus five equals eight'
+
+    Arguments:
+        - language: The language is set to 'ENG' for English by default.
     """
-    functions = {
-        'sqrt': math.sqrt,
-
-        # Most people assume a log of base 10 when a base is not specified
-        'log': math.log10
-    }
 
     def __init__(self, **kwargs):
         super(MathematicalEvaluation, self).__init__(**kwargs)
 
-        language = kwargs.get('math_words_language', 'english')
-        self.math_words = self.get_language_data(language)
+        self.language = kwargs.get('language', 'ENG')
         self.cache = {}
-
-    def get_language_data(self, language):
-        """
-        Load language-specific data
-        """
-        from chatterbot.corpus import Corpus
-
-        corpus = Corpus()
-
-        math_words_data_file_path = corpus.get_file_path(
-            'chatterbot.corpus.{}.math_words'.format(language),
-            extension='json'
-        )
-
-        try:
-            with open(math_words_data_file_path) as data:
-                return json.load(data)
-        except IOError:
-            raise self.UnrecognizedLanguageException(
-                'A math_words data file was not found for `{}` at `{}`.'.format(
-                    language, math_words_data_file_path
-                )
-            )
 
     def can_process(self, statement):
         """
@@ -70,9 +36,10 @@ class MathematicalEvaluation(LogicAdapter):
     def process(self, statement):
         """
         Takes a statement string.
-        Returns the simplified statement string
-        with the mathematical terms solved.
+        Returns the equation from the statement with the mathematical terms solved.
         """
+        from mathparse import mathparse
+
         input_text = statement.text
 
         # Use the result cached by the process method if it exists
@@ -82,184 +49,18 @@ class MathematicalEvaluation(LogicAdapter):
             return cached_result
 
         # Getting the mathematical terms within the input statement
-        expression = str(self.simplify_chunks(self.normalize(input_text)))
+        expression = mathparse.extract_expression(input_text, language=self.language)
 
         response = Statement(text=expression)
 
         try:
-            response.text += '= ' + str(
-                eval(expression, {f: self.functions[f] for f in self.functions})
+            response.text += ' = ' + str(
+                mathparse.parse(expression, language=self.language)
             )
-
-            # Replace '**' with '^' for evaluated exponents
-            response.text = response.text.replace('**', '^')
 
             # The confidence is 1 if the expression could be evaluated
             response.confidence = 1
-        except:
+        except mathparse.PostfixTokenEvaluationException:
             response.confidence = 0
 
         return response
-
-    def simplify_chunks(self, input_text):
-        """
-        Separates the incoming text.
-        """
-        string = ''
-        chunks = re.split(r'([\w\.-]+|[\(\)\*\+])', input_text)
-        chunks = [chunk.strip() for chunk in chunks]
-        chunks = [chunk for chunk in chunks if chunk != '']
-
-        classifiers = [
-            'is_integer', 'is_float', 'is_operator', 'is_constant', 'is_function'
-        ]
-
-        for chunk in chunks:
-            for classifier in classifiers:
-                result = getattr(self, classifier)(chunk)
-                if result is not False:
-                    string += str(result) + ' '
-                    break
-
-        # Replace '^' with '**' to evaluate exponents
-        string = string.replace('^', '**')
-
-        return string
-
-    def is_float(self, string):
-        """
-        If the string is a float, returns
-        the float of the string. Otherwise,
-        it returns False.
-        """
-        try:
-            return decimal.Decimal(string)
-        except decimal.DecimalException:
-            return False
-
-    def is_integer(self, string):
-        """
-        If the string is an integer, returns
-        the int of the string. Otherwise,
-        it returns False.
-        """
-        try:
-            return int(string)
-        except:
-            return False
-
-    def is_constant(self, string):
-        """
-        If the string is a mathematical constant, returns
-        said constant. Otherwise, it returns False.
-        """
-        constants = {
-            'pi': 3.141693,
-            'e': 2.718281
-        }
-        return constants.get(string, False)
-
-    def is_function(self, string):
-        """
-        If the string is an availbale mathematical function, returns
-        said function. Otherwise, it returns False.
-        """
-        if string in self.functions:
-            return string
-        else:
-            return False
-
-    def is_operator(self, string):
-        """
-        If the string is an operator, returns
-        said operator. Otherwise, it returns false.
-        """
-        if string in '+-/*^()':
-            return string
-        else:
-            return False
-
-    def normalize(self, string):
-        """
-        Normalizes input text, reducing errors
-        and improper calculations.
-        """
-
-        # If the string is empty, just return it
-        if len(string) is 0:
-            return string
-
-        # Setting all words to lowercase
-        string = string.lower()
-
-        # Removing punctuation
-        if not string[-1].isalnum():
-            string = string[:-1]
-
-        # Removing words
-        string = self.substitute_words(string)
-
-        # Returning normalized text
-        return string
-
-    def substitute_words(self, string):
-        """
-        Substitutes numbers for words.
-        """
-        condensed_string = '_'.join(string.split())
-
-        for word in self.math_words['words']:
-            condensed_string = re.sub(
-                '_'.join(word.split(' ')),
-                self.math_words['words'][word],
-                condensed_string
-            )
-
-        for number in self.math_words['numbers']:
-            condensed_string = re.sub(
-                number,
-                str(self.math_words['numbers'][number]),
-                condensed_string
-            )
-
-        for scale in self.math_words['scales']:
-            condensed_string = re.sub(
-                '_' + scale,
-                ' ' + self.math_words['scales'][scale],
-                condensed_string
-            )
-
-        condensed_string = condensed_string.split('_')
-        for chunk_index in range(0, len(condensed_string)):
-            value = ''
-
-            try:
-                value = str(eval(condensed_string[chunk_index]))
-
-                condensed_string[chunk_index] = value
-            except:
-                pass
-
-        for chunk_index in range(0, len(condensed_string)):
-            condensed_chunk = condensed_string[chunk_index]
-            if self.is_integer(condensed_chunk) or self.is_float(condensed_chunk):
-                i = 1
-                start_index = chunk_index
-                end_index = -1
-                while (chunk_index + i < len(condensed_string) and (self.is_integer(condensed_string[chunk_index + i]) or self.is_float(condensed_string[chunk_index + i]))):
-                    end_index = chunk_index + i
-                    i += 1
-
-                for sub_chunk in range(start_index, end_index):
-                    condensed_string[sub_chunk] += ' +'
-
-                condensed_string[start_index] = '( ' + condensed_string[start_index]
-                condensed_string[end_index] += ' )'
-
-        return ' '.join(condensed_string)
-
-    class UnrecognizedLanguageException(Exception):
-        """
-        Exception raised when the specified language is not known.
-        """
-        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-chatterbot-corpus>=1.0,<1.1
+chatterbot-corpus>=1.1,<1.2
 jsondatabase>=0.1.7,<1.0.0
+mathparse>=0.1,<0.2
 nltk>=3.2,<4.0
 pymongo>=3.3,<4.0
 python-dateutil>=2.6,<2.7

--- a/tests/logic_adapter_tests/test_mathematical_evaluation.py
+++ b/tests/logic_adapter_tests/test_mathematical_evaluation.py
@@ -6,12 +6,7 @@ from chatterbot.conversation import Statement
 class MathematicalEvaluationTests(TestCase):
 
     def setUp(self):
-        import sys
-
         self.adapter = MathematicalEvaluation()
-
-        # Some tests may return decimals under python 3
-        self.python_version = sys.version_info[0]
 
     def test_can_process(self):
         statement = Statement('What is 10 + 10 + 10?')
@@ -81,10 +76,7 @@ class MathematicalEvaluationTests(TestCase):
         statement = Statement('What is one thousand two hundred four divided by one hundred?')
         response = self.adapter.process(statement)
 
-        if self.python_version <= 2:
-            self.assertEqual(response.text, 'one thousand two hundred four divided by one hundred = 12')
-        else:
-            self.assertEqual(response.text, 'one thousand two hundred four divided by one hundred = 12.04')
+        self.assertEqual(response.text, 'one thousand two hundred four divided by one hundred = 12.04')
 
         self.assertEqual(response.confidence, 1)
 

--- a/tests/logic_adapter_tests/test_mathematical_evaluation.py
+++ b/tests/logic_adapter_tests/test_mathematical_evaluation.py
@@ -6,7 +6,12 @@ from chatterbot.conversation import Statement
 class MathematicalEvaluationTests(TestCase):
 
     def setUp(self):
+        import sys
+
         self.adapter = MathematicalEvaluation()
+
+        # Some tests may return decimals under python 3
+        self.python_version = sys.version_info[0]
 
     def test_can_process(self):
         statement = Statement('What is 10 + 10 + 10?')
@@ -16,112 +21,60 @@ class MathematicalEvaluationTests(TestCase):
         statement = Statement('What is your favorite song?')
         self.assertFalse(self.adapter.can_process(statement))
 
-    def test_is_integer(self):
-        self.assertTrue(self.adapter.is_integer(42))
-
-    def test_is_float(self):
-        self.assertTrue(self.adapter.is_float(0.5))
-
-    def test_is_operator(self):
-        self.assertTrue(self.adapter.is_operator('+'))
-
-    def test_is_not_operator(self):
-        self.assertFalse(self.adapter.is_operator('9'))
-
-    def test_normalize_empty_string(self):
-        """
-        If a string is empty, the string should be returned.
-        """
-        self.assertEqual(self.adapter.normalize(''), '')
-
-    def test_normalize_text_to_lowercase(self):
-        normalized = self.adapter.normalize('HELLO')
-        self.assertTrue(normalized.islower())
-
-    def test_normalize_punctuation(self):
-        normalized = self.adapter.normalize('the end.')
-        self.assertEqual(normalized, 'the end')
-
-    def test_load_english_data(self):
-        self.adapter.get_language_data('english')
-        self.assertIn('numbers', self.adapter.math_words)
-
-    def test_load_nonexistent_data(self):
-        with self.assertRaises(MathematicalEvaluation.UnrecognizedLanguageException):
-            self.adapter.get_language_data('0101010')
-
-
-class MathematicalEvaluationOperationTests(TestCase):
-
-    def setUp(self):
-        import sys
-
-        self.adapter = MathematicalEvaluation()
-
-        # Some tests may return decimals under python 3
-        self.python_version = sys.version_info[0]
-
     def test_addition_operator(self):
         statement = Statement('What is 100 + 54?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( 100 + 54 ) = 154')
+        self.assertEqual(response.text, '100 + 54 = 154')
         self.assertEqual(response.confidence, 1)
 
     def test_subtraction_operator(self):
         statement = Statement('What is 100 - 58?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( 100 - 58 ) = 42')
+        self.assertEqual(response.text, '100 - 58 = 42')
         self.assertEqual(response.confidence, 1)
 
     def test_multiplication_operator(self):
         statement = Statement('What is 100 * 20')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( 100 * 20 ) = 2000')
+        self.assertEqual(response.text, '100 * 20 = 2000')
         self.assertEqual(response.confidence, 1)
 
     def test_division_operator(self):
         statement = Statement('What is 100 / 20')
         response = self.adapter.process(statement)
-        self.assertEqual(response.confidence, 1)
 
-        if self.python_version <= 2:
-            self.assertEqual(response.text, '( 100 / 20 ) = 5')
-        else:
-            self.assertEqual(response.text, '( 100 / 20 ) = 5.0')
+        self.assertEqual(response.text, '100 / 20 = 5')
+        self.assertEqual(response.confidence, 1)
 
     def test_exponent_operator(self):
         statement = Statement('What is 2 ^ 10')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( 2 ^ 10 ) = 1024')
+        self.assertEqual(response.text, '2 ^ 10 = 1024')
         self.assertEqual(response.confidence, 1)
 
     def test_parenthesized_multiplication_and_addition(self):
         statement = Statement('What is 100 + ( 1000 * 2 )?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( 100 + ( ( 1000 * ( 2 ) ) ) ) = 2100')
+        self.assertEqual(response.text, '100 + ( 1000 * 2 ) = 2100')
         self.assertEqual(response.confidence, 1)
 
     def test_parenthesized_with_words(self):
         statement = Statement('What is four plus 100 + ( 100 * 2 )?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( 4 + ( 100 + ( ( 100 * ( 2 ) ) ) ) ) = 304')
+        self.assertEqual(response.text, 'four plus 100 + ( 100 * 2 ) = 304')
         self.assertEqual(response.confidence, 1)
 
     def test_word_numbers_addition(self):
         statement = Statement('What is one hundred + four hundred?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( 100 + 400 ) = 500')
+        self.assertEqual(response.text, 'one hundred + four hundred = 500')
         self.assertEqual(response.confidence, 1)
 
     def test_word_division_operator(self):
         statement = Statement('What is 100 divided by 100?')
         response = self.adapter.process(statement)
 
-        if self.python_version <= 2:
-            self.assertEqual(response.text, '( 100 / 100 ) = 1')
-        else:
-            self.assertEqual(response.text, '( 100 / 100 ) = 1.0')
-
+        self.assertEqual(response.text, '100 divided by 100 = 1')
         self.assertEqual(response.confidence, 1)
 
     def test_large_word_division_operator(self):
@@ -129,44 +82,44 @@ class MathematicalEvaluationOperationTests(TestCase):
         response = self.adapter.process(statement)
 
         if self.python_version <= 2:
-            self.assertEqual(response.text, '( 1000 + 200 + 4 ) / ( 100 ) = 12')
+            self.assertEqual(response.text, 'one thousand two hundred four divided by one hundred = 12')
         else:
-            self.assertEqual(response.text, '( 1000 + 200 + 4 ) / ( 100 ) = 12.04')
+            self.assertEqual(response.text, 'one thousand two hundred four divided by one hundred = 12.04')
 
         self.assertEqual(response.confidence, 1)
 
     def test_negative_multiplication(self):
         statement = Statement('What is -105 * 5')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( -105 * 5 ) = -525')
+        self.assertEqual(response.text, '-105 * 5 = -525')
         self.assertEqual(response.confidence, 1)
 
     def test_negative_decimal_multiplication(self):
         statement = Statement('What is -100.5 * 20?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '( -100.5 * 20 ) = -2010.0')
+        self.assertEqual(response.text, '-100.5 * 20 = -2010.0')
         self.assertEqual(response.confidence, 1)
 
     def test_pi_constant(self):
         statement = Statement('What is pi plus one ?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '3.141693 + ( 1 ) = 4.141693')
+        self.assertEqual(response.text, 'pi plus one = 4.141693')
         self.assertEqual(response.confidence, 1)
 
     def test_e_constant(self):
         statement = Statement('What is e plus one ?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, '2.718281 + ( 1 ) = 3.718281')
+        self.assertEqual(response.text, 'e plus one = 3.718281')
         self.assertEqual(response.confidence, 1)
 
     def test_log_function(self):
         statement = Statement('What is log 100 ?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, 'log ( 100 ) = 2.0')
+        self.assertEqual(response.text, 'log 100 = 2.0')
         self.assertEqual(response.confidence, 1)
 
     def test_square_root_function(self):
         statement = Statement('What is the sqrt 144 ?')
         response = self.adapter.process(statement)
-        self.assertEqual(response.text, 'sqrt ( 144 ) = 12.0')
+        self.assertEqual(response.text, 'sqrt 144 = 12.0')
         self.assertEqual(response.confidence, 1)

--- a/tests_django/integration_tests/test_logic_adapter_integration.py
+++ b/tests_django/integration_tests/test_logic_adapter_integration.py
@@ -59,7 +59,7 @@ class LogicIntegrationTestCase(TestCase):
 
         response = adapter.process(statement)
 
-        self.assertEqual(response.text, '( 6 + 6 ) = 12')
+        self.assertEqual(response.text, '6 + 6 = 12')
         self.assertEqual(response.confidence, 1)
 
     def test_time(self):


### PR DESCRIPTION
This pull request switches ChatterBot's mathematical evaluation logic adapter to use the Mathparse library (https://github.com/gunthercox/mathparse/)

Mathparse is a new library that is designed to efficiently handle the process of evaluating natural mathematical language.

***

Related to #1016