### PR TITLE
Make get_response_statements methods into lazy-loading generators

### DIFF
--- a/chatterbot/logic/best_match.py
+++ b/chatterbot/logic/best_match.py
@@ -12,20 +12,9 @@ class BestMatch(LogicAdapter):
         Takes a statement string and a list of statement strings.
         Returns the closest matching statement from the list.
         """
-        statement_list = self.chatbot.storage.get_response_statements()
-
-        if not statement_list:
-            if self.chatbot.storage.count():
-                # Use a randomly picked statement
-                self.chatbot.logger.info(
-                    'No statements have known responses. ' +
-                    'Choosing a random response to return.'
-                )
-                random_response = self.chatbot.storage.get_random()
-                random_response.confidence = 0
-                return random_response
-            else:
-                raise self.EmptyDatasetException()
+        statement_list = self.chatbot.storage.get_response_statements(
+            self.search_page_size
+        )
 
         closest_match = input_statement
         closest_match.confidence = 0
@@ -37,6 +26,10 @@ class BestMatch(LogicAdapter):
             if confidence > closest_match.confidence:
                 statement.confidence = confidence
                 closest_match = statement
+
+            # Stop searching if a match that is close enough is found
+            if closest_match.confidence >= self.maximum_similarity_threshold:
+                break
 
         return closest_match
 

--- a/chatterbot/logic/logic_adapter.py
+++ b/chatterbot/logic/logic_adapter.py
@@ -30,6 +30,21 @@ class LogicAdapter(Adapter):
             if isinstance(import_path, str):
                 kwargs['response_selection_method'] = import_module(import_path)
 
+        '''
+        The maximum amount of similarity between two statement that is required
+        before the search process is halted. The search for a matching statement
+        will continue until a statement with a greater than or equal similarity
+        is found or the search set is exhausted.
+        '''
+        self.maximum_similarity_threshold = kwargs.get(
+            'maximum_similarity_threshold', 0.99
+        )
+
+        # The maximum number of records to load into memory at a time when searching
+        self.search_page_size = kwargs.get(
+            'search_page_size', 1000
+        )
+
         # By default, compare statements using Levenshtein distance
         self.compare_statements = kwargs.get(
             'statement_comparison_function',
@@ -89,8 +104,3 @@ class LogicAdapter(Adapter):
         This is typically used for logging and debugging.
         """
         return str(self.__class__.__name__)
-
-    class EmptyDatasetException(Exception):
-
-        def __init__(self, message='An empty set was received when at least one statement was expected.'):
-            super().__init__(message)

--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -157,7 +157,7 @@ class DjangoStorageAdapter(StorageAdapter):
         Statement.objects.all().delete()
         Tag.objects.all().delete()
 
-    def get_response_statements(self):
+    def get_response_statements(self, page_size=1000):
         """
         Return only statements that are in response to another statement.
         A statement must exist which lists the closest matching statement in the
@@ -166,12 +166,22 @@ class DjangoStorageAdapter(StorageAdapter):
         """
         Statement = self.get_model('statement')
 
-        statements_with_responses = Statement.objects.filter(
-            in_response_to__isnull=False
-        ).values_list('in_response_to', flat=True)
+        total_statements = self.count()
+        start = 0
+        stop = min(page_size, total_statements)
 
