### PR TITLE
Support for Django 2.0

### DIFF
--- a/chatterbot/ext/django_chatterbot/abstract_models.py
+++ b/chatterbot/ext/django_chatterbot/abstract_models.py
@@ -155,12 +155,14 @@ class AbstractBaseResponse(models.Model):
 
     statement = models.ForeignKey(
         STATEMENT_MODEL,
-        related_name='in_response'
+        related_name='in_response',
+        on_delete=models.CASCADE
     )
 
     response = models.ForeignKey(
         STATEMENT_MODEL,
-        related_name='responses'
+        related_name='responses',
+        on_delete=models.CASCADE
     )
 
     created_at = models.DateTimeField(


### PR DESCRIPTION
From Django 2.0 Release [note](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0)...

> The on_delete argument for ForeignKey and OneToOneField is now required in models and migrations. Consider squashing migrations so that you have less of them to update.

So on_delete must needed in ForeignKey so update to Django 2.0 won't break the development. 
