### PR TITLE
Documentation updates

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -63,6 +63,17 @@ ChatterBot data can be saved and retrieved from SQL databases.
 .. literalinclude:: ../examples/sql/memory_sql_example.py
    :language: python
 
+Read only mode
+==============
+
+Your chat bot will learn based on each new input statement it receives.
+If you want to disable this learning feature after your bot has been trained,
+you can set `read_only=True` as a parameter when initializing the bot.
+
+.. code-block:: python
+
+   chatbot = ChatBot("Johnny Five", read_only=True)
+
 More Examples
 =============
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -65,14 +65,3 @@ Get a response
 
    response = chatbot.get_response("Good morning!")
    print(response)
-
-Read only mode
-==============
-
-Your ChatterBot will learn based on each new input statement it receives.
-If you want to disable this learning feature after your bot has been trained,
-you can set `read_only=True` as a parameter when initializing the bot.
-
-.. code-block:: python
-
-   chatbot = ChatBot("Johnny Five", read_only=True)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -2,13 +2,21 @@
 Quick Start Guide
 =================
 
+The first thing you'll need to do to get started is install ChatterBot.
+
+.. code-block:: bash
+
+   pip install chatterbot
+
+See :ref:`Installation` for options for alternative installation methods.
+
 Create a new chat bot
 =====================
 
 .. note::
 
    If you are using Python 2.7, be sure that the unicode header is the first line of
-   your Python file: :code:`# -*- coding: utf-8 -*-`
+   your Python file: ``# -*- coding: utf-8 -*-``
 
 .. code-block:: python
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -2,18 +2,22 @@
 Releasing ChatterBot
 ====================
 
+ChatterBot follows the following rules when it comes to new versions and updates.
+
+Versioning
+==========
+
 ChatterBot follows semantic versioning as a set of guidelines for release versions.
 
-- **Major** releases (2.0.0, 3.0.0, etc.) are used for large, potentially
-  backwards incompatible changes.
+- **Major** releases (2.0.0, 3.0.0, etc.) are used for large, almost
+  entirely backwards incompatible changes.
 
 - **Minor** releases (2.1.0, 2.2.0, 3.1.0, 3.2.0, etc.) are used for
-  releases that contain features and dependency changes.
+  releases that contain small, backwards incompatible changes. Known
+  backwards incompatibilities will be described in the release notes.
 
-- **Patch** releases (e.g., 2.1.1, 2.1.2, 3.0.1, 3.0.10, etc.) are used for
-  releases that contain *only* bug fixes.
-
-These rules are adhered to as much as possible but sometimes mistakes are made.
+- **Patch** releases (e.g., 2.1.1, 2.1.2, 3.0.1, 3.0.10, etc.) are used
+  for releases that contain bug fixes, features and dependency changes.
 
 
 Release Process

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -13,6 +13,17 @@ to chat with other ChatterBot users who might be able to help.
 If you believe that you have encountered an error in ChatterBot, please open a
 ticket on GitHub: https://github.com/gunthercox/ChatterBot/issues/new
 
+Installing ChatterBot
+=====================
+
+You can install ChatterBot on your system using Python's pip command.
+
+.. code-block:: bash
+
+   pip install chatterbot
+
+See :ref:`Installation` for alternative installation options.
+
 Creating your first chat bot
 ============================
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -4,7 +4,7 @@ Upgrading to Newer Releases
 
 Like any software, changes will be made to ChatterBot over time.
 Most of these changes are improvements. Frequently, you don't have
-to change anything in your code to benifit from a new release.
+to change anything in your code to benefit from a new release.
 
 Occasionally there are changes that will require modifications in
 your code or there will be changes that make it possible for you
@@ -21,3 +21,5 @@ installation by providing the --upgrade parameter:
 .. code-block:: bash
 
    pip install chatterbot --upgrade
+
+Also see :ref:`Versioning` for information about ChatterBot's versioning policy.


### PR DESCRIPTION
This adds a few links to connect pages in ways that might be helpful. Instructions to install ChatterBot have been added to the tutorial and quick start guide.