### PR TITLE
Add a persona filed to statements to track the speaker

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -156,6 +156,7 @@ class ChatBot(object):
 
         result.confidence = max_confidence
         result.conversation = input_statement.conversation
+        result.persona = 'bot:' + self.name
 
         return result
 

--- a/chatterbot/constants.py
+++ b/chatterbot/constants.py
@@ -16,6 +16,11 @@ of a UUID4 with no hyphens.
 '''
 CONVERSATION_LABEL_MAX_LENGTH = 32
 
+'''
+The maximum length of text that can be stored in the persona field of the statement model.
+'''
+PERSONA_MAX_LENGTH = 50
+
 # The maximum length of characters that the name of a tag can contain
 TAG_NAME_MAX_LENGTH = 50
 

--- a/chatterbot/conversation.py
+++ b/chatterbot/conversation.py
@@ -27,6 +27,7 @@ class StatementMixin(object):
             'created_at': self.created_at.isoformat().split('+', 1)[0],
             'conversation': self.conversation,
             'in_response_to': self.in_response_to,
+            'persona': self.persona,
             'tags': self.get_tags()
         }
 
@@ -52,6 +53,8 @@ class Statement(StatementMixin):
         self.text = text
 
         self.conversation = kwargs.get('conversation', '')
+
+        self.persona = kwargs.get('persona', '')
 
         self.tags = kwargs.pop('tags', [])
         self.in_response_to = kwargs.pop('in_response_to', None)

--- a/chatterbot/ext/django_chatterbot/abstract_models.py
+++ b/chatterbot/ext/django_chatterbot/abstract_models.py
@@ -50,6 +50,10 @@ class AbstractBaseStatement(models.Model, StatementMixin):
         null=True
     )
 
+    persona = models.CharField(
+        max_length=constants.PERSONA_MAX_LENGTH
+    )
+
     # This is the confidence with which the chat bot believes
     # this is an accurate response. This value is set when the
     # statement is returned by the chat bot.

--- a/chatterbot/ext/django_chatterbot/migrations/0015_statement_persona.py
+++ b/chatterbot/ext/django_chatterbot/migrations/0015_statement_persona.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_chatterbot', '0014_remove_statement_extra_data'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='statement',
+            name='persona',
+            field=models.CharField(default='', max_length=50),
+            preserve_default=False,
+        ),
+    ]

--- a/chatterbot/ext/sqlalchemy_app/models.py
+++ b/chatterbot/ext/sqlalchemy_app/models.py
@@ -76,6 +76,10 @@ class Statement(Base, StatementMixin):
         nullable=True
     )
 
+    persona = Column(
+        String(constants.PERSONA_MAX_LENGTH)
+    )
+
     def get_tags(self):
         """
         Return a list of tags for this statement.

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -220,7 +220,8 @@ class SQLStorageAdapter(StorageAdapter):
                 if not record:
                     record = Statement(
                         text=statement.text,
-                        conversation=statement.conversation
+                        conversation=statement.conversation,
+                        persona=statement.persona
                     )
 
             # Update the response value

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -244,3 +244,11 @@ class ChatBotLogicAdapterTestCase(ChatBotTestCase):
     def test_chatbot_set_for_all_logic_adapters(self):
         for sub_adapter in self.chatbot.get_logic_adapters():
             self.assertEqual(sub_adapter.chatbot, self.chatbot)
+
+    def test_response_persona_is_bot(self):
+        """
+        The response returned from the chatbot should be set to the name of the chatbot.
+        """
+        response = self.chatbot.get_response('Hey everyone!')
+
+        self.assertEqual(response.persona, 'bot:Test Bot')


### PR DESCRIPTION
For now, this will track statements generated by the chatbot. In the future, this may be used to record statement in conversations with multiple users.