### PR TITLE
Remove the set_chatbot method from input adapters, output adapters, and logic adapters

### DIFF
--- a/chatterbot/adapters.py
+++ b/chatterbot/adapters.py
@@ -5,21 +5,13 @@ class Adapter(object):
     """
     A superclass for all adapter classes.
 
-    :param logger: A python logger.
+    :param chatbot: A ChatBot instance.
+    :param logger: A python logger (optional).
     """
 
-    def __init__(self, **kwargs):
-        self.logger = kwargs.get('logger', logging.getLogger(__name__))
-        self.chatbot = kwargs.get('chatbot')
-
-    def set_chatbot(self, chatbot):
-        """
-        Gives the adapter access to an instance of the ChatBot class.
-
-        :param chatbot: A chat bot instance.
-        :type chatbot: ChatBot
-        """
+    def __init__(self, chatbot, **kwargs):
         self.chatbot = chatbot
+        self.logger = kwargs.get('logger', logging.getLogger(__name__))
 
     class AdapterMethodNotImplementedError(NotImplementedError):
         """

--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -1,9 +1,9 @@
 import logging
-from .storage import StorageAdapter
-from .logic import LogicAdapter
-from .input import InputAdapter
-from .output import OutputAdapter
-from . import utils
+from chatterbot.storage import StorageAdapter
+from chatterbot.logic import LogicAdapter
+from chatterbot.input import InputAdapter
+from chatterbot.output import OutputAdapter
+from chatterbot import utils
 
 
 class ChatBot(object):
@@ -42,8 +42,8 @@ class ChatBot(object):
         self.system_logic_adapters = []
 
         self.storage = utils.initialize_class(storage_adapter, **kwargs)
-        self.input = utils.initialize_class(input_adapter, **kwargs)
-        self.output = utils.initialize_class(output_adapter, **kwargs)
+        self.input = utils.initialize_class(input_adapter, self, **kwargs)
+        self.output = utils.initialize_class(output_adapter, self, **kwargs)
 
         filters = kwargs.get('filters', tuple())
         self.filters = tuple([utils.import_module(F)() for F in filters])
@@ -51,20 +51,13 @@ class ChatBot(object):
         # Add required system logic adapter
         for system_logic_adapter in system_logic_adapters:
             utils.validate_adapter_class(system_logic_adapter, LogicAdapter)
-            logic_adapter = utils.initialize_class(system_logic_adapter, **kwargs)
-            logic_adapter.set_chatbot(self)
+            logic_adapter = utils.initialize_class(system_logic_adapter, self, **kwargs)
             self.system_logic_adapters.append(logic_adapter)
 
         for adapter in logic_adapters:
             utils.validate_adapter_class(adapter, LogicAdapter)
-            logic_adapter = utils.initialize_class(adapter, **kwargs)
-            logic_adapter.set_chatbot(self)
+            logic_adapter = utils.initialize_class(adapter, self, **kwargs)
             self.logic_adapters.append(logic_adapter)
-
-        # Add the chatbot instance to each adapter to share information such as
-        # the name, the current conversation, or other adapters
-        self.input.set_chatbot(self)
-        self.output.set_chatbot(self)
 
         preprocessors = kwargs.get(
             'preprocessors', [
@@ -193,7 +186,7 @@ class ChatBot(object):
         Returns the latest response in a conversation if it exists.
         Returns None if a matching conversation cannot be found.
         """
