### PR TITLE
process_response no longer needs to take a conversation parameter

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -117,7 +117,7 @@ class ChatBot(object):
             self.learn_response(input_statement, previous_statement)
 
         # Process the response output with the output adapter
-        return self.output.process_response(response, conversation)
+        return self.output.process_response(response)
 
     def generate_response(self, input_statement):
         """
@@ -127,6 +127,8 @@ class ChatBot(object):
 
         # Select a response to the input statement
         response = self.logic.process(input_statement)
+
+        response.conversation = input_statement.conversation
 
         return response
 

--- a/chatterbot/output/gitter.py
+++ b/chatterbot/output/gitter.py
@@ -67,7 +67,7 @@ class Gitter(OutputAdapter):
         self._validate_status_code(response)
         return response.json()
 
-    def process_response(self, statement, session_id=None):
+    def process_response(self, statement):
         self.send_message(statement.text)
         return statement
 

--- a/chatterbot/output/hipchat.py
+++ b/chatterbot/output/hipchat.py
@@ -55,7 +55,7 @@ class HipChat(OutputAdapter):
         """
         raise self.AdapterMethodNotImplementedError()
 
-    def process_response(self, statement, session_id=None):
+    def process_response(self, statement):
         data = self.send_message(self.hipchat_room, statement.text)
 
         # Update the output statement with the message id

--- a/chatterbot/output/mailgun.py
+++ b/chatterbot/output/mailgun.py
@@ -32,7 +32,7 @@ class Mailgun(OutputAdapter):
                 'text': text
             })
 
-    def process_response(self, statement, session_id=None):
+    def process_response(self, statement):
         """
         Send the response statement as an email.
         """

--- a/chatterbot/output/microsoft.py
+++ b/chatterbot/output/microsoft.py
@@ -90,7 +90,7 @@ class Microsoft(OutputAdapter):
         # Microsoft return 204 on operation succeeded and no content was returned.
         return self.get_most_recent_message()
 
-    def process_response(self, statement, session_id=None):
+    def process_response(self, statement):
         data = self.send_message(self.conversation_id, statement.text)
         self.logger.info('processing user response {}'.format(data))
         return statement

--- a/chatterbot/output/output_adapter.py
+++ b/chatterbot/output/output_adapter.py
@@ -7,13 +7,11 @@ class OutputAdapter(Adapter):
     functionality, such as delivering a response to an API endpoint.
     """
 
-    def process_response(self, statement, session_id=None):
+    def process_response(self, statement):
         """
         Override this method in a subclass to implement customized functionality.
 
         :param statement: The statement that the chat bot has produced in response to some input.
-
-        :param session_id: The unique id of the current chat session.
 
         :returns: The response statement.
         """

--- a/chatterbot/output/terminal.py
+++ b/chatterbot/output/terminal.py
@@ -7,7 +7,7 @@ class TerminalAdapter(OutputAdapter):
     communicate through the terminal.
     """
 
-    def process_response(self, statement, session_id=None):
+    def process_response(self, statement):
         """
         Print the response to the user's input.
         """

--- a/chatterbot/storage/storage_adapter.py
+++ b/chatterbot/storage/storage_adapter.py
@@ -33,13 +33,13 @@ class StorageAdapter(object):
 
         return get_model_method()
 
-    def generate_base_query(self, chatterbot, session_id):
+    def generate_base_query(self, chatterbot, conversation):
         """
         Create a base query for the storage adapter.
         """
         if self.adapter_supports_queries:
             for filter_instance in chatterbot.filters:
-                self.base_query = filter_instance.filter_selection(chatterbot, session_id)
+                self.base_query = filter_instance.filter_selection(chatterbot, conversation)
 
     def count(self):
         """

--- a/tests/output_adapter_tests/test_output_adapter.py
+++ b/tests/output_adapter_tests/test_output_adapter.py
@@ -18,5 +18,5 @@ class OutputAdapterTestCase(TestCase):
         """
         The value passed in for the statement parameter should be returned.
         """
-        statement = self.adapter.process_response('_', 0)
+        statement = self.adapter.process_response('_')
         self.assertEqual(statement, '_')


### PR DESCRIPTION
The conversation can be found using the statement that gets passed in to the function already.