-        return Statement.objects.exclude(
-            persona__startswith='bot:'
-        ).filter(
-            text__in=statements_with_responses
-        )
+        while stop <= total_statements:
+
+            statements_with_responses = Statement.objects.filter(
+                in_response_to__isnull=False
+            )[start:stop].values_list('in_response_to', flat=True)
+
+            start += page_size
+            stop += page_size
+
+            for statement in Statement.objects.exclude(
+                persona__startswith='bot:'
+            ).filter(
+                text__in=statements_with_responses
+            ):
+                yield statement

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -228,40 +228,52 @@ class MongoDatabaseAdapter(StorageAdapter):
         """
         self.statements.delete_one({'text': statement_text})
 
-    def get_response_statements(self):
+    def get_response_statements(self, page_size=1000):
         """
         Return only statements that are in response to another statement.
         A statement must exist which lists the closest matching statement in the
         in_response_to field. Otherwise, the logic adapter may find a closest
         matching statement that does not have a known response.
         """
+        total_statements = self.count()
+        start = 0
+
         _response_query = {
             'in_response_to': {
                 '$ne': None
             }
         }
 
-        response_query = self.statements.find(_response_query)
+        while start <= total_statements:
 
-        responses = set(
-            statement['in_response_to'] for statement in response_query
-        )
+            response_query = self.statements.find(
+                _response_query
+            ).skip(
+                start
+            ).limit(
+                page_size
+            )
 
-        _statement_query = {
-            'text': {
-                '$in': list(responses)
-            },
-            'persona': {
-                '$not': re.compile('^bot:*')
+            start += page_size
+
+            responses = set(
+                statement['in_response_to'] for statement in response_query
+            )
+
+            _statement_query = {
+                'text': {
+                    '$in': list(responses)
+                },
+                'persona': {
+                    '$not': re.compile('^bot:*')
+                }
             }
-        }
 
-        _statement_query.update(self.base_query.value())
-        statement_query = self.statements.find(_statement_query)
-        statement_objects = []
-        for statement in list(statement_query):
-            statement_objects.append(self.mongo_to_object(statement))
-        return statement_objects
+            _statement_query.update(self.base_query.value())
+            statement_query = self.statements.find(_statement_query)
+
+            for statement in list(statement_query):
+                yield self.mongo_to_object(statement)
 
     def drop(self):
         """

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -265,6 +265,7 @@ class UbuntuCorpusTrainer(Trainer):
 
     def __init__(self, chatbot, **kwargs):
         super().__init__(chatbot, **kwargs)
+        home_directory = os.path.expanduser('~')
 
         self.data_download_url = kwargs.get(
             'ubuntu_corpus_data_download_url',
@@ -273,7 +274,7 @@ class UbuntuCorpusTrainer(Trainer):
 
         self.data_directory = kwargs.get(
             'ubuntu_corpus_data_directory',
-            './data/'
+            os.path.join(home_directory, 'ubuntu_data')
         )
 
         self.extracted_data_directory = os.path.join(
@@ -369,8 +370,8 @@ class UbuntuCorpusTrainer(Trainer):
         return True
 
     def train(self):
-        import glob
         import csv
+        import glob
 
         # Download and extract the Ubuntu dialog corpus if needed
         corpus_download_path = self.download(self.data_download_url)
@@ -384,12 +385,12 @@ class UbuntuCorpusTrainer(Trainer):
             '**', '**', '*.tsv'
         )
 
-        for file in glob.iglob(extracted_corpus_path):
-            self.chatbot.logger.info('Training from: {}'.format(file))
+        for tsv_file in glob.iglob(extracted_corpus_path):
+            print('Training from: {}'.format(tsv_file))
 
             statements_to_create = []
 
-            with open(file, 'r', encoding='utf-8') as tsv:
+            with open(tsv_file, 'r', encoding='utf-8') as tsv:
                 reader = csv.reader(tsv, delimiter='\t')
 
                 previous_statement_text = None
@@ -404,7 +405,6 @@ class UbuntuCorpusTrainer(Trainer):
                                 conversation='training'
                             )
                         )
-                        print(text, len(row))
 
                         statement.add_tags('datetime:' + row[0])
                         statement.add_tags('speaker:' + row[1])

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -375,7 +375,7 @@ class UbuntuCorpusTrainer(Trainer):
         # Download and extract the Ubuntu dialog corpus if needed
         corpus_download_path = self.download(self.data_download_url)
 