-        from .conversation import Statement as StatementObject
+        from chatterbot.conversation import Statement as StatementObject
 
         conversation_statements = self.storage.filter(
             conversation=conversation,

--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -88,7 +88,7 @@ class SynsetDistance(Comparator):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
-        from .utils import nltk_download_corpus
+        from chatterbot.utils import nltk_download_corpus
 
         nltk_download_corpus('corpora/wordnet')
 
@@ -96,7 +96,7 @@ class SynsetDistance(Comparator):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
-        from .utils import nltk_download_corpus
+        from chatterbot.utils import nltk_download_corpus
 
         nltk_download_corpus('tokenizers/punkt')
 
@@ -104,7 +104,7 @@ class SynsetDistance(Comparator):
         """
         Download required NLTK corpora if they have not already been downloaded.
         """
-        from .utils import nltk_download_corpus
+        from chatterbot.utils import nltk_download_corpus
 
         nltk_download_corpus('corpora/stopwords')
 
@@ -173,7 +173,7 @@ class SentimentComparison(Comparator):
         Download the NLTK vader lexicon for sentiment analysis
         that is required for this algorithm to run.
         """
-        from .utils import nltk_download_corpus
+        from chatterbot.utils import nltk_download_corpus
 
         nltk_download_corpus('sentiment/vader_lexicon')
 
@@ -248,7 +248,7 @@ class JaccardSimilarity(Comparator):
         Download the NLTK wordnet corpora that is required for this algorithm
         to run only if the corpora has not already been downloaded.
         """
-        from .utils import nltk_download_corpus
+        from chatterbot.utils import nltk_download_corpus
 
         nltk_download_corpus('corpora/wordnet')
 

--- a/chatterbot/input/__init__.py
+++ b/chatterbot/input/__init__.py
@@ -1,9 +1,9 @@
-from .input_adapter import InputAdapter
-from .microsoft import Microsoft
-from .gitter import Gitter
-from .mailgun import Mailgun
-from .terminal import TerminalAdapter
-from .variable_input_type_adapter import VariableInputTypeAdapter
+from chatterbot.input.input_adapter import InputAdapter
+from chatterbot.input.microsoft import Microsoft
+from chatterbot.input.gitter import Gitter
+from chatterbot.input.mailgun import Mailgun
+from chatterbot.input.terminal import TerminalAdapter
+from chatterbot.input.variable_input_type_adapter import VariableInputTypeAdapter
 
 
 __all__ = (

--- a/chatterbot/input/gitter.py
+++ b/chatterbot/input/gitter.py
@@ -10,8 +10,8 @@ class Gitter(InputAdapter):
     input statements from a Gitter room.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
 
         self.gitter_room = kwargs.get('gitter_room')
         self.gitter_api_token = kwargs.get('gitter_api_token')

--- a/chatterbot/input/microsoft.py
+++ b/chatterbot/input/microsoft.py
@@ -11,8 +11,8 @@ class Microsoft(InputAdapter):
     https://docs.botframework.com/en-us/restapi/directline/#navtitle
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
         import requests
         from requests.packages.urllib3.exceptions import InsecureRequestWarning
         requests.packages.urllib3.disable_warnings(InsecureRequestWarning)

--- a/chatterbot/logic/__init__.py
+++ b/chatterbot/logic/__init__.py
@@ -1,11 +1,11 @@
-from .logic_adapter import LogicAdapter
-from .best_match import BestMatch
-from .low_confidence import LowConfidenceAdapter
-from .mathematical_evaluation import MathematicalEvaluation
-from .no_knowledge_adapter import NoKnowledgeAdapter
-from .specific_response import SpecificResponseAdapter
-from .time_adapter import TimeLogicAdapter
-from .unit_conversion import UnitConversion
+from chatterbot.logic.logic_adapter import LogicAdapter
+from chatterbot.logic.best_match import BestMatch
+from chatterbot.logic.low_confidence import LowConfidenceAdapter
+from chatterbot.logic.mathematical_evaluation import MathematicalEvaluation
+from chatterbot.logic.no_knowledge_adapter import NoKnowledgeAdapter
+from chatterbot.logic.specific_response import SpecificResponseAdapter
+from chatterbot.logic.time_adapter import TimeLogicAdapter
+from chatterbot.logic.unit_conversion import UnitConversion
 
 __all__ = (
     'LogicAdapter',

--- a/chatterbot/logic/best_match.py
+++ b/chatterbot/logic/best_match.py
@@ -1,4 +1,4 @@
-from .logic_adapter import LogicAdapter
+from chatterbot.logic import LogicAdapter
 
 
 class BestMatch(LogicAdapter):

--- a/chatterbot/logic/logic_adapter.py
+++ b/chatterbot/logic/logic_adapter.py
@@ -14,8 +14,8 @@ class LogicAdapter(Adapter):
                                       Defaults to ``get_first_response``.
     """
 
-    def __init__(self, **kwargs):
-        super(LogicAdapter, self).__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
         from chatterbot.comparisons import levenshtein_distance
         from chatterbot.response_selection import get_first_response
 

--- a/chatterbot/logic/low_confidence.py
+++ b/chatterbot/logic/low_confidence.py
@@ -1,5 +1,5 @@
 from chatterbot.conversation import Statement
-from .best_match import BestMatch
+from chatterbot.logic.best_match import BestMatch
 
 
 class LowConfidenceAdapter(BestMatch):
@@ -18,8 +18,8 @@ class LowConfidenceAdapter(BestMatch):
           Defaults to ``get_first_response``.
     """
 
-    def __init__(self, **kwargs):
-        super(LowConfidenceAdapter, self).__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
 
         self.confidence_threshold = kwargs.get('threshold', 0.65)
 

--- a/chatterbot/logic/mathematical_evaluation.py
+++ b/chatterbot/logic/mathematical_evaluation.py
@@ -18,8 +18,8 @@ class MathematicalEvaluation(LogicAdapter):
           The language is set to 'ENG' for English by default.
     """
 
-    def __init__(self, **kwargs):
-        super(MathematicalEvaluation, self).__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
 
         self.language = kwargs.get('language', 'ENG')
         self.cache = {}

--- a/chatterbot/logic/no_knowledge_adapter.py
+++ b/chatterbot/logic/no_knowledge_adapter.py
@@ -1,4 +1,4 @@
-from .logic_adapter import LogicAdapter
+from chatterbot.logic import LogicAdapter
 
 
 class NoKnowledgeAdapter(LogicAdapter):

--- a/chatterbot/logic/specific_response.py
+++ b/chatterbot/logic/specific_response.py
@@ -1,4 +1,4 @@
-from .logic_adapter import LogicAdapter
+from chatterbot.logic import LogicAdapter
 
 
 class SpecificResponseAdapter(LogicAdapter):
@@ -12,8 +12,8 @@ class SpecificResponseAdapter(LogicAdapter):
           The output text returned by this logic adapter.
     """
 
-    def __init__(self, **kwargs):
-        super(SpecificResponseAdapter, self).__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
         from chatterbot.conversation import Statement
 
         self.input_text = kwargs.get('input_text')

--- a/chatterbot/logic/time_adapter.py
+++ b/chatterbot/logic/time_adapter.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from .logic_adapter import LogicAdapter
+from chatterbot.logic import LogicAdapter
 
 
 class TimeLogicAdapter(LogicAdapter):
@@ -15,8 +15,8 @@ class TimeLogicAdapter(LogicAdapter):
           Defaults to a list of English sentences.
     """
 
-    def __init__(self, **kwargs):
-        super(TimeLogicAdapter, self).__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
         from nltk import NaiveBayesClassifier
 
         self.positive = kwargs.get('positive', [

--- a/chatterbot/logic/unit_conversion.py
+++ b/chatterbot/logic/unit_conversion.py
@@ -20,8 +20,8 @@ class UnitConversion(LogicAdapter):
         The language is set to 'ENG' for English by default.
     """
 
-    def __init__(self, **kwargs):
-        super(UnitConversion, self).__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
 
         self.language = kwargs.get('language', 'ENG')
         self.cache = {}

--- a/chatterbot/output/__init__.py
+++ b/chatterbot/output/__init__.py
@@ -1,8 +1,8 @@
-from .output_adapter import OutputAdapter
-from .microsoft import Microsoft
-from .terminal import TerminalAdapter
-from .mailgun import Mailgun
-from .gitter import Gitter
+from chatterbot.output.output_adapter import OutputAdapter
+from chatterbot.output.microsoft import Microsoft
+from chatterbot.output.terminal import TerminalAdapter
+from chatterbot.output.mailgun import Mailgun
+from chatterbot.output.gitter import Gitter
 
 __all__ = (
     'OutputAdapter',

--- a/chatterbot/output/gitter.py
+++ b/chatterbot/output/gitter.py
@@ -1,4 +1,4 @@
-from .output_adapter import OutputAdapter
+from chatterbot.output import OutputAdapter
 from chatterbot.api import gitter
 
 
@@ -8,8 +8,8 @@ class Gitter(OutputAdapter):
     responses to a Gitter room.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
 
         self.gitter_room = kwargs.get('gitter_room')
         self.gitter_api_token = kwargs.get('gitter_api_token')

--- a/chatterbot/output/microsoft.py
+++ b/chatterbot/output/microsoft.py
@@ -8,8 +8,8 @@ class Microsoft(OutputAdapter):
     responses to a Microsoft bot using *Direct Line client protocol*.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
 
         self.direct_line_token_or_secret = kwargs.get(
             'direct_line_token_or_secret'

--- a/chatterbot/output/terminal.py
+++ b/chatterbot/output/terminal.py
@@ -1,4 +1,4 @@
-from .output_adapter import OutputAdapter
+from chatterbot.output import OutputAdapter
 
 
 class TerminalAdapter(OutputAdapter):

--- a/chatterbot/storage/__init__.py
+++ b/chatterbot/storage/__init__.py
@@ -1,7 +1,7 @@
-from .storage_adapter import StorageAdapter
-from .django_storage import DjangoStorageAdapter
-from .mongodb import MongoDatabaseAdapter
-from .sql_storage import SQLStorageAdapter
+from chatterbot.storage.storage_adapter import StorageAdapter
+from chatterbot.storage.django_storage import DjangoStorageAdapter
+from chatterbot.storage.mongodb import MongoDatabaseAdapter
+from chatterbot.storage.sql_storage import SQLStorageAdapter
 
 
 __all__ = (

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -1,7 +1,7 @@
 import os
 import sys
-from .conversation import Statement
-from . import utils
+from chatterbot.conversation import Statement
+from chatterbot import utils
 
 
 class Trainer(object):
@@ -107,9 +107,9 @@ class ChatterBotCorpusTrainer(Trainer):
     ChatterBot dialog corpus.
     """
 
-    def __init__(self, storage, **kwargs):
-        super(ChatterBotCorpusTrainer, self).__init__(storage, **kwargs)
-        from .corpus import Corpus
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
+        from chatterbot.corpus import Corpus
 
         self.corpus = Corpus()
 
@@ -171,8 +171,8 @@ class TwitterTrainer(Trainer):
                          This parameter is optional. Default is None (all languages).
     """
 
-    def __init__(self, storage, **kwargs):
-        super(TwitterTrainer, self).__init__(storage, **kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
         from twitter import Api as TwitterApi
 
         # The word to be used as the first search term when searching for tweets
@@ -266,8 +266,8 @@ class UbuntuCorpusTrainer(Trainer):
     the Ubuntu Dialog Corpus.
     """
 
-    def __init__(self, storage, **kwargs):
-        super(UbuntuCorpusTrainer, self).__init__(storage, **kwargs)
+    def __init__(self, chatbot, **kwargs):
+        super().__init__(chatbot, **kwargs)
 
         self.data_download_url = kwargs.get(
             'ubuntu_corpus_data_download_url',

--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -17,7 +17,7 @@ def import_module(dotted_path):
     return getattr(module, module_parts[-1])
 
 
-def initialize_class(data, **kwargs):
+def initialize_class(data, *args, **kwargs):
     """
     :param data: A string or dictionary containing a import_path attribute.
     """
@@ -26,11 +26,11 @@ def initialize_class(data, **kwargs):
         data.update(kwargs)
         Class = import_module(import_path)
 
-        return Class(**data)
+        return Class(*args, **data)
     else:
         Class = import_module(data)
 
-        return Class(**kwargs)
+        return Class(*args, **kwargs)
 
 
 def validate_adapter_class(validate_class, adapter_class):
@@ -46,7 +46,7 @@ def validate_adapter_class(validate_class, adapter_class):
 
     :raises: Adapter.InvalidAdapterTypeException
     """
-    from .adapters import Adapter
+    from chatterbot.adapters import Adapter
 
     # If a dictionary was passed in, check if it has an import_path attribute
     if isinstance(validate_class, dict):

--- a/tests/api_tests/test_gitter.py
+++ b/tests/api_tests/test_gitter.py
@@ -1,5 +1,5 @@
-from unittest import TestCase
 from unittest.mock import Mock
+from tests.base_case import ChatBotTestCase
 from chatterbot.api import gitter
 
 
@@ -39,7 +39,7 @@ def mock_post_response(*args, **kwargs):
     return endpoints[url]
 
 
-class GitterTestCase(TestCase):
+class GitterTestCase(ChatBotTestCase):
 
     def setUp(self):
         super().setUp()

--- a/tests/api_tests/test_microsoft.py
+++ b/tests/api_tests/test_microsoft.py
@@ -1,5 +1,5 @@
-from unittest import TestCase
 from unittest.mock import Mock
+from tests.base_case import ChatBotTestCase
 from chatterbot.api import microsoft
 
 
@@ -78,7 +78,7 @@ def mock_get_request(*args, **kwargs):
     return endpoints[url]
 
 
-class MicrosoftTestCase(TestCase):
+class MicrosoftTestCase(ChatBotTestCase):
 
     def setUp(self):
         super().setUp()

--- a/tests/input_adapter_tests/test_gitter_input_adapter.py
+++ b/tests/input_adapter_tests/test_gitter_input_adapter.py
@@ -9,6 +9,7 @@ class GitterAdapterTests(GitterTestCase):
         super().setUp()
 
         self.adapter = Gitter(
+            self.chatbot,
             gitter_room='',
             gitter_api_token='',
             gitter_sleep_time=0,

--- a/tests/input_adapter_tests/test_input_adapter.py
+++ b/tests/input_adapter_tests/test_input_adapter.py
@@ -11,8 +11,8 @@ class InputAdapterTestCase(ChatBotTestCase):
     """
 
     def setUp(self):
-        super(InputAdapterTestCase, self).setUp()
-        self.adapter = InputAdapter()
+        super().setUp()
+        self.adapter = InputAdapter(self.chatbot)
 
     def test_process_response(self):
         with self.assertRaises(InputAdapter.AdapterMethodNotImplementedError):

--- a/tests/input_adapter_tests/test_microsoft_input_adapter.py
+++ b/tests/input_adapter_tests/test_microsoft_input_adapter.py
@@ -9,6 +9,7 @@ class MicrosoftInputAdapterTests(MicrosoftTestCase):
         super().setUp()
 
         self.adapter = Microsoft(
+            self.chatbot,
             direct_line_token_or_secret='xtFDtPemROU.cwA.Mcs.qiScdaSx87ffj2l7OjSITqJFoN-9Ado5AgwVeknac94',
         )
 

--- a/tests/input_adapter_tests/test_variable_input_type_adapter.py
+++ b/tests/input_adapter_tests/test_variable_input_type_adapter.py
@@ -1,12 +1,13 @@
-from unittest import TestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.conversation import Statement
 from chatterbot.input import VariableInputTypeAdapter
 
 
-class VariableInputTypeAdapterTests(TestCase):
+class VariableInputTypeAdapterTests(ChatBotTestCase):
 
     def setUp(self):
-        self.adapter = VariableInputTypeAdapter()
+        super().setUp()
+        self.adapter = VariableInputTypeAdapter(self.chatbot)
 
     def test_statement_returned_dict(self):
         data = {

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_levenshtein_distance.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_levenshtein_distance.py
@@ -11,13 +11,13 @@ class BestMatchLevenshteinDistanceTestCase(ChatBotTestCase):
     """
 
     def setUp(self):
-        super(BestMatchLevenshteinDistanceTestCase, self).setUp()
+        super().setUp()
         from chatterbot.comparisons import levenshtein_distance
 
         self.adapter = BestMatch(
+            self.chatbot,
             statement_comparison_function=levenshtein_distance
         )
-        self.adapter.set_chatbot(self.chatbot)
 
     def test_get_closest_statement(self):
         """

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_sentiment_comparison.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_sentiment_comparison.py
@@ -10,7 +10,7 @@ class BestMatchSentimentComparisonTestCase(ChatBotTestCase):
     """
 
     def setUp(self):
-        super(BestMatchSentimentComparisonTestCase, self).setUp()
+        super().setUp()
         from chatterbot.trainers import ListTrainer
         from chatterbot.comparisons import sentiment_comparison
 
@@ -20,9 +20,9 @@ class BestMatchSentimentComparisonTestCase(ChatBotTestCase):
         )
 
         self.adapter = BestMatch(
+            self.chatbot,
             statement_comparison_function=sentiment_comparison
         )
-        self.adapter.set_chatbot(self.chatbot)
         self.adapter.initialize()
 
     def test_exact_input(self):

--- a/tests/logic_adapter_tests/best_match_integration_tests/test_synset_distance.py
+++ b/tests/logic_adapter_tests/best_match_integration_tests/test_synset_distance.py
@@ -11,17 +11,14 @@ class BestMatchSynsetDistanceTestCase(ChatBotTestCase):
     """
 
     def setUp(self):
-        super(BestMatchSynsetDistanceTestCase, self).setUp()
+        super().setUp()
         from chatterbot.comparisons import synset_distance
 
         self.adapter = BestMatch(
+            self.chatbot,
             statement_comparison_function=synset_distance
         )
-
         self.adapter.initialize()
-
-        # Add a mock storage adapter to the logic adapter
-        self.adapter.set_chatbot(self.chatbot)
 
     def test_get_closest_statement(self):
         """

--- a/tests/logic_adapter_tests/test_best_match.py
+++ b/tests/logic_adapter_tests/test_best_match.py
@@ -10,9 +10,8 @@ class BestMatchTestCase(ChatBotTestCase):
     """
 
     def setUp(self):
-        super(BestMatchTestCase, self).setUp()
-        self.adapter = BestMatch()
-        self.adapter.set_chatbot(self.chatbot)
+        super().setUp()
+        self.adapter = BestMatch(self.chatbot)
 
     def test_no_choices(self):
         """

--- a/tests/logic_adapter_tests/test_data_cache.py
+++ b/tests/logic_adapter_tests/test_data_cache.py
@@ -20,11 +20,11 @@ class DummyMutatorLogicAdapter(LogicAdapter):
 class DataCachingTests(ChatBotTestCase):
 
     def setUp(self):
-        super(DataCachingTests, self).setUp()
+        super().setUp()
 
-        logic_adapter = DummyMutatorLogicAdapter()
-        logic_adapter.set_chatbot(self.chatbot)
-        self.chatbot.logic_adapters = [logic_adapter]
+        self.chatbot.logic_adapters = [
+            DummyMutatorLogicAdapter(self.chatbot)
+        ]
 
         self.trainer = ListTrainer(
             self.chatbot,

--- a/tests/logic_adapter_tests/test_logic_adapter.py
+++ b/tests/logic_adapter_tests/test_logic_adapter.py
@@ -1,8 +1,8 @@
-from unittest import TestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.logic import LogicAdapter
 
 
-class LogicAdapterTestCase(TestCase):
+class LogicAdapterTestCase(ChatBotTestCase):
     """
     This test case is for the LogicAdapter base class.
     Although this class is not intended for direct use,
@@ -11,8 +11,8 @@ class LogicAdapterTestCase(TestCase):
     """
 
     def setUp(self):
-        super(LogicAdapterTestCase, self).setUp()
-        self.adapter = LogicAdapter()
+        super().setUp()
+        self.adapter = LogicAdapter(self.chatbot)
 
     def test_class_name(self):
         """
@@ -32,6 +32,7 @@ class LogicAdapterTestCase(TestCase):
 
     def test_set_statement_comparison_function_string(self):
         adapter = LogicAdapter(
+            self.chatbot,
             statement_comparison_function='chatterbot.comparisons.levenshtein_distance'
         )
         self.assertTrue(callable(adapter.compare_statements))
@@ -39,12 +40,14 @@ class LogicAdapterTestCase(TestCase):
     def test_set_statement_comparison_function_callable(self):
         from chatterbot.comparisons import levenshtein_distance
         adapter = LogicAdapter(
+            self.chatbot,
             statement_comparison_function=levenshtein_distance
         )
         self.assertTrue(callable(adapter.compare_statements))
 
     def test_set_response_selection_method_string(self):
         adapter = LogicAdapter(
+            self.chatbot,
             response_selection_method='chatterbot.response_selection.get_first_response'
         )
         self.assertTrue(callable(adapter.select_response))
@@ -52,6 +55,7 @@ class LogicAdapterTestCase(TestCase):
     def test_set_response_selection_method_callable(self):
         from chatterbot.response_selection import get_first_response
         adapter = LogicAdapter(
+            self.chatbot,
             response_selection_method=get_first_response
         )
         self.assertTrue(callable(adapter.select_response))

--- a/tests/logic_adapter_tests/test_low_confidence_adapter.py
+++ b/tests/logic_adapter_tests/test_low_confidence_adapter.py
@@ -10,11 +10,8 @@ class LowConfidenceAdapterTestCase(ChatBotTestCase):
     """
 
     def setUp(self):
-        super(LowConfidenceAdapterTestCase, self).setUp()
-        self.adapter = LowConfidenceAdapter()
-
-        # Add a mock storage adapter to the logic adapter
-        self.adapter.set_chatbot(self.chatbot)
+        super().setUp()
+        self.adapter = LowConfidenceAdapter(self.chatbot)
 
         possible_choices = [
             Statement(

--- a/tests/logic_adapter_tests/test_mathematical_evaluation.py
+++ b/tests/logic_adapter_tests/test_mathematical_evaluation.py
@@ -1,12 +1,13 @@
-from unittest import TestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.logic import MathematicalEvaluation
 from chatterbot.conversation import Statement
 
 
-class MathematicalEvaluationTests(TestCase):
+class MathematicalEvaluationTests(ChatBotTestCase):
 
     def setUp(self):
-        self.adapter = MathematicalEvaluation()
+        super().setUp()
+        self.adapter = MathematicalEvaluation(self.chatbot)
 
     def test_can_process(self):
         statement = Statement('What is 10 + 10 + 10?')

--- a/tests/logic_adapter_tests/test_specific_response.py
+++ b/tests/logic_adapter_tests/test_specific_response.py
@@ -1,16 +1,17 @@
-from unittest import TestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.logic import SpecificResponseAdapter
 from chatterbot.conversation import Statement
 
 
-class SpecificResponseAdapterTestCase(TestCase):
+class SpecificResponseAdapterTestCase(ChatBotTestCase):
     """
     Test cases for the SpecificResponseAdapter
     """
 
     def setUp(self):
-        super(SpecificResponseAdapterTestCase, self).setUp()
+        super().setUp()
         self.adapter = SpecificResponseAdapter(
+            self.chatbot,
             input_text='Open sesame!',
             output_text='Your sesame seed hamburger roll is now open.'
         )

--- a/tests/logic_adapter_tests/test_time.py
+++ b/tests/logic_adapter_tests/test_time.py
@@ -1,12 +1,13 @@
-from unittest import TestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.logic import TimeLogicAdapter
 from chatterbot.conversation import Statement
 
 
-class TimeAdapterTests(TestCase):
+class TimeAdapterTests(ChatBotTestCase):
 
     def setUp(self):
-        self.adapter = TimeLogicAdapter()
+        super().setUp()
+        self.adapter = TimeLogicAdapter(self.chatbot)
 
     def test_positive_input(self):
         statement = Statement("Do you know what time it is?")

--- a/tests/logic_adapter_tests/test_unit_conversion.py
+++ b/tests/logic_adapter_tests/test_unit_conversion.py
@@ -1,11 +1,12 @@
-from unittest import TestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.logic import UnitConversion
 from chatterbot.conversation import Statement
 
 
-class UnitConversionTests(TestCase):
+class UnitConversionTests(ChatBotTestCase):
     def setUp(self):
-        self.adapter = UnitConversion()
+        super().setUp()
+        self.adapter = UnitConversion(self.chatbot)
 
     def test_can_process(self):
         statement = Statement('How many inches are in two kilometers?')

--- a/tests/output_adapter_tests/test_gitter_output_adapter.py
+++ b/tests/output_adapter_tests/test_gitter_output_adapter.py
@@ -9,6 +9,7 @@ class GitterAdapterTestCase(GitterTestCase):
         super().setUp()
 
         self.adapter = Gitter(
+            self.chatbot,
             gitter_room='',
             gitter_api_token='',
             gitter_sleep_time=0,

--- a/tests/output_adapter_tests/test_microsoft_output_adapter.py
+++ b/tests/output_adapter_tests/test_microsoft_output_adapter.py
@@ -9,6 +9,7 @@ class MicrosoftAdapterTests(MicrosoftTestCase):
         super().setUp()
 
         self.adapter = Microsoft(
+            self.chatbot,
             direct_line_token_or_secret='xtFDtPemROU.cwA.Mcs.qiScdaSx87ffj2l7OjSITqJFoN-9Ado5AgwVeknac94',
             conversation_id='IEyJvnDULgn'
         )

--- a/tests/output_adapter_tests/test_output_adapter.py
+++ b/tests/output_adapter_tests/test_output_adapter.py
@@ -1,8 +1,8 @@
-from unittest import TestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.output import OutputAdapter
 
 
-class OutputAdapterTestCase(TestCase):
+class OutputAdapterTestCase(ChatBotTestCase):
     """
     This test case is for the OutputAdapter base class.
     Although this class is not intended for direct use,
@@ -11,8 +11,8 @@ class OutputAdapterTestCase(TestCase):
     """
 
     def setUp(self):
-        super(OutputAdapterTestCase, self).setUp()
-        self.adapter = OutputAdapter()
+        super().setUp()
+        self.adapter = OutputAdapter(self.chatbot)
 
     def test_process_response(self):
         """

--- a/tests/output_adapter_tests/test_terminal_adapter.py
+++ b/tests/output_adapter_tests/test_terminal_adapter.py
@@ -1,9 +1,9 @@
-from unittest import TestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.conversation import Statement
 from chatterbot.output import TerminalAdapter
 
 
-class TerminalAdapterTests(TestCase):
+class TerminalAdapterTests(ChatBotTestCase):
     """
     The terminal adapter is designed to allow
     interaction with the chat bot to occur through
@@ -11,7 +11,8 @@ class TerminalAdapterTests(TestCase):
     """
 
     def setUp(self):
-        self.adapter = TerminalAdapter()
+        super().setUp()
+        self.adapter = TerminalAdapter(self.chatbot)
 
     def test_response_is_returned(self):
         """

--- a/tests/test_adapter_validation.py
+++ b/tests/test_adapter_validation.py
@@ -1,6 +1,6 @@
 from chatterbot import ChatBot
 from chatterbot.adapters import Adapter
-from .base_case import ChatBotTestCase
+from tests.base_case import ChatBotTestCase
 
 
 class AdapterValidationTests(ChatBotTestCase):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -5,7 +5,7 @@ performance based regressions when changes are made.
 """
 
 from random import choice
-from .base_case import ChatBotSQLTestCase, ChatBotMongoTestCase
+from tests.base_case import ChatBotSQLTestCase, ChatBotMongoTestCase
 from chatterbot import ChatBot
 from chatterbot.trainers import ListTrainer
 from chatterbot import utils

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .base_case import ChatBotTestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.logic import LogicAdapter
 from chatterbot.conversation import Statement
 
@@ -217,9 +217,9 @@ class ChatBotLogicAdapterTestCase(ChatBotTestCase):
         highest confidence available from these matching options.
         """
         self.chatbot.logic_adapters = [
-            TestAdapterA(),
-            TestAdapterB(),
-            TestAdapterC()
+            TestAdapterA(self.chatbot),
+            TestAdapterB(self.chatbot),
+            TestAdapterC(self.chatbot)
         ]
 
         statement = self.chatbot.generate_response(Statement('Howdy!'))
@@ -232,8 +232,8 @@ class ChatBotLogicAdapterTestCase(ChatBotTestCase):
         Test that all system logic adapters and regular logic adapters
         can be retrieved as a list by a single method.
         """
-        adapter_a = TestAdapterA()
-        adapter_b = TestAdapterB()
+        adapter_a = TestAdapterA(self.chatbot)
+        adapter_b = TestAdapterB(self.chatbot)
         self.chatbot.system_logic_adapters = [adapter_a]
         self.chatbot.logic_adapters = [adapter_b]
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,4 @@
-from .base_case import ChatBotTestCase
+from tests.base_case import ChatBotTestCase
 
 
 class AdapterTests(ChatBotTestCase):

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,4 +1,4 @@
-from .base_case import ChatBotTestCase
+from tests.base_case import ChatBotTestCase
 
 
 class StringInitializationTestCase(ChatBotTestCase):

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .base_case import ChatBotTestCase
+from tests.base_case import ChatBotTestCase
 from chatterbot.conversation import Statement
 from chatterbot import preprocessors
 

--- a/tests/test_response_selection.py
+++ b/tests/test_response_selection.py
@@ -1,4 +1,4 @@
-from .base_case import ChatBotSQLTestCase
+from tests.base_case import ChatBotSQLTestCase
 from chatterbot import response_selection
 from chatterbot.conversation import Statement
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .base_case import ChatBotTestCase
+from tests.base_case import ChatBotTestCase
 from unittest import TestCase
 from chatterbot import utils
 

--- a/tests_django/base_case.py
+++ b/tests_django/base_case.py
@@ -1,0 +1,10 @@
+from chatterbot import ChatBot
+from django.test import TestCase
+from tests_django import test_settings
+
+
+class ChatterBotTestCase(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.chatbot = ChatBot(**test_settings.CHATTERBOT)

--- a/tests_django/integration_tests/test_chatterbot_corpus_training.py
+++ b/tests_django/integration_tests/test_chatterbot_corpus_training.py
@@ -1,10 +1,8 @@
-from django.test import TestCase
-from django.conf import settings
-from chatterbot import ChatBot
+from tests_django.base_case import ChatterBotTestCase
 from chatterbot.trainers import ChatterBotCorpusTrainer
 
 
-class ChatterBotCorpusTrainingTestCase(TestCase):
+class ChatterBotCorpusTrainingTestCase(ChatterBotTestCase):
     """
     Test case for training with data from the ChatterBot Corpus.
 
@@ -12,8 +10,7 @@ class ChatterBotCorpusTrainingTestCase(TestCase):
     """
 
     def setUp(self):
-        super(ChatterBotCorpusTrainingTestCase, self).setUp()
-        self.chatbot = ChatBot(**settings.CHATTERBOT)
+        super().setUp()
 
         self.trainer = ChatterBotCorpusTrainer(
             self.chatbot,
@@ -21,7 +18,7 @@ class ChatterBotCorpusTrainingTestCase(TestCase):
         )
 
     def tearDown(self):
-        super(ChatterBotCorpusTrainingTestCase, self).setUp()
+        super().setUp()
         self.chatbot.storage.drop()
 
     def test_train_with_english_greeting_corpus(self):

--- a/tests_django/integration_tests/test_input_adapter_integration.py
+++ b/tests_django/integration_tests/test_input_adapter_integration.py
@@ -1,8 +1,8 @@
-from django.test import TestCase
+from tests_django.base_case import ChatterBotTestCase
 from chatterbot.ext.django_chatterbot.models import Statement
 
 
-class InputIntegrationTestCase(TestCase):
+class InputIntegrationTestCase(ChatterBotTestCase):
     """
     Tests to make sure that logic adapters
     function correctly when using Django.
@@ -11,7 +11,7 @@ class InputIntegrationTestCase(TestCase):
     def test_variable_type_input_adapter(self):
         from chatterbot.input import VariableInputTypeAdapter
 
-        adapter = VariableInputTypeAdapter()
+        adapter = VariableInputTypeAdapter(self.chatbot)
 
         statement = Statement(text='_')
 

--- a/tests_django/integration_tests/test_logic_adapter_integration.py
+++ b/tests_django/integration_tests/test_logic_adapter_integration.py
@@ -1,27 +1,22 @@
-from django.test import TestCase
+from tests_django.base_case import ChatterBotTestCase
 from chatterbot.ext.django_chatterbot.models import Statement
 
 
-class LogicIntegrationTestCase(TestCase):
+class LogicIntegrationTestCase(ChatterBotTestCase):
     """
     Tests to make sure that logic adapters
     function correctly when using Django.
     """
 
     def setUp(self):
-        super(LogicIntegrationTestCase, self).setUp()
-        from chatterbot import ChatBot
-        from chatterbot.ext.django_chatterbot import settings
-
-        self.chatbot = ChatBot(**settings.CHATTERBOT)
+        super().setUp()
 
         Statement.objects.create(text='Default statement')
 
     def test_best_match(self):
         from chatterbot.logic import BestMatch
 
-        adapter = BestMatch()
-        adapter.set_chatbot(self.chatbot)
+        adapter = BestMatch(self.chatbot)
 
         statement1 = Statement.objects.create(
             text='Do you like programming?',
@@ -42,8 +37,7 @@ class LogicIntegrationTestCase(TestCase):
     def test_low_confidence(self):
         from chatterbot.logic import LowConfidenceAdapter
 
-        adapter = LowConfidenceAdapter()
-        adapter.set_chatbot(self.chatbot)
+        adapter = LowConfidenceAdapter(self.chatbot)
 
         statement = Statement(text='Why is the sky blue?')
 
@@ -54,8 +48,7 @@ class LogicIntegrationTestCase(TestCase):
     def test_mathematical_evaluation(self):
         from chatterbot.logic import MathematicalEvaluation
 
-        adapter = MathematicalEvaluation()
-        adapter.set_chatbot(self.chatbot)
+        adapter = MathematicalEvaluation(self.chatbot)
 
         statement = Statement(text='What is 6 + 6?')
 
@@ -67,8 +60,7 @@ class LogicIntegrationTestCase(TestCase):
     def test_time(self):
         from chatterbot.logic import TimeLogicAdapter
 
-        adapter = TimeLogicAdapter()
-        adapter.set_chatbot(self.chatbot)
+        adapter = TimeLogicAdapter(self.chatbot)
 
         statement = Statement(text='What time is it?')
 

--- a/tests_django/integration_tests/test_output_adapter_integration.py
+++ b/tests_django/integration_tests/test_output_adapter_integration.py
@@ -1,8 +1,8 @@
-from django.test import TestCase
+from tests_django.base_case import ChatterBotTestCase
 from chatterbot.ext.django_chatterbot.models import Statement
 
 
-class OutputIntegrationTestCase(TestCase):
+class OutputIntegrationTestCase(ChatterBotTestCase):
     """
     Tests to make sure that output adapters
     function correctly when using Django.
@@ -11,7 +11,7 @@ class OutputIntegrationTestCase(TestCase):
     def test_output_adapter(self):
         from chatterbot.output import OutputAdapter
 
-        adapter = OutputAdapter()
+        adapter = OutputAdapter(self.chatbot)
 
         statement = Statement(text='_')
         result = adapter.process_response(statement)

--- a/tests_django/integration_tests/test_statement_integration.py
+++ b/tests_django/integration_tests/test_statement_integration.py
@@ -10,7 +10,7 @@ class StatementIntegrationTestCase(TestCase):
     """
 
     def setUp(self):
-        super(StatementIntegrationTestCase, self).setUp()
+        super().setUp()
 
         from datetime import datetime
         from pytz import UTC

--- a/tests_django/test_settings.py
+++ b/tests_django/test_settings.py
@@ -2,6 +2,7 @@
 Django settings for when tests are run.
 """
 import os
+from chatterbot import constants
 
 DEBUG = True
 
@@ -27,6 +28,8 @@ CHATTERBOT = {
             'import_path': 'chatterbot.logic.MathematicalEvaluation',
         }
     ],
+    'storage_adapter': 'chatterbot.storage.DjangoStorageAdapter',
+    'django_app_name': constants.DEFAULT_DJANGO_APP_NAME,
     'initialize': False
 }
 


### PR DESCRIPTION
The `chatbot` is not a parameter that is **required** when the class is initialized.