### PR TITLE
The parser just recognizes case sensitive strings

### DIFF
--- a/chatterbot/parsing.py
+++ b/chatterbot/parsing.py
@@ -206,8 +206,8 @@ regex = [
         ),
         lambda m, base_date: date_from_relative_week_year(
             base_date,
-            m.group('time'),
-            m.group('dmy'),
+            m.group('time').lower(),
+            m.group('dmy').lower(),
             m.group('number')
         ) + timedelta(**convert_time_to_hour_minute(
             m.group('hour'),
@@ -488,7 +488,7 @@ def convert_time_to_hour_minute(hour, minute, convention):
     hour = int(hour)
     minute = int(minute)
 
-    if convention == 'pm':
+    if convention.lower() == 'pm':
         hour += 12
 
     return {'hours': hour, 'minutes': minute}

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -189,6 +189,16 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
         )
         self.assertEqual(len(parser), 1)
 
+    def test_captured_pattern_is_next_x_weeks_case_insensitive(self):
+        input_text = 'next 2 Weeks'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn(input_text, parser[0])
+        self.assertEqual(
+            parser[0][1].strftime('%d-%m-%Y'),
+            (datetime.today() + timedelta(weeks=2)).strftime('%d-%m-%Y')
+        )
+        self.assertEqual(len(parser), 1)
+
     def test_captured_pattern_is_next_eight_days(self):
         input_text = 'Next 8 days'
         parser = parsing.datetime_parsing(input_text)
@@ -196,6 +206,16 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
         self.assertEqual(
             parser[0][1].strftime('%d-%m-%Y'),
             (datetime.today() + timedelta(days=8)).strftime('%d-%m-%Y')
+        )
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_is_next_x_days_case_insensitive(self):
+        input_text = 'next 14 Days'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn(input_text, parser[0])
+        self.assertEqual(
+            parser[0][1].strftime('%d-%m-%Y'),
+            (datetime.today() + timedelta(days=14)).strftime('%d-%m-%Y')
         )
         self.assertEqual(len(parser), 1)
 
@@ -209,6 +229,16 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
         )
         self.assertEqual(len(parser), 1)
 
+    def test_captured_pattern_is_next_x_years_case_insensitive(self):
+        input_text = 'next 43 Years'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('next 43 Year', parser[0])
+        self.assertEqual(
+            parser[0][1].strftime('%d-%m-%Y'),
+            (datetime.today() + timedelta(43 * 365)).strftime('%d-%m-%Y')
+        )
+        self.assertEqual(len(parser), 1)
+
     def test_captured_pattern_is_next_eleven_months(self):
         import calendar
         input_text = 'Next 11 months'
@@ -219,6 +249,21 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
         month = month % 12 + 1
         day = min(relative_date.day, calendar.monthrange(year, month)[1])
         self.assertIn('Next 11 month', parser[0])
+        self.assertEqual(
+            parser[0][1].strftime('%d-%m-%Y'), datetime(year, month, day).strftime('%d-%m-%Y')
+        )
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_is_next_x_months_case_insensitive(self):
+        import calendar
+        input_text = 'next 55 Months'
+        parser = parsing.datetime_parsing(input_text)
+        relative_date = datetime.today()
+        month = relative_date.month - 1 + 55
+        year = relative_date.year + month // 12
+        month = month % 12 + 1
+        day = min(relative_date.day, calendar.monthrange(year, month)[1])
+        self.assertIn('next 55 Month', parser[0])
         self.assertEqual(
             parser[0][1].strftime('%d-%m-%Y'), datetime(year, month, day).strftime('%d-%m-%Y')
         )
@@ -254,12 +299,60 @@ class DateTimeParsingFunctionIntegrationTestCases(TestCase):
         self.assertEqual(parser[0][1].strftime('%H'), '05')
         self.assertEqual(len(parser), 1)
 
+    def test_captured_pattern_has_am_case_insensitive_1(self):
+        input_text = '7 AM'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('7 AM', parser[0])
+        self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
+        self.assertEqual(parser[0][1].strftime('%H'), '07')
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_has_am_case_insensitive_2(self):
+        input_text = '1 Am'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('1 Am', parser[0])
+        self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
+        self.assertEqual(parser[0][1].strftime('%H'), '01')
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_has_am_case_insensitive_3(self):
+        input_text = '9aM'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('9aM', parser[0])
+        self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
+        self.assertEqual(parser[0][1].strftime('%H'), '09')
+        self.assertEqual(len(parser), 1)
+
     def test_captured_pattern_has_pm(self):
         input_text = 'Your dental appointment at 4 pm in the evening.'
         parser = parsing.datetime_parsing(input_text)
         self.assertIn('4 pm', parser[0])
         self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
         self.assertEqual(parser[0][1].strftime('%H'), '16')
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_has_pm_case_insensitive_1(self):
+        input_text = '8 PM'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('8 PM', parser[0])
+        self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
+        self.assertEqual(parser[0][1].strftime('%H'), '20')
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_has_pm_case_insensitive_2(self):
+        input_text = '11 pM'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('11 pM', parser[0])
+        self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
+        self.assertEqual(parser[0][1].strftime('%H'), '23')
+        self.assertEqual(len(parser), 1)
+
+    def test_captured_pattern_has_pm_case_insensitive_3(self):
+        input_text = '3Pm'
+        parser = parsing.datetime_parsing(input_text)
+        self.assertIn('3Pm', parser[0])
+        self.assertEqual(parser[0][1].strftime('%d'), datetime.today().strftime('%d'))
+        self.assertEqual(parser[0][1].strftime('%H'), '15')
         self.assertEqual(len(parser), 1)
 
 


### PR DESCRIPTION
@gunthercox I tested the parser with some test cases to get **datetime** objects and I realised that upper letters are crashing the parser when it try to compare strings. 

In the first scenario below, as the parser uses the function **date_from_relative_week_year**, the function argument **time** assigned with string "Next" is not equals to string "next" and the function will return a "NoneType".

_Scenario 1:_
```
from chatterbot import parsing
text = "Next Week"
parser = parsing.datetime_parsing(text)
print(str(parser))

```
In the second scenario, the parser uses the function **convert_time_to_hour_minute**. As similar before, the function will return a "NoneType" because the comparison between the **convention** argument (storing the string "PM") and string "pm" is false. 

_Scenario 2:_
```
from chatterbot import parsing
text = "2PM"
parser = parsing.datetime_parsing(text)
print(str(parser))
```