### PR TITLE
Fix logic adapter kwargs

### DIFF
--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -22,7 +22,7 @@ def initialize_class(data, **kwargs):
     :param data: A string or dictionary containing a import_path attribute.
     """
     if isinstance(data, dict):
-        import_path = data.pop('import_path')
+        import_path = data.get('import_path')
         data.update(kwargs)
         Class = import_module(import_path)
 

--- a/tests_django/test_settings.py
+++ b/tests_django/test_settings.py
@@ -23,6 +23,14 @@ CHATTERBOT = {
     'training_data': [
         'chatterbot.corpus.english.greetings'
     ],
+    'logic_adapters': [
+        {
+            'import_path': 'chatterbot.logic.BestMatch',
+        },
+        {
+            'import_path': 'chatterbot.logic.MathematicalEvaluation',
+        }
+    ],
     'initialize': False
 }
 


### PR DESCRIPTION
This corrects an issue specific to the expanded notation that can be used to pass additional parameters to logic adapters.

Closes #1092
Closes #1012 
Closes #1157