### PR TITLE
Remove conversation parameter from get_response and process_input methods

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -90,19 +90,15 @@ class ChatBot(object):
         """
         self.logic.initialize()
 
-    def get_response(self, input_item, conversation='default'):
+    def get_response(self, input_item):
         """
         Return the bot's response based on the input.
 
         :param input_item: An input value.
-        :param conversation: A string of characters unique to the conversation.
         :returns: A response to the input.
         :rtype: Statement
         """
-        input_statement = self.input.process_input(
-            input_item,
-            conversation
-        )
+        input_statement = self.input.process_input(input_item)
 
         # Preprocess the input statement
         for preprocessor in self.preprocessors:

--- a/chatterbot/input/gitter.py
+++ b/chatterbot/input/gitter.py
@@ -147,7 +147,7 @@ class Gitter(InputAdapter):
 
         return text_without_mentions
 
-    def process_input(self, statement, conversation):
+    def process_input(self, statement):
         new_message = False
 
         while not new_message:
@@ -158,9 +158,8 @@ class Gitter(InputAdapter):
             sleep(self.sleep_time)
 
         text = self.remove_mentions(data['text'])
-        statement = Statement(text)
 
-        return statement
+        return Statement(text)
 
     class HTTPStatusException(Exception):
         """

--- a/chatterbot/input/hipchat.py
+++ b/chatterbot/input/hipchat.py
@@ -76,14 +76,14 @@ class HipChat(InputAdapter):
             return None
         return items[-1]
 
-    def process_input(self, statement, conversation):
+    def process_input(self, statement):
         """
         Process input from the HipChat room.
         """
         new_message = False
 
         conversation = self.chatbot.storage.filter(
-            text=conversation,
+            conversation=statement.conversation,
             order_by=['id']
         )
 

--- a/chatterbot/input/input_adapter.py
+++ b/chatterbot/input/input_adapter.py
@@ -7,7 +7,7 @@ class InputAdapter(Adapter):
     interface that all input adapters should implement.
     """
 
-    def process_input(self, statement, conversation):
+    def process_input(self, statement):
         """
         Returns a statement object based on the input source.
         """

--- a/chatterbot/input/mailgun.py
+++ b/chatterbot/input/mailgun.py
@@ -48,7 +48,7 @@ class Mailgun(InputAdapter):
             auth=('api', self.api_key)
         )
 
-    def process_input(self, statement, conversation):
+    def process_input(self, statement):
         urls = self.get_stored_email_urls()
         url = list(urls)[0]
 

--- a/chatterbot/input/microsoft.py
+++ b/chatterbot/input/microsoft.py
@@ -88,7 +88,7 @@ class Microsoft(InputAdapter):
             return data['messages'][last_msg - 1]
         return None
 
-    def process_input(self, statement, conversation):
+    def process_input(self, statement):
         new_message = False
         data = None
         while not new_message:

--- a/chatterbot/input/terminal.py
+++ b/chatterbot/input/terminal.py
@@ -8,7 +8,7 @@ class TerminalAdapter(InputAdapter):
     communicate through the terminal.
     """
 
-    def process_input(self, *args, **kwargs):
+    def process_input(self, *args):
         """
         Read the user's input from the terminal.
         """

--- a/chatterbot/input/variable_input_type_adapter.py
+++ b/chatterbot/input/variable_input_type_adapter.py
@@ -25,14 +25,16 @@ class VariableInputTypeAdapter(InputAdapter):
             )
         )
 
-    def process_input(self, statement, conversation):
+    def process_input(self, statement):
+        DEFAULT_CONVERSATION = 'default'
+
         input_type = self.detect_type(statement)
 
         # Return the statement object without modification
         if input_type == self.OBJECT:
 
             if not statement.conversation:
-                statement.conversation = conversation
+                statement.conversation = DEFAULT_CONVERSATION
 
             return statement
 
@@ -40,7 +42,7 @@ class VariableInputTypeAdapter(InputAdapter):
         if input_type == self.TEXT:
             return Statement(
                 text=statement,
-                conversation=conversation
+                conversation=DEFAULT_CONVERSATION
             )
 
         # Convert input dictionary into a statement object
@@ -50,7 +52,7 @@ class VariableInputTypeAdapter(InputAdapter):
             del input_json['text']
 
             if 'conversation' not in input_json:
-                input_json['conversation'] = conversation
+                input_json['conversation'] = DEFAULT_CONVERSATION
 
             return Statement(text, **input_json)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,5 +194,5 @@ epub_exclude_files = ['search.html']
 
 # Configuration for intersphinx
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.4', None)
+    'python': ('https://docs.python.org/3', None)
 }

--- a/examples/django_app/example_app/views.py
+++ b/examples/django_app/example_app/views.py
@@ -32,10 +32,8 @@ class ChatterBotApiView(View):
                 ]
             }, status=400)
 