-        # Extract if the directory doesn not already exists
+        # Extract if the directory does not already exist
         if not self.is_extracted(self.extracted_data_directory):
             self.extract(corpus_download_path)
 

--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -147,7 +147,7 @@ def get_greatest_confidence(statement, options):
     return max(values)
 
 
-def get_response_time(chatbot):
+def get_response_time(chatbot, statement='Hello'):
     """
     Returns the amount of time taken for a given
     chat bot to return a response.
@@ -162,7 +162,7 @@ def get_response_time(chatbot):
 
     start_time = time.time()
 
-    chatbot.get_response('Hello')
+    chatbot.get_response(statement)
 
     return time.time() - start_time
 

--- a/tests/logic_adapter_tests/test_best_match.py
+++ b/tests/logic_adapter_tests/test_best_match.py
@@ -21,6 +21,7 @@ class BestMatchTestCase(ChatBotTestCase):
         self.adapter.chatbot.storage.count = MagicMock(return_value=0)
 
         statement = Statement(text='What is your quest?')
+        response = self.adapter.get(statement)
 
-        with self.assertRaises(BestMatch.EmptyDatasetException):
-            self.adapter.get(statement)
+        self.assertEqual(response.text, 'What is your quest?')
+        self.assertEqual(response.confidence, 0)

--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -142,7 +142,7 @@ class MongoDatabaseAdapterTestCase(MongoAdapterTestCase):
         self.adapter.create(text="A what?", in_response_to="This is a phone.")
         self.adapter.create(text="A phone.", in_response_to="A what?")
 
-        responses = self.adapter.get_response_statements()
+        responses = list(self.adapter.get_response_statements())
 
         self.assertIn("This is a phone.", responses)
         self.assertIn("A what?", responses)
@@ -158,7 +158,7 @@ class MongoDatabaseAdapterTestCase(MongoAdapterTestCase):
         self.adapter.create(text='That is awesome to hear.', in_response_to='I am doing great.', persona='bot:Test')
         self.adapter.create(text='Thank you.', in_response_to='That is awesome to hear.')
 
-        responses = self.adapter.get_response_statements()
+        responses = list(self.adapter.get_response_statements())
 
         self.assertIn('Hello', responses)
         self.assertIn('I am doing great.', responses)

--- a/tests/storage_adapter_tests/test_sql_adapter.py
+++ b/tests/storage_adapter_tests/test_sql_adapter.py
@@ -121,7 +121,7 @@ class SQLStorageAdapterTests(SQLStorageAdapterTestCase):
         self.adapter.create(text="A what?", in_response_to="This is a phone.")
         self.adapter.create(text="A phone.", in_response_to="A what?")
 
-        responses = self.adapter.get_response_statements()
+        responses = list(self.adapter.get_response_statements())
 
         self.assertIn("This is a phone.", responses)
         self.assertIn("A what?", responses)
@@ -137,7 +137,7 @@ class SQLStorageAdapterTests(SQLStorageAdapterTestCase):
         self.adapter.create(text='That is awesome to hear.', in_response_to='I am doing great.', persona='bot:Test')
         self.adapter.create(text='Thank you.', in_response_to='That is awesome to hear.')
 
-        responses = self.adapter.get_response_statements()
+        responses = list(self.adapter.get_response_statements())
 
         self.assertIn('Hello', responses)
         self.assertIn('I am doing great.', responses)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -4,10 +4,10 @@ various chat bot configurations to help prevent
 performance based regressions when changes are made.
 """
 
+from unittest import skip
 from warnings import warn
 from random import choice
 from tests.base_case import ChatBotSQLTestCase, ChatBotMongoTestCase
-from chatterbot import ChatBot
 from chatterbot.trainers import ListTrainer, ChatterBotCorpusTrainer, UbuntuCorpusTrainer
 from chatterbot.logic import BestMatch
 from chatterbot import utils
