### PR TITLE
Datetime parsing does recognize am or pm

### DIFF
--- a/chatterbot/parsing.py
+++ b/chatterbot/parsing.py
@@ -558,7 +558,14 @@ def date_from_relative_week_year(base_date, time, dow, ordinal=1):
         elif time == 'last' or time == 'previous':
             return datetime(relative_date.year, relative_date.month - 1, relative_date.day)
         elif time == 'next' or time == 'following':
-            return datetime(relative_date.year, relative_date.month + ord, relative_date.day)
+            if relative_date.month + ord >= 12:
+                month = relative_date.month - 1 + ord
+                year = relative_date.year + month // 12
+                month = month % 12 + 1
+                day = min(relative_date.day, calendar.monthrange(year, month)[1])
+                return datetime(year, month, day)
+            else:
+                return datetime(relative_date.year, relative_date.month + ord, relative_date.day)
         elif time == 'end of the':
             return datetime(
                 relative_date.year,

--- a/chatterbot/parsing.py
+++ b/chatterbot/parsing.py
@@ -206,7 +206,7 @@ regex = [
         ),
         lambda m, base_date: date_from_relative_week_year(
             base_date,
-            m.group('time'),
+            m.group('time').lower(),
             m.group('dmy'),
             m.group('number')
         ) + timedelta(**convert_time_to_hour_minute(
@@ -227,7 +227,7 @@ regex = [
         ),
         lambda m, base_date: date_from_relative_day(
             base_date,
-            m.group('time'),
+            m.group('time').lower(),
             m.group('dow')
         ) + timedelta(**convert_time_to_hour_minute(
             m.group('hour'),
@@ -549,7 +549,7 @@ def date_from_relative_week_year(base_date, time, dow, ordinal=1):
         elif time == 'last' or time == 'previous':
             return datetime(relative_date.year - 1, relative_date.month, 1)
         elif time == 'next' or time == 'following':
-            return relative_date + timedelta(relative_date.year + ord)
+            return relative_date + timedelta(ord*365)
         elif time == 'end of the':
             return datetime(relative_date.year, 12, 31)
     elif dow in month_variations:

--- a/chatterbot/parsing.py
+++ b/chatterbot/parsing.py
@@ -542,13 +542,14 @@ def date_from_relative_week_year(base_date, time, dow, ordinal=1):
     # If there is an ordinal (next 3 weeks) => return a start and end range
     # Reset date to start of the day
     relative_date = datetime(base_date.year, base_date.month, base_date.day)
+    ord = convert_string_to_number(ordinal)
     if dow in year_variations:
         if time == 'this' or time == 'coming':
             return datetime(relative_date.year, 1, 1)
         elif time == 'last' or time == 'previous':
             return datetime(relative_date.year - 1, relative_date.month, 1)
         elif time == 'next' or time == 'following':
-            return relative_date + timedelta(relative_date.year + 1)
+            return relative_date + timedelta(relative_date.year + ord)
         elif time == 'end of the':
             return datetime(relative_date.year, 12, 31)
     elif dow in month_variations:
@@ -557,7 +558,7 @@ def date_from_relative_week_year(base_date, time, dow, ordinal=1):
         elif time == 'last' or time == 'previous':
             return datetime(relative_date.year, relative_date.month - 1, relative_date.day)
         elif time == 'next' or time == 'following':
-            return datetime(relative_date.year, relative_date.month + 1, relative_date.day)
+            return datetime(relative_date.year, relative_date.month + ord, relative_date.day)
         elif time == 'end of the':
             return datetime(
                 relative_date.year,
@@ -570,7 +571,7 @@ def date_from_relative_week_year(base_date, time, dow, ordinal=1):
         elif time == 'last' or time == 'previous':
             return relative_date - timedelta(weeks=1)
         elif time == 'next' or time == 'following':
-            return relative_date + timedelta(weeks=1)
+            return relative_date + timedelta(weeks=ord)
         elif time == 'end of the':
             day_of_week = base_date.weekday()
             return day_of_week + timedelta(days=6 - relative_date.weekday())
@@ -580,7 +581,7 @@ def date_from_relative_week_year(base_date, time, dow, ordinal=1):
         elif time == 'last' or time == 'previous':
             return relative_date - timedelta(days=1)
         elif time == 'next' or time == 'following':
-            return relative_date + timedelta(days=1)
+            return relative_date + timedelta(days=ord)
         elif time == 'end of the':
             return datetime(relative_date.year, relative_date.month, relative_date.day, 23, 59, 59)
 

--- a/chatterbot/parsing.py
+++ b/chatterbot/parsing.py
@@ -29,7 +29,7 @@ re_duration = '(before|after|earlier|later|ago|from\snow)'
 re_year = '(19|20)\d{2}|^(19|20)\d{2}'
 re_timeframe = 'this|coming|next|following|previous|last|end\sof\sthe'
 re_ordinal = 'st|nd|rd|th|first|second|third|fourth|fourth|' + re_timeframe
-re_time = r'(?P<hour>\d{1,2})(\:(?P<minute>\d{1,2})|(?P<convention>am|pm))'
+re_time = r'(?P<hour>\d{1,2})(\:(?P<minute>\d{1,2})(\sam|pm)?|\s?(?P<convention>am|pm))'
 re_separator = 'of|at|on'
 
 # A list tuple of regular expressions / parser fn to match
@@ -360,7 +360,7 @@ regex = [
     (
         re.compile(
             r'''
-            (%s) # Matches time 12:00
+            (%s) # Matches time 12:00 am or 12:00 pm
             ''' % (re_time),
             (re.VERBOSE | re.IGNORECASE),
         ),

--- a/chatterbot/parsing.py
+++ b/chatterbot/parsing.py
@@ -549,7 +549,7 @@ def date_from_relative_week_year(base_date, time, dow, ordinal=1):
         elif time == 'last' or time == 'previous':
             return datetime(relative_date.year - 1, relative_date.month, 1)
         elif time == 'next' or time == 'following':
-            return relative_date + timedelta(ord*365)
+            return relative_date + timedelta(ord * 365)
         elif time == 'end of the':
             return datetime(relative_date.year, 12, 31)
     elif dow in month_variations:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -179,6 +179,52 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
         self.assertEqual(parser[0][1][1].strftime('%d-%m-%Y'), '31-12-2015')
         self.assertEqual(len(parser), 1)
 
+    def test_captured_pattern_is_next_three_weeks(self):
+        input_text = 'Next 3 weeks'
+        parser = parsing.datetime_parsing(input_text)
+        relative_date = datetime(self.base_date.year, self.base_date.month, self.base_date.day) + timedelta(weeks=3)
+        self.assertIn(input_text, parser[0])
+        self.assertEqual(parser[0][1][0].strftime('%d-%m-%Y'),
+                         '{day}-{month}-{year}'.format(month=relative_date.day,
+                                                       day=relative_date.month,
+                                                       year=relative_date.year))
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_is_next_eight_days(self):
+        input_text = 'Next 8 days'
+        parser = parsing.datetime_parsing(input_text)
+        relative_date = datetime(self.base_date.year, self.base_date.month, self.base_date.day)
+        self.assertIn(input_text, parser[0])
+        self.assertEqual(parser[0][1][0].strftime('%d-%m-%Y'),
+                         '{day}-{month}-{year}'.format(month=relative_date.day + 8,
+                                                       day=relative_date.month,
+                                                       year=relative_date.year))
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_is_next_ten_years(self):
+        input_text = 'Next 10 years'
+        parser = parsing.datetime_parsing(input_text)
+        relative_date = datetime(self.base_date.year, self.base_date.month, self.base_date.day) + timedelta(
+            self.base_date.year + 10)
+        self.assertIn(input_text, parser[0])
+        self.assertEqual(parser[0][1][0].strftime('%d-%m-%Y'),
+                         '{day}-{month}-{year}'.format(day=relative_date.day,
+                                                       month=relative_date.month,
+                                                       year=relative_date.year))
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_is_next_eleven_months(self):
+        input_text = 'Next 11 months'
+        parser = parsing.datetime_parsing(input_text)
+        relative_date = datetime(self.base_date.year, self.base_date.month, self.base_date.day) + timedelta(
+            self.base_date.month + 11)
+        self.assertIn(input_text, parser[0])
+        self.assertEqual(parser[0][1][0].strftime('%d-%m-%Y'),
+                         '{day}-{month}-{year}'.format(day=relative_date.day,
+                                                       month=relative_date.month,
+                                                       year=relative_date.year))
+        self.assertEqual(len(parser), 1)
+
     def test_captured_pattern_is_on_day(self):
         input_text = 'My birthday is on January 2nd.'
         parser = parsing.datetime_parsing(input_text)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -6,7 +6,7 @@ from chatterbot import parsing
 
 class DateTimeParsingFunctionIntegrationTestCases(TestCase):
     """
-    Test the datetime parseing module.
+    Test the datetime parsing module.
 
     Output of the parser is an array of tuples
     [match, value, (start, end)]
@@ -182,47 +182,41 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
     def test_captured_pattern_is_next_three_weeks(self):
         input_text = 'Next 3 weeks'
         parser = parsing.datetime_parsing(input_text)
-        relative_date = datetime(self.base_date.year, self.base_date.month, self.base_date.day) + timedelta(weeks=3)
         self.assertIn(input_text, parser[0])
-        self.assertEqual(parser[0][1][0].strftime('%d-%m-%Y'),
-                         '{day}-{month}-{year}'.format(month=relative_date.day,
-                                                       day=relative_date.month,
-                                                       year=relative_date.year))
+        self.assertEqual(
+            parser[0][1].strftime('%d-%m-%Y'),
+            (datetime.today() + timedelta(weeks=3)).strftime('%d-%m-%Y')
+        )
         self.assertEqual(len(parser), 1)
 
     def test_captured_pattern_is_next_eight_days(self):
         input_text = 'Next 8 days'
         parser = parsing.datetime_parsing(input_text)
-        relative_date = datetime(self.base_date.year, self.base_date.month, self.base_date.day)
         self.assertIn(input_text, parser[0])
-        self.assertEqual(parser[0][1][0].strftime('%d-%m-%Y'),
-                         '{day}-{month}-{year}'.format(month=relative_date.day + 8,
-                                                       day=relative_date.month,
-                                                       year=relative_date.year))
+        self.assertEqual(
+            parser[0][1].strftime('%d-%m-%Y'),
+            (datetime.today() + timedelta(days=8)).strftime('%d-%m-%Y')
+        )
         self.assertEqual(len(parser), 1)
 
     def test_captured_pattern_is_next_ten_years(self):
         input_text = 'Next 10 years'
         parser = parsing.datetime_parsing(input_text)
-        relative_date = datetime(self.base_date.year, self.base_date.month, self.base_date.day) + timedelta(
-            self.base_date.year + 10)
-        self.assertIn(input_text, parser[0])
-        self.assertEqual(parser[0][1][0].strftime('%d-%m-%Y'),
-                         '{day}-{month}-{year}'.format(day=relative_date.day,
-                                                       month=relative_date.month,
-                                                       year=relative_date.year))
+        self.assertIn('Next 10 year', parser[0])
+        self.assertEqual(
+            parser[0][1].strftime('%d-%m-%Y'),
+            (datetime.today() + timedelta(10*365)).strftime('%d-%m-%Y')
+        )
         self.assertEqual(len(parser), 1)
 
     def test_captured_pattern_is_next_eleven_months(self):
         input_text = 'Next 11 months'
         parser = parsing.datetime_parsing(input_text)
-        relative_date = datetime(self.base_date.year, self.base_date.month, self.base_date.day) + timedelta(
-            self.base_date.month + 11)
-        self.assertIn(input_text, parser[0])
-        self.assertEqual(parser[0][1][0].strftime('%d-%m-%Y'),
-                         '{day}-{month}-{year}'.format(day=relative_date.day,
-                                                       month=relative_date.month,
-                                                       year=relative_date.year))
+        self.assertIn('Next 11 month', parser[0])
+        self.assertEqual(
+            parser[0][1].strftime('%d-%m-%Y'),
+            (datetime.today() + timedelta(11*365/12)).strftime('%d-%m-%Y')
+        )
         self.assertEqual(len(parser), 1)
 
     def test_captured_pattern_is_on_day(self):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -201,6 +201,22 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
         self.assertEqual(parser[0][1].strftime('%d-%m-%Y'), '02-01-2014')
         self.assertEqual(len(parser), 1)
 
+    def test_captured_pattern_has_am(self):
+        input_text = 'You have to woke up at 5 am in the morning'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('5 am', parser[0])
+        self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
+        self.assertEqual(parser[0][1].strftime('%H'), '05')
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_has_pm(self):
+        input_text = 'Your dental appointment at 4 pm in the evening.'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('4 pm', parser[0])
+        self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
+        self.assertEqual(parser[0][1].strftime('%H'), '16')
+        self.assertEqual(len(parser), 1)
+
 
 class DateTimeParsingTestCases(TestCase):
     """

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -205,17 +205,22 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
         self.assertIn('Next 10 year', parser[0])
         self.assertEqual(
             parser[0][1].strftime('%d-%m-%Y'),
-            (datetime.today() + timedelta(10*365)).strftime('%d-%m-%Y')
+            (datetime.today() + timedelta(10 * 365)).strftime('%d-%m-%Y')
         )
         self.assertEqual(len(parser), 1)
 
     def test_captured_pattern_is_next_eleven_months(self):
+        import calendar
         input_text = 'Next 11 months'
         parser = parsing.datetime_parsing(input_text)
+        relative_date = datetime.today()
+        month = relative_date.month - 1 + 11
+        year = relative_date.year + month // 12
+        month = month % 12 + 1
+        day = min(relative_date.day, calendar.monthrange(year, month)[1])
         self.assertIn('Next 11 month', parser[0])
         self.assertEqual(
-            parser[0][1].strftime('%d-%m-%Y'),
-            (datetime.today() + timedelta(11*365/12)).strftime('%d-%m-%Y')
+            parser[0][1].strftime('%d-%m-%Y'), datetime(year, month, day).strftime('%d-%m-%Y')
         )
         self.assertEqual(len(parser), 1)
 


### PR DESCRIPTION
@coolrb The script assumes 24hr format by default, to work for you scenario you have to write like this

Scenario 1

```Python
from chatterbot import parsing
text= u'Your dental appointment with Dr P. Delvour is scheduled for October 29, 4:00pm. ABC Dentist, 555-555-555.'
dates_ch = parsing.datetime_parsing(text)
print(dates_ch)
```
Update regular expression
```
re_time = r'(?P<hour>\d{1,2})(\:(?P<minute>\d{1,2})\s?(?P<convention>am|pm))'
```

Scenario 2:
```Python
from chatterbot import parsing
text= u'Your dental appointment with Dr P. Delvour is scheduled for October 29, 16:00. ABC Dentist, 555-555-555.'
dates_ch = parsing.datetime_parsing(text)
print(dates_ch)
```
Scenario 3:
Skip minutes, the regex will work.

```Python
from chatterbot import parsing
text= u'Your dental appointment with Dr P. Delvour is scheduled for October 29, 4 pm. ABC Dentist, 555-555-555.'
dates_ch = parsing.datetime_parsing(text)
print(dates_ch)
```
Closes: https://github.com/gunthercox/ChatterBot/issues/1277