-        response = self.chatterbot.get_response(
-            input_data,
-            input_data.get('conversation', 'default')
-        )
+        response = self.chatterbot.get_response(input_data)
+
         response_data = response.serialize()
 
         return JsonResponse(response_data, status=200)

--- a/tests/filter_integration_tests/test_filters_with_mongo_storage.py
+++ b/tests/filter_integration_tests/test_filters_with_mongo_storage.py
@@ -10,6 +10,7 @@ class RepetitiveResponseFilterTestCase(ChatBotMongoTestCase):
         """
         Test that repetitive responses are filtered out of the results.
         """
+        from chatterbot.conversation import Statement
         from chatterbot.filters import RepetitiveResponseFilter
         from chatterbot.trainers import ListTrainer
 
@@ -29,8 +30,9 @@ class RepetitiveResponseFilterTestCase(ChatBotMongoTestCase):
             'How are you?'
         ])
 
-        first_response = self.chatbot.get_response('Hello', conversation='training')
-        second_response = self.chatbot.get_response('Hello', conversation='training')
+        statement = Statement(text='Hello', conversation='training')
+        first_response = self.chatbot.get_response(statement)
+        second_response = self.chatbot.get_response(statement)
 
         self.assertEqual('I am good.', first_response.text)
         self.assertEqual('Hi', second_response.text)

--- a/tests/input_adapter_tests/test_gitter_input_adapter.py
+++ b/tests/input_adapter_tests/test_gitter_input_adapter.py
@@ -120,5 +120,5 @@ class GitterAdapterTests(TestCase):
 
     def test_process_input(self):
         statement = Statement('Hello')
-        data = self.adapter.process_input(statement, 'test')
+        data = self.adapter.process_input(statement)
         self.assertEqual('Hello', data)

--- a/tests/input_adapter_tests/test_input_adapter.py
+++ b/tests/input_adapter_tests/test_input_adapter.py
@@ -16,7 +16,4 @@ class InputAdapterTestCase(ChatBotTestCase):
 
     def test_process_response(self):
         with self.assertRaises(InputAdapter.AdapterMethodNotImplementedError):
-            self.adapter.process_input(
-                'test statement',
-                'test conversation'
-            )
+            self.adapter.process_input('test statement')

--- a/tests/input_adapter_tests/test_microsoft_input_adapter.py
+++ b/tests/input_adapter_tests/test_microsoft_input_adapter.py
@@ -124,5 +124,5 @@ class MicrosoftAdapterTests(TestCase):
 
     def test_process_input(self):
         statement = Statement('Hi! What is your name?')
-        data = self.adapter.process_input(statement, conversation='test')
+        data = self.adapter.process_input(statement)
         self.assertEqual('Hi! What is your name?', data)

--- a/tests/input_adapter_tests/test_variable_input_type_adapter.py
+++ b/tests/input_adapter_tests/test_variable_input_type_adapter.py
@@ -7,26 +7,25 @@ class VariableInputTypeAdapterTests(TestCase):
 
     def setUp(self):
         self.adapter = VariableInputTypeAdapter()
-        self.conversation = 'test'
 
     def test_statement_returned_dict(self):
         data = {
             'text': 'Robot ipsum datus scan amet.',
             'in_response_to': []
         }
-        response = self.adapter.process_input(data, self.conversation)
+        response = self.adapter.process_input(data)
 
         self.assertEqual(response.text, data['text'])
 
     def test_statement_returned_text(self):
         text = 'The test statement to process is here.'
-        response = self.adapter.process_input(text, self.conversation)
+        response = self.adapter.process_input(text)
 
         self.assertEqual(response.text, text)
 
     def test_statement_returned_object(self):
         statement = Statement('The test statement to process is here.')
-        response = self.adapter.process_input(statement, self.conversation)
+        response = self.adapter.process_input(statement)
 
         self.assertEqual(response.text, statement.text)
 
@@ -34,4 +33,4 @@ class VariableInputTypeAdapterTests(TestCase):
         data = ['A list', 'of text', 'is an', 'invalid input type.']
 
         with self.assertRaises(VariableInputTypeAdapter.UnrecognizedInputFormatException):
-            self.adapter.process_input(data, self.conversation)
+            self.adapter.process_input(data)

--- a/tests_django/integration_tests/test_input_adapter_integration.py
+++ b/tests_django/integration_tests/test_input_adapter_integration.py
@@ -15,6 +15,6 @@ class InputIntegrationTestCase(TestCase):
 
         statement = Statement(text='_')
 
-        result = adapter.process_input(statement, 'test')
+        result = adapter.process_input(statement)
 
         self.assertEqual(result.text, '_')


### PR DESCRIPTION
The `conversation` is available on the statement object that gets passed in.