### PR TITLE
Remove modules included in Python 3 from dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,8 @@
 coveralls
 factory-boy>=2.9,<2.10
 flake8
-mock
 nose
-pip
 twine
 twython
 sphinx>=1.6,<1.7
 sphinx_rtd_theme
-wheel

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,5 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    test_suite='tests',
-    tests_require=['mock']
+    test_suite='tests'
 )

--- a/tests/input_adapter_tests/test_gitter_input_adapter.py
+++ b/tests/input_adapter_tests/test_gitter_input_adapter.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from chatterbot.conversation import Statement
 from chatterbot.input import gitter
 from chatterbot.input import Gitter

--- a/tests/input_adapter_tests/test_microsoft_input_adapter.py
+++ b/tests/input_adapter_tests/test_microsoft_input_adapter.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from chatterbot.conversation import Statement
 from chatterbot.input import Microsoft
 from chatterbot.input import microsoft

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_levenshtein_distance.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_levenshtein_distance.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 from chatterbot.logic import BestMatch
 from chatterbot.conversation import Statement, Response
 from tests.base_case import ChatBotTestCase

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_synset_distance.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_synset_distance.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 from chatterbot.logic import BestMatch
 from chatterbot.conversation import Statement, Response
 from tests.base_case import ChatBotTestCase

--- a/tests/logic_adapter_tests/test_best_match.py
+++ b/tests/logic_adapter_tests/test_best_match.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 from chatterbot.logic import BestMatch
 from chatterbot.conversation import Statement
 from tests.base_case import ChatBotTestCase

--- a/tests/logic_adapter_tests/test_low_confidence_adapter.py
+++ b/tests/logic_adapter_tests/test_low_confidence_adapter.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 from chatterbot.logic import LowConfidenceAdapter
 from chatterbot.conversation import Statement, Response
 from tests.base_case import ChatBotTestCase

--- a/tests/output_adapter_tests/test_gitter_output_adapter.py
+++ b/tests/output_adapter_tests/test_gitter_output_adapter.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from chatterbot.conversation import Statement
 from chatterbot.input import gitter
 from chatterbot.output import Gitter

--- a/tests/output_adapter_tests/test_microsoft_output_adapter.py
+++ b/tests/output_adapter_tests/test_microsoft_output_adapter.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from chatterbot.conversation import Statement
 from chatterbot.output import Microsoft
 from chatterbot.output import microsoft

--- a/tests/training_tests/test_twitter_trainer.py
+++ b/tests/training_tests/test_twitter_trainer.py
@@ -1,5 +1,5 @@
 from tests.base_case import ChatBotTestCase
-from mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock
 from chatterbot.trainers import TwitterTrainer
 import os
 import json

--- a/tests/training_tests/test_ubuntu_corpus_training.py
+++ b/tests/training_tests/test_ubuntu_corpus_training.py
@@ -1,8 +1,8 @@
+from unittest.mock import Mock
 from io import BytesIO
 import unittest
 import tarfile
 import os
-from mock import Mock
 
 from tests.base_case import ChatBotTestCase
 from chatterbot.trainers import UbuntuCorpusTrainer


### PR DESCRIPTION
These dependencies are included in standard Python 3 installations and no longer need to be installed as a part of the list of dev-dependencies.