### PR TITLE
Speed up matching with mongodb

### DIFF
--- a/chatterbot/logic/best_match.py
+++ b/chatterbot/logic/best_match.py
@@ -13,7 +13,7 @@ class BestMatch(LogicAdapter):
         Takes a statement string and a list of statement strings.
         Returns the closest matching statement from the list.
         """
-        statement_list = self.chatbot.storage.get_response_statements()
+        statement_list = self.chatbot.storage.get_response_statements(input_statement)
 
         if not statement_list:
             if self.chatbot.storage.count():

--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -199,7 +199,7 @@ class DjangoStorageAdapter(StorageAdapter):
         Response.objects.all().delete()
         Conversation.objects.all().delete()
 
-    def get_response_statements(self):
+    def get_response_statements(self,input_statement=""):
         """
         Return only statements that are in response to another statement.
         A statement must exist which lists the closest matching statement in the

--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -199,7 +199,7 @@ class DjangoStorageAdapter(StorageAdapter):
         Response.objects.all().delete()
         Conversation.objects.all().delete()
 
-    def get_response_statements(self,input_statement=""):
+    def get_response_statements(self, input_statement=""):
         """
         Return only statements that are in response to another statement.
         A statement must exist which lists the closest matching statement in the

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -358,7 +358,7 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         self.statements.delete_one({'text': statement_text})
 
-    def get_response_statements(self,input_statement=""):
+    def get_response_statements(self, input_statement=""):
         """
         Return only statements that are in response to another statement.
         A statement must exist which lists the closest matching statement in the
@@ -379,25 +379,24 @@ class MongoDatabaseAdapter(StorageAdapter):
                 '$in': responses
             }
         }
-        
+
         import jieba.analyse as al
-        word_topk = al.extract_tags(input_statement.text,topK=4)
-        reg_str=u"|".join(word_topk)
-        
+        word_topk = al.extract_tags(input_statement.text, topK=4)
+        reg_str = u"|".join(word_topk)
+
         if reg_str != "":
             _statement_query = {
                 '$and':
                 [
                     {
                         'text': {
-                        '$in': responses
+                            '$in': responses
                         }
-                    }
-                    ,
+                    },
                     {
-                        'text':{
-                        '$regex':reg_str,
-                        '$options': 'i'
+                        'text': {
+                            '$regex': reg_str,
+                            '$options': 'i'
                         }
                     }                    
                 ]

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -358,7 +358,7 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         self.statements.delete_one({'text': statement_text})
 
-    def get_response_statements(self):
+    def get_response_statements(self,input_statement=""):
         """
         Return only statements that are in response to another statement.
         A statement must exist which lists the closest matching statement in the

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -379,6 +379,29 @@ class MongoDatabaseAdapter(StorageAdapter):
                 '$in': responses
             }
         }
+        
+        import jieba.analyse as al
+        word_topk = al.extract_tags(input_statement.text,topK=4)
+        reg_str=u"|".join(word_topk)
+        
+        if reg_str != "":
+            _statement_query = {
+                '$and':
+                [
+                    {
+                        'text': {
+                        '$in': responses
+                        }
+                    }
+                    ,
+                    {
+                        'text':{
+                        '$regex':reg_str,
+                        '$options': 'i'
+                        }
+                    }                    
+                ]
+            }
 
         _statement_query.update(self.base_query.value())
         statement_query = self.statements.find(_statement_query)

--- a/chatterbot/storage/storage_adapter.py
+++ b/chatterbot/storage/storage_adapter.py
@@ -129,7 +129,7 @@ class StorageAdapter(object):
             'The `drop` method is not implemented by this adapter.'
         )
 
-    def get_response_statements(self):
+    def get_response_statements(self,input_statement=""):
         """
         Return only statements that are in response to another statement.
         A statement must exist which lists the closest matching statement in the

--- a/chatterbot/storage/storage_adapter.py
+++ b/chatterbot/storage/storage_adapter.py
@@ -129,7 +129,7 @@ class StorageAdapter(object):
             'The `drop` method is not implemented by this adapter.'
         )
 
-    def get_response_statements(self,input_statement=""):
+    def get_response_statements(self, input_statement=""):
         """
         Return only statements that are in response to another statement.
         A statement must exist which lists the closest matching statement in the

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pymongo>=3.3,<4.0
 python-dateutil>=2.6,<2.7
 python-twitter>=3.0,<4.0
 sqlalchemy>=1.1,<1.2
+jieba>=0.39,<1.0


### PR DESCRIPTION
Using jieba to extact input tags,before best_match.

For example, suppose there are 10000+ corpus in mongo, while user_input is "where is the apple?"

Before:
The best_match logic get all the corpus in mongo (distinct by in_reponse.text) , the size is about 10000 .Then we compare all this corpus with input. This takes a lot time.

After:
This pull extracts tags of the input. for this example,tags are maybe "apple". Then we add a addtional search option to mongo, using regex ,to select the corpus only related with "apple". the size is more less than 10000 (maybe only 100). Then we compare this 100 corpus with input. This is more fast than before.

Notice:

1.JiaBa required.
2.Best perfomance with Chinese, compatible with english.
3.The first time we load jieba takes about 2s,for each bot.