### PR TITLE
Update python and requirement test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: pip
 
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: pip
 
 python:
   - '2.7'
-  - '3.5'
+  - '3.6'
 
 os:
   - linux

--- a/examples/django_app/requirements.txt
+++ b/examples/django_app/requirements.txt
@@ -1,2 +1,2 @@
-django>=1.8.0,<2.0.0
-chatterbot>=0.5.0
+django>=1.8,<2.0
+chatterbot>=0.8

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,7 @@ passenv = DJANGO_SETTINGS_MODULE NLTK_DATA PYTHONPATH HOME DISPLAY
 setenv = PYTHONDONTWRITEBYTECODE=1
 deps =
   django18: Django>=1.8,<1.9
-  django19: Django>=1.9,<1.10
-  django110: Django>=1.10,<1.11
+  django111: Django>=1.11,<1.12
   -rrequirements.txt
   -rdev-requirements.txt
 
@@ -22,13 +21,7 @@ commands =
   python runtests.py
   python examples/django_app/manage.py test examples/django_app/
 
-[testenv:django19]
-commands =
-  python setup.py develop --no-deps
-  python runtests.py
-  python examples/django_app/manage.py test examples/django_app/
-
-[testenv:django110]
+[testenv:django111]
 commands =
   python setup.py develop --no-deps
   python runtests.py


### PR DESCRIPTION
This pull request makes a few changes to update test requirement versions (such as Django 1.11 and Python 3.6) and also trims off some versions that _probably_ don't need to be tested against (such as Django 1.10).