### PR TITLE
Make it simpler to override system logic adapters.

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -22,6 +22,11 @@ class ChatBot(object):
 
         storage_adapter = kwargs.get('storage_adapter', 'chatterbot.storage.SQLStorageAdapter')
 
+        # These are logic adapters that are required for normal operation
+        system_logic_adapters = kwargs.get('system_logic_adapters', (
+            'chatterbot.logic.NoKnowledgeAdapter',
+        ))
+
         logic_adapters = kwargs.get('logic_adapters', [
             'chatterbot.logic.BestMatch'
         ])
@@ -44,9 +49,10 @@ class ChatBot(object):
         self.filters = tuple([utils.import_module(F)() for F in filters])
 
         # Add required system logic adapter
-        self.logic.system_adapters.append(
-            utils.initialize_class('chatterbot.logic.NoKnowledgeAdapter', **kwargs)
-        )
+        for system_logic_adapter in system_logic_adapters:
+            self.logic.system_adapters.append(
+                utils.initialize_class(system_logic_adapter, **kwargs)
+            )
 
         for adapter in logic_adapters:
             self.logic.add_adapter(adapter, **kwargs)


### PR DESCRIPTION
This makes a change so that developers can override the built in set of system logic adapters that ChatterBot uses.

This isn't something that is needed for typical use of ChatterBot but in some advanced cases it can be useful to disable them.

**Example usage**

```python
chatbot = ChatBot(
    system_logic_adapters=[]
)
```

For #1273