### PR TITLE
Fix "Statement matching query does not exist" error

### DIFF
--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -181,8 +181,8 @@ class DjangoStorageAdapter(StorageAdapter):
         Statement = self.get_model('statement')
         Response = self.get_model('response')
 
-        first_statement = Statement.objects.get(text=statement.text)
-        first_response = Statement.objects.get(text=response.text)
+        first_statement, created = Statement.objects.get_or_create(text=statement.text)
+        first_response, created = Statement.objects.get_or_create(text=response.text)
 
         response = Response.objects.create(
             statement=first_statement,


### PR DESCRIPTION
When using a logic adapter, if an unknown statement was given in Django project,  `chatterbot.ext.django_chatterbot.models.DoesNotExist: Statement matching query does not exist.` error used to pop up.  Happens in `chatterbot.logic.LowConfidenceAdapter` for default response and the other logic adapters as well.