### PR TITLE
Remove unused requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 chatterbot-corpus>=1.1,<1.2
-jsondatabase>=0.1.7,<1.0.0
 mathparse>=0.1,<0.2
 nltk>=3.2,<4.0
 pymongo>=3.3,<4.0


### PR DESCRIPTION
The jsondatabase requirement is no longer used in ChatterBot.