### PR TITLE
Add create method to storage adapters

### DIFF
--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -93,6 +93,24 @@ class DjangoStorageAdapter(StorageAdapter):
 
         return statements
 
+    def create(self, **kwargs):
+        """
+        Creates a new statement matching the keyword arguments specified.
+        Returns the created statement.
+        """
+        Statement = self.get_model('statement')
+
+        tags = kwargs.pop('tags', [])
+
+        statement = Statement(**kwargs)
+
+        statement.save()
+
+        for tag in tags:
+            statement.tags.create(name=tag)
+
+        return statement
+
     def update(self, statement):
         """
         Update the provided statement.

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -234,6 +234,19 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         return results
 
+    def create(self, **kwargs):
+        """
+        Creates a new statement matching the keyword arguments specified.
+        Returns the created statement.
+        """
+        Statement = self.get_model('statement')
+
+        inserted = self.statements.insert_one(kwargs)
+
+        kwargs['id'] = inserted.inserted_id
+
+        return Statement(**kwargs)
+
     def update(self, statement):
         from pymongo import UpdateOne
         from pymongo.errors import BulkWriteError

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -212,6 +212,30 @@ class SQLStorageAdapter(StorageAdapter):
 
         return results
 
+    def create(self, **kwargs):
+        """
+        Creates a new statement matching the keyword arguments specified.
+        Returns the created statement.
+        """
+        Statement = self.get_model('statement')
+        Tag = self.get_model('tag')
+
+        session = self.Session()
+
+        tags = kwargs.pop('tags', [])
+
+        statement = Statement(**kwargs)
+
+        statement.tags.extend([
+            Tag(name=tag) for tag in tags
+        ])
+
+        session.add(statement)
+
+        self._session_finish(session)
+
+        return statement
+
     def update(self, statement):
         """
         Modifies an entry in the database.

--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -484,3 +484,26 @@ class MongoOrderingTestCase(MongoAdapterTestCase):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0], statement_a)
         self.assertEqual(results[1], statement_b)
+
+
+class StorageAdapterCreateTestCase(MongoAdapterTestCase):
+    """
+    Tests for the create function of the storage adapter.
+    """
+
+    def test_create_text(self):
+        self.adapter.create(text='testing')
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, 'testing')
+
+    def test_create_tags(self):
+        self.adapter.create(text='testing', tags=['a', 'b'])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertIn('a', results[0].tags)
+        self.assertIn('b', results[0].tags)

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -478,3 +478,26 @@ class SQLOrderingTestCase(SQLAlchemyAdapterTestCase):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0], statement_a)
         self.assertEqual(results[1], statement_b)
+
+
+class StorageAdapterCreateTestCase(SQLAlchemyAdapterTestCase):
+    """
+    Tests for the create function of the storage adapter.
+    """
+
+    def test_create_text(self):
+        self.adapter.create(text='testing')
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, 'testing')
+
+    def test_create_tags(self):
+        self.adapter.create(text='testing', tags=['a', 'b'])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertIn('a', results[0].tags)
+        self.assertIn('b', results[0].tags)

--- a/tests_django/test_django_adapter.py
+++ b/tests_django/test_django_adapter.py
@@ -411,3 +411,27 @@ class DjangoOrderingTestCase(DjangoStorageAdapterTestCase):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[1], statement_a)
         self.assertEqual(results[0], statement_b)
+
+
+class StorageAdapterCreateTestCase(DjangoStorageAdapterTestCase):
+    """
+    Tests for the create function of the storage adapter.
+    """
+
+    def test_create_text(self):
+        self.adapter.create(text='testing')
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, 'testing')
+
+    def test_create_tags(self):
+        self.adapter.create(text='testing', tags=['a', 'b'])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        tags = results[0].tags.values_list('name', flat=True)
+        self.assertIn('a', tags)
+        self.assertIn('b', tags)


### PR DESCRIPTION
This is an explicit `create` function for cases when the "update or create" functionality of the `update` method results in unwanted or unclear functionality.