@@ -28,6 +28,7 @@ STATEMENT_LIST = [
         *[choice(WORDBANK) for __ in range(0, 10)]
     ) for _ in range(0, 10)
 ]
+
 
 def get_list_trainer(chatbot):
     return ListTrainer(
@@ -127,11 +128,15 @@ class SqlBenchmarkingTests(BenchmarkingMixin, ChatBotSQLTestCase):
 
         self.assert_response_duration_is_less_than(3)
 
+    @skip('Test marked as skipped due to execution time.')
     def test_get_response_after_ubuntu_corpus_training(self):
         """
         Test response time after training with the Ubuntu corpus.
         """
-        self.skipTest('TODO: This test needs to be written.')
+        trainer = get_ubuntu_corpus_trainer(self.chatbot)
+        trainer.train()
+
+        self.assert_response_duration_is_less_than(6)
 
 
 class MongoBenchmarkingTests(BenchmarkingMixin, ChatBotMongoTestCase):
@@ -183,8 +188,12 @@ class MongoBenchmarkingTests(BenchmarkingMixin, ChatBotMongoTestCase):
 
         self.assert_response_duration_is_less_than(3)
 
+    @skip('Test marked as skipped due to execution time.')
     def test_get_response_after_ubuntu_corpus_training(self):
         """
         Test response time after training with the Ubuntu corpus.
         """
-        self.skipTest('TODO: This test needs to be written.')
+        trainer = get_ubuntu_corpus_trainer(self.chatbot)
+        trainer.train()
+
+        self.assert_response_duration_is_less_than(6)

--- a/tests_django/test_django_adapter.py
+++ b/tests_django/test_django_adapter.py
@@ -125,10 +125,12 @@ class DjangoStorageAdapterTests(DjangoAdapterTestCase):
         s3 = self.adapter.create(text="A what?", in_response_to=s2.text)
         self.adapter.create(text="A phone.", in_response_to=s3.text)
 
-        responses = self.adapter.get_response_statements()
+        responses = [
+            response.text for response in list(self.adapter.get_response_statements())
+        ]
 
-        self.assertTrue(responses.filter(text="This is a phone.").exists())
-        self.assertTrue(responses.filter(text="A what?").exists())
+        self.assertIn("This is a phone.", responses)
+        self.assertIn("A what?", responses)
         self.assertEqual(len(responses), 2)
 
     def test_get_response_statements_bot_responses_filtered_out(self):
@@ -141,10 +143,12 @@ class DjangoStorageAdapterTests(DjangoAdapterTestCase):
         self.adapter.create(text='That is awesome to hear.', in_response_to='I am doing great.', persona='bot:Test')
         self.adapter.create(text='Thank you.', in_response_to='That is awesome to hear.')
 
-        responses = self.adapter.get_response_statements()
+        responses = [
+            response.text for response in list(self.adapter.get_response_statements())
+        ]
 
-        self.assertTrue(responses.filter(text='Hello').exists())
-        self.assertTrue(responses.filter(text='I am doing great.').exists())
+        self.assertIn('Hello', responses)
+        self.assertIn('I am doing great.', responses)
         self.assertEqual(len(responses), 2)
 
 


### PR DESCRIPTION
This resolves a major performance issue where ChatterBot loads large numbers of statements into memory for processing as a part of the search process. Memory allocation at that size has a massive amount of overhead. With this change, a more reasonable amount of statements will be analysed at a time and the processing will not be continued if an optimal response (within a specified range of similarity) is found.

* Closes #1363 
* Closes #1206
* Closes #1140
* Closes #1138
* Closes #697
* Closes #679
* Closes #1139

This should also help with #1218 but doesn't resolve it completely. Tests I've conduced locally still demonstrate ~15 second response times for 50 MB of training data. This means that response times are still not optimal after training the bot with a dataset the size if the Ubuntu Dialog Corpus.

***

I'm prepared to make additional performance optimizations as needed. My eventual goal is to be able to proved response times < 1 second for generating a response.