### PR TITLE
Mitigate the addition of duplicate tags

### DIFF
--- a/chatterbot/ext/django_chatterbot/abstract_models.py
+++ b/chatterbot/ext/django_chatterbot/abstract_models.py
@@ -77,8 +77,9 @@ class AbstractBaseStatement(models.Model, StatementMixin):
         Add a list of strings to the statement as tags.
         (Overrides the method from StatementMixin)
         """
-        for tag in tags:
-            self.tags.create(name=tag)
+        for _tag in tags:
+            if not self.tags.filter(name=_tag).exists():
+                self.tags.create(name=_tag)
 
 
 class AbstractBaseTag(models.Model):

--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -51,6 +51,7 @@ class DjangoStorageAdapter(StorageAdapter):
         Returns the created statement.
         """
         Statement = self.get_model('statement')
+        Tag = self.get_model('tag')
 
         tags = kwargs.pop('tags', [])
 
@@ -58,8 +59,10 @@ class DjangoStorageAdapter(StorageAdapter):
 
         statement.save()
 
-        for tag in tags:
-            statement.tags.create(name=tag)
+        for _tag in tags:
+            tag, _ = Tag.objects.get_or_create(name=_tag)
+
+            statement.tags.add(tag)
 
         return statement
 
@@ -68,6 +71,7 @@ class DjangoStorageAdapter(StorageAdapter):
         Update the provided statement.
         """
         Statement = self.get_model('statement')
+        Tag = self.get_model('tag')
 
         if hasattr(statement, 'id'):
             statement.save()
@@ -79,8 +83,10 @@ class DjangoStorageAdapter(StorageAdapter):
                 created_at=statement.created_at
             )
 
-        for tag in statement.tags.all():
-            statement.tags.create(name=tag)
+        for _tag in statement.tags.all():
+            tag, _ = Tag.objects.get_or_create(name=_tag)
+
+            statement.tags.add(tag)
 
         return statement
 

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -160,13 +160,18 @@ class SQLStorageAdapter(StorageAdapter):
 
         session = self.Session()
 
-        tags = kwargs.pop('tags', [])
+        tags = set(kwargs.pop('tags', []))
 
         statement = Statement(**kwargs)
 
-        statement.tags.extend([
-            Tag(name=tag) for tag in tags
-        ])
+        for _tag in tags:
+            tag = session.query(Tag).filter_by(name=_tag).first()
+
+            if not tag:
+                # Create the tag
+                tag = Tag(name=_tag)
+
+            statement.tags.append(tag)
 
         session.add(statement)
 

--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -289,6 +289,19 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
         self.assertIn('a', results[0].get_tags())
         self.assertIn('b', results[0].get_tags())
 
+    def test_create_duplicate_tags(self):
+        """
+        The storage adapter should not create a statement with tags
+        that are duplicates.
+        """
+        self.adapter.create(text='testing', tags=['ab', 'ab'])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0].get_tags()), 1)
+        self.assertEqual(results[0].get_tags(), ['ab'])
+
 
 class StorageAdapterUpdateTestCase(MongoAdapterFilterTestCase):
     """
@@ -305,3 +318,18 @@ class StorageAdapterUpdateTestCase(MongoAdapterFilterTestCase):
         self.assertEqual(len(statements), 1)
         self.assertIn('a', statements[0].get_tags())
         self.assertIn('b', statements[0].get_tags())
+
+    def test_update_duplicate_tags(self):
+        """
+        The storage adapter should not update a statement with tags
+        that are duplicates.
+        """
+        statement = self.adapter.create(text='Testing', tags=['ab'])
+        statement.add_tags('ab')
+        self.adapter.update(statement)
+
+        statements = self.adapter.filter()
+
+        self.assertEqual(len(statements), 1)
+        self.assertEqual(len(statements[0].get_tags()), 1)
+        self.assertEqual(statements[0].get_tags(), ['ab'])

--- a/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
+++ b/tests/storage_adapter_tests/test_sqlalchemy_adapter.py
@@ -303,6 +303,19 @@ class StorageAdapterCreateTestCase(SQLAlchemyAdapterTestCase):
         self.assertIn('a', results[0].get_tags())
         self.assertIn('b', results[0].get_tags())
 
+    def test_create_duplicate_tags(self):
+        """
+        The storage adapter should not create a statement with tags
+        that are duplicates.
+        """
+        self.adapter.create(text='testing', tags=['ab', 'ab'])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0].get_tags()), 1)
+        self.assertEqual(results[0].get_tags(), ['ab'])
+
 
 class StorageAdapterUpdateTestCase(SQLAlchemyAdapterTestCase):
     """
@@ -319,3 +332,18 @@ class StorageAdapterUpdateTestCase(SQLAlchemyAdapterTestCase):
         self.assertEqual(len(statements), 1)
         self.assertIn('a', statements[0].get_tags())
         self.assertIn('b', statements[0].get_tags())
+
+    def test_update_duplicate_tags(self):
+        """
+        The storage adapter should not update a statement with tags
+        that are duplicates.
+        """
+        statement = self.adapter.create(text='Testing', tags=['ab'])
+        statement.add_tags('ab')
+        self.adapter.update(statement)
+
+        statements = self.adapter.filter()
+
+        self.assertEqual(len(statements), 1)
+        self.assertEqual(len(statements[0].get_tags()), 1)
+        self.assertEqual(statements[0].get_tags(), ['ab'])

--- a/tests_django/test_django_adapter.py
+++ b/tests_django/test_django_adapter.py
@@ -263,6 +263,19 @@ class StorageAdapterCreateTestCase(DjangoStorageAdapterTestCase):
         self.assertIn('a', results[0].get_tags())
         self.assertIn('b', results[0].get_tags())
 
+    def test_create_duplicate_tags(self):
+        """
+        The storage adapter should not create a statement with tags
+        that are duplicates.
+        """
+        self.adapter.create(text='testing', tags=['ab', 'ab'])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0].get_tags()), 1)
+        self.assertEqual(results[0].get_tags(), ['ab'])
+
 
 class StorageAdapterUpdateTestCase(DjangoStorageAdapterTestCase):
     """
@@ -279,3 +292,18 @@ class StorageAdapterUpdateTestCase(DjangoStorageAdapterTestCase):
         self.assertEqual(len(statements), 1)
         self.assertIn('a', statements[0].get_tags())
         self.assertIn('b', statements[0].get_tags())
+
+    def test_update_duplicate_tags(self):
+        """
+        The storage adapter should not update a statement with tags
+        that are duplicates.
+        """
+        statement = self.adapter.create(text='Testing', tags=['ab'])
+        statement.add_tags('ab')
+        self.adapter.update(statement)
+
+        statements = self.adapter.filter()
+
+        self.assertEqual(len(statements), 1)
+        self.assertEqual(len(statements[0].get_tags()), 1)
+        self.assertEqual(statements[0].get_tags(), ['ab'])


### PR DESCRIPTION
This adds tests and makes changes accordingly to help prevent the creation and addition of duplicate tags to a statement.