### PR TITLE
Log Django test output to stdout

### DIFF
--- a/tests_django/test_settings.py
+++ b/tests_django/test_settings.py
@@ -58,3 +58,19 @@ PASSWORD_HASHERS = (
 )
 
 USE_TZ = True
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+    },
+}


### PR DESCRIPTION
I noticed that `print` statements weren't logging output when running tests for Django. This could make debugging difficult.