### PR TITLE
Move tests for examples into the tests directory

### DIFF
--- a/examples/tests/readme.md
+++ b/examples/tests/readme.md
@@ -1,6 +1,0 @@
-Tests for ChatterBot examples
-=============================
-
-This directory contains tests for the ChatterBot example programs
-to make sure that things don't break and continue to work as
-expected as changes are made to the chatterbot package.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,12 +1,4 @@
 from unittest import TestCase, SkipTest
-import sys
-import os
-
-
-# Insert the examples root directory into the PYTHONPATH
-current_directory = os.path.dirname(os.path.abspath(__file__))
-parent_directory = os.path.abspath(os.path.join(current_directory, os.pardir))
-sys.path.insert(0, parent_directory)
 
 
 class ExamplesSmokeTestCase(TestCase):
@@ -16,10 +8,10 @@ class ExamplesSmokeTestCase(TestCase):
     """
 
     def test_basic_example(self):
-        import basic_example # NOQA
+        from examples import basic_example # NOQA
 
     def test_default_response_example(self):
-        import default_response_example # NOQA
+        from examples import default_response_example # NOQA
 
     def test_export_example(self):
         raise SkipTest(
@@ -53,7 +45,7 @@ class ExamplesSmokeTestCase(TestCase):
         )
 
     def test_math_and_time(self):
-        import math_and_time # NOQA
+        from examples import math_and_time # NOQA
 
     def test_microsoft_bot(self):
         raise SkipTest(
@@ -62,7 +54,7 @@ class ExamplesSmokeTestCase(TestCase):
         )
 
     def test_specific_response_example(self):
-        import specific_response_example # NOQA
+        from examples import specific_response_example # NOQA
 
     def test_terminal_example(self):
         raise SkipTest(

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,16 @@ deps =
   -rrequirements.txt
   -rdev-requirements.txt
 
+[testenv:docs]
+commands = sphinx-build -nW -b html ./docs/ {envtmpdir}/build/
+
+[testenv:lint]
+deps = flake8
+commands = flake8
+
 [testenv:test]
 commands =
   nosetests
-  nosetests examples
 
 [testenv:django111]
 commands =
@@ -26,10 +32,3 @@ commands =
   python setup.py develop --no-deps
   python runtests.py
   python examples/django_app/manage.py test examples/django_app/
-
-[testenv:lint]
-deps = flake8
-commands = flake8
-
-[testenv:docs]
-commands = sphinx-build -nW -b html ./docs/ {envtmpdir}/build/


### PR DESCRIPTION
This change results in fewer commands being required to run all the tests.