### PR TITLE
Removing support for redundant database connection parameters (#939)

### DIFF
--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -1,5 +1,4 @@
 from chatterbot.storage import StorageAdapter
-import re
 
 
 class Query(object):
@@ -87,7 +86,7 @@ class MongoDatabaseAdapter(StorageAdapter):
             'database_uri', 'mongodb://localhost:27017/'
         )
 
-        self._database_name = re.sub(r'\W+', '', self.database_uri)
+        self._database_name = "chatterbot-database"
 
         # Use the default host and port
         self.client = MongoClient(self.database_uri)

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -86,8 +86,7 @@ class MongoDatabaseAdapter(StorageAdapter):
             'database_uri', 'mongodb://localhost:27017/'
         )
 
-        re.compile('[a-zA-z]]')
-        self._database_name = re.sub("", self.database_uri)
+        self._database_name = re.sub(r'\W+', '', self.database_uri)
 
         # Use the default host and port
         self.client = MongoClient(self.database_uri)

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -1,6 +1,7 @@
 from chatterbot.storage import StorageAdapter
 import re
 
+
 class Query(object):
 
     def __init__(self, query={}):

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -1,5 +1,5 @@
 from chatterbot.storage import StorageAdapter
-
+import re
 
 class Query(object):
 
@@ -82,15 +82,15 @@ class MongoDatabaseAdapter(StorageAdapter):
         from pymongo import MongoClient
         from pymongo.errors import OperationFailure
 
-        self.database_name = self.kwargs.get(
-            'database', 'chatterbot-database'
-        )
         self.database_uri = self.kwargs.get(
             'database_uri', 'mongodb://localhost:27017/'
         )
 
+        re.compile('[a-zA-z]]')
+        self._database_name = re.sub("",self.database_uri)
+
         # Use the default host and port
-        self.client = MongoClient(self.database_uri)
+        self.client = MongoClient(self._database_name)
 
         # Increase the sort buffer to 42M if possible
         try:
@@ -99,7 +99,8 @@ class MongoDatabaseAdapter(StorageAdapter):
             pass
 
         # Specify the name of the database
-        self.database = self.client[self.database_name]
+        # By convention self.database_uri is the name of the database. Refer to ticket #939
+        self.database = self.client[self.database_uri]
 
         # The mongo collection of statement documents
         self.statements = self.database['statements']
@@ -391,4 +392,4 @@ class MongoDatabaseAdapter(StorageAdapter):
         """
         Remove the database.
         """
-        self.client.drop_database(self.database_name)
+        self.client.drop_database(self._database_name)

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -87,10 +87,10 @@ class MongoDatabaseAdapter(StorageAdapter):
         )
 
         re.compile('[a-zA-z]]')
-        self._database_name = re.sub("",self.database_uri)
+        self._database_name = re.sub("", self.database_uri)
 
         # Use the default host and port
-        self.client = MongoClient(self._database_name)
+        self.client = MongoClient(self.database_uri)
 
         # Increase the sort buffer to 42M if possible
         try:
@@ -100,7 +100,7 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         # Specify the name of the database
         # By convention self.database_uri is the name of the database. Refer to ticket #939
-        self.database = self.client[self.database_uri]
+        self.database = self.client[self._database_name]
 
         # The mongo collection of statement documents
         self.statements = self.database['statements']

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -43,19 +43,9 @@ class SQLStorageAdapter(StorageAdapter):
 
         default_uri = "sqlite:///db.sqlite3"
 
-        database_name = self.kwargs.get("database", False)
-
-        # None results in a sqlite in-memory database as the default
-        if database_name is None:
-            default_uri = "sqlite://"
-
         self.database_uri = self.kwargs.get(
             "database_uri", default_uri
         )
-
-        # Create a sqlite file if a database name is provided
-        if database_name:
-            self.database_uri = "sqlite:///" + database_name
 
         self.engine = create_engine(self.database_uri, convert_unicode=True)
 


### PR DESCRIPTION
Now database parameter is not longer supported by MongoDB and SQL adapters.

In the case of MongoDB, database_name was kept as local variable to have a clean reference for datase other than the pure database_uri (to avoid non-alphanumeric characters in file name).