### PR TITLE
Fixed performance issue of Levenshtein distance comparison when python-Levenshtein is not pre-installed

### DIFF
--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     from difflib import SequenceMatcher
 
+
 class Comparator:
 
     def __call__(self, statement_a, statement_b):

--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
+import sys
+
 
 """
 This module contains various text-comparison algorithms
 designed to compare one statement to another.
 """
 
+# Use python-Levenshtein if available
+try:
+    from Levenshtein.StringMatcher import StringMatcher as SequenceMatcher
+except ImportError:
+    from difflib import SequenceMatcher
 
 class Comparator:
 
@@ -49,13 +56,6 @@ class LevenshteinDistance(Comparator):
         :return: The percent of similarity between the text of the statements.
         :rtype: float
         """
-        import sys
-
-        # Use python-Levenshtein if available
-        try:
-            from Levenshtein.StringMatcher import StringMatcher as SequenceMatcher
-        except ImportError:
-            from difflib import SequenceMatcher
 
         PYTHON = sys.version_info[0]
 


### PR DESCRIPTION
### Problem
When python-Levenshtein library is not pre-installed, the following logic in best_match is pretty slow:
```
# Find the closest matching known statement
for statement in statement_list:
    confidence = self.compare_statements(input_statement, statement)

    if confidence > closest_match.confidence:
        statement.confidence = confidence
        closest_match = statement
```

The problem is similar as [https://github.com/gunthercox/ChatterBot/issues/679](https://github.com/gunthercox/ChatterBot/issues/679).

### Reason
try... except... block to check whether use difflib or python-Levenshtein has performance issue in iteration loop if it always enter except block. see: [http://paltman.com/try-except-performance-in-python-a-simple-test/](http://paltman.com/try-except-performance-in-python-a-simple-test/)

### Resolve
Move the try... except... block out of function scope.
