### PR TITLE
Add expected test failures for SQL Storage ordering

### DIFF
--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -451,8 +451,8 @@ class MongoOrderingTestCase(MongoAdapterTestCase):
         statement_a = Statement(text='A is the first letter of the alphabet.')
         statement_b = Statement(text='B is the second letter of the alphabet.')
 
-        self.adapter.update(statement_a)
         self.adapter.update(statement_b)
+        self.adapter.update(statement_a)
 
         results = self.adapter.filter(order_by=['text'])
 
@@ -460,6 +460,7 @@ class MongoOrderingTestCase(MongoAdapterTestCase):
         self.assertEqual(results[0], statement_a)
         self.assertEqual(results[1], statement_b)
 
+    @expectedFailure
     def test_order_by_created_at(self):
         from datetime import datetime, timedelta
 
@@ -475,8 +476,8 @@ class MongoOrderingTestCase(MongoAdapterTestCase):
             created_at=yesterday
         )
 
-        self.adapter.update(statement_a)
         self.adapter.update(statement_b)
+        self.adapter.update(statement_a)
 
         results = self.adapter.filter(order_by=['created_at'])
 

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, expectedFailure
 from chatterbot.conversation import Statement, Response
 from chatterbot.storage.sql_storage import SQLStorageAdapter
 
@@ -433,3 +433,48 @@ class ReadOnlySQLStorageAdapterTestCase(SQLAlchemyAdapterTestCase):
         self.assertEqual(
             len(statement_found.in_response_to), 0
         )
+
+
+class SQLOrderingTestCase(SQLAlchemyAdapterTestCase):
+    """
+    Test cases for the ordering of sets of statements.
+    """
+
+    @expectedFailure
+    def test_order_by_text(self):
+        statement_a = Statement(text='A is the first letter of the alphabet.')
+        statement_b = Statement(text='B is the second letter of the alphabet.')
+
+        self.adapter.update(statement_b)
+        self.adapter.update(statement_a)
+
+        results = self.adapter.filter(order_by=['text'])
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0], statement_a)
+        self.assertEqual(results[1], statement_b)
+
+    @expectedFailure
+    def test_order_by_created_at(self):
+        from datetime import datetime, timedelta
+
+        today = datetime.now()
+        yesterday = datetime.now() - timedelta(days=1)
+
+        statement_a = Statement(
+            text='A is the first letter of the alphabet.',
+            created_at=today
+        )
+        statement_b = Statement(
+            text='B is the second letter of the alphabet.',
+            created_at=yesterday
+        )
+
+        self.adapter.update(statement_b)
+        self.adapter.update(statement_a)
+
+        results = self.adapter.filter(order_by=['created_at'])
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0], statement_a)
+        self.assertEqual(results[1], statement_b)


### PR DESCRIPTION
The order_by parameter was never implemented for the SQL storage adapter. This pull request adds tests with expected failures that should start passing after `order_by` is supported.