### PR TITLE
Add bulk-creation methods to storage adapters

### DIFF
--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -160,6 +160,12 @@ class MongoDatabaseAdapter(StorageAdapter):
 
         return Statement(**kwargs)
 
+    def create_many(self, statements):
+        """
+        Creates multiple statement entries.
+        """
+        self.statements.insert_many(statements)
+
     def update(self, statement):
         data = statement.serialize()
         data.pop('id', None)

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -164,6 +164,10 @@ class MongoDatabaseAdapter(StorageAdapter):
         """
         Creates multiple statement entries.
         """
+        for statement in statements:
+            if 'tags' in statement:
+                statement['tags'] = list(set(statement['tags']))
+
         self.statements.insert_many(statements)
 
     def update(self, statement):

--- a/chatterbot/storage/storage_adapter.py
+++ b/chatterbot/storage/storage_adapter.py
@@ -80,6 +80,14 @@ class StorageAdapter(object):
             'The `create` method is not implemented by this adapter.'
         )
 
+    def create_many(self, statements):
+        """
+        Creates multiple statement entries.
+        """
+        raise self.AdapterMethodNotImplementedError(
+            'The `create_many` method is not implemented by this adapter.'
+        )
+
     def update(self, statement):
         """
         Modifies an entry in the database.

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -73,6 +73,8 @@ class ListTrainer(Trainer):
         """
         previous_statement_text = None
 
+        statements_to_create = []
+
         for conversation_count, text in enumerate(conversation):
             if self.show_training_progress:
                 utils.print_progress_bar(
@@ -90,12 +92,14 @@ class ListTrainer(Trainer):
 
             previous_statement_text = statement.text
 
-            self.chatbot.storage.create(
-                text=statement.text,
-                in_response_to=statement.in_response_to,
-                conversation=statement.conversation,
-                tags=statement.tags
-            )
+            statements_to_create.append({
+                'text': statement.text,
+                'in_response_to': statement.in_response_to,
+                'conversation': statement.conversation,
+                'tags': statement.tags
+            })
+
+        self.chatbot.storage.create_many(statements_to_create)
 
 
 class ChatterBotCorpusTrainer(Trainer):
@@ -114,6 +118,8 @@ class ChatterBotCorpusTrainer(Trainer):
             data_file_paths.extend(list_corpus_files(corpus_path))
 
         for corpus, categories, file_path in load_corpus(*data_file_paths):
+
+            statements_to_create = []
 
             # Train the chat bot with each statement and response pair
             for conversation_count, conversation in enumerate(corpus):
@@ -141,12 +147,14 @@ class ChatterBotCorpusTrainer(Trainer):
 
                     previous_statement_text = statement.text
 
-                    self.chatbot.storage.create(
-                        text=statement.text,
-                        in_response_to=statement.in_response_to,
-                        conversation=statement.conversation,
-                        tags=statement.tags
-                    )
+                    statements_to_create.append({
+                        'text': statement.text,
+                        'in_response_to': statement.in_response_to,
+                        'conversation': statement.conversation,
+                        'tags': statement.tags
+                    })
+
+            self.chatbot.storage.create_many(statements_to_create)
 
 
 class TwitterTrainer(Trainer):
@@ -379,6 +387,8 @@ class UbuntuCorpusTrainer(Trainer):
         for file in glob.iglob(extracted_corpus_path):
             self.chatbot.logger.info('Training from: {}'.format(file))
 
+            statements_to_create = []
+
             with open(file, 'r', encoding='utf-8') as tsv:
                 reader = csv.reader(tsv, delimiter='\t')
 
@@ -404,9 +414,11 @@ class UbuntuCorpusTrainer(Trainer):
 
                         previous_statement_text = statement.text
 
-                        self.chatbot.storage.create(
-                            text=statement.text,
-                            in_response_to=statement.in_response_to,
-                            conversation=statement.conversation,
-                            tags=statement.tags
-                        )
+                        statements_to_create.append({
+                            'text': statement.text,
+                            'in_response_to': statement.in_response_to,
+                            'conversation': statement.conversation,
+                            'tags': statement.tags
+                        })
+
+            self.chatbot.storage.create_many(statements_to_create)

--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -341,6 +341,41 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
         self.assertEqual(len(results[0].get_tags()), 1)
         self.assertEqual(results[0].get_tags(), ['ab'])
 
+    def test_create_many_text(self):
+        self.adapter.create_many([
+            {
+                'text': 'A'
+            },
+            {
+                'text': 'B'
+            }
+        ])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].text, 'A')
+        self.assertEqual(results[1].text, 'B')
+
+    def test_create_many_tags(self):
+        self.adapter.create_many([
+            {
+                'text': 'A',
+                'tags': ['first', 'letter']
+            },
+            {
+                'text': 'B',
+                'tags': ['second', 'letter']
+            }
+        ])
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 2)
+        self.assertIn('letter', results[0].get_tags())
+        self.assertIn('letter', results[1].get_tags())
+        self.assertIn('first', results[0].get_tags())
+        self.assertIn('second', results[1].get_tags())
+
 
 class StorageAdapterUpdateTestCase(MongoAdapterFilterTestCase):
     """

--- a/tests/storage_adapter_tests/test_mongo_adapter.py
+++ b/tests/storage_adapter_tests/test_mongo_adapter.py
@@ -376,6 +376,24 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
         self.assertIn('first', results[0].get_tags())
         self.assertIn('second', results[1].get_tags())
 
+    def test_create_many_duplicate_tags(self):
+        """
+        The storage adapter should not create a statement with tags
+        that are duplicates.
+        """
+        self.adapter.create_many([
+            {
+                'text': 'testing',
+                'tags': ['ab', 'ab']
+            }
+        ])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0].get_tags()), 1)
+        self.assertEqual(results[0].get_tags(), ['ab'])
+
 
 class StorageAdapterUpdateTestCase(MongoAdapterFilterTestCase):
     """

--- a/tests/storage_adapter_tests/test_sql_adapter.py
+++ b/tests/storage_adapter_tests/test_sql_adapter.py
@@ -375,6 +375,24 @@ class StorageAdapterCreateTests(SQLStorageAdapterTestCase):
         self.assertIn('first', results[0].get_tags())
         self.assertIn('second', results[1].get_tags())
 
+    def test_create_many_duplicate_tags(self):
+        """
+        The storage adapter should not create a statement with tags
+        that are duplicates.
+        """
+        self.adapter.create_many([
+            {
+                'text': 'testing',
+                'tags': ['ab', 'ab']
+            }
+        ])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0].get_tags()), 1)
+        self.assertEqual(results[0].get_tags(), ['ab'])
+
 
 class StorageAdapterUpdateTests(SQLStorageAdapterTestCase):
     """

--- a/tests/storage_adapter_tests/test_sql_adapter.py
+++ b/tests/storage_adapter_tests/test_sql_adapter.py
@@ -340,6 +340,41 @@ class StorageAdapterCreateTests(SQLStorageAdapterTestCase):
         self.assertEqual(len(results[0].get_tags()), 1)
         self.assertEqual(results[0].get_tags(), ['ab'])
 
+    def test_create_many_text(self):
+        self.adapter.create_many([
+            {
+                'text': 'A'
+            },
+            {
+                'text': 'B'
+            }
+        ])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].text, 'A')
+        self.assertEqual(results[1].text, 'B')
+
+    def test_create_many_tags(self):
+        self.adapter.create_many([
+            {
+                'text': 'A',
+                'tags': ['first', 'letter']
+            },
+            {
+                'text': 'B',
+                'tags': ['second', 'letter']
+            }
+        ])
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 2)
+        self.assertIn('letter', results[0].get_tags())
+        self.assertIn('letter', results[1].get_tags())
+        self.assertIn('first', results[0].get_tags())
+        self.assertIn('second', results[1].get_tags())
+
 
 class StorageAdapterUpdateTests(SQLStorageAdapterTestCase):
     """

--- a/tests/storage_adapter_tests/test_storage_adapter.py
+++ b/tests/storage_adapter_tests/test_storage_adapter.py
@@ -30,6 +30,10 @@ class StorageAdapterTestCase(TestCase):
         with self.assertRaises(StorageAdapter.AdapterMethodNotImplementedError):
             self.adapter.create()
 
+    def test_create_many(self):
+        with self.assertRaises(StorageAdapter.AdapterMethodNotImplementedError):
+            self.adapter.create_many([])
+
     def test_update(self):
         with self.assertRaises(StorageAdapter.AdapterMethodNotImplementedError):
             self.adapter.update('')

--- a/tests_django/test_django_adapter.py
+++ b/tests_django/test_django_adapter.py
@@ -320,6 +320,41 @@ class StorageAdapterCreateTests(DjangoAdapterTestCase):
         self.assertEqual(len(results[0].get_tags()), 1)
         self.assertEqual(results[0].get_tags(), ['ab'])
 
+    def test_create_many_text(self):
+        self.adapter.create_many([
+            {
+                'text': 'A'
+            },
+            {
+                'text': 'B'
+            }
+        ])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].text, 'A')
+        self.assertEqual(results[1].text, 'B')
+
+    def test_create_many_tags(self):
+        self.adapter.create_many([
+            {
+                'text': 'A',
+                'tags': ['first', 'letter']
+            },
+            {
+                'text': 'B',
+                'tags': ['second', 'letter']
+            }
+        ])
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 2)
+        self.assertIn('letter', results[0].get_tags())
+        self.assertIn('letter', results[1].get_tags())
+        self.assertIn('first', results[0].get_tags())
+        self.assertIn('second', results[1].get_tags())
+
 
 class StorageAdapterUpdateTests(DjangoAdapterTestCase):
     """

--- a/tests_django/test_django_adapter.py
+++ b/tests_django/test_django_adapter.py
@@ -355,6 +355,24 @@ class StorageAdapterCreateTests(DjangoAdapterTestCase):
         self.assertIn('first', results[0].get_tags())
         self.assertIn('second', results[1].get_tags())
 
+    def test_create_many_duplicate_tags(self):
+        """
+        The storage adapter should not create a statement with tags
+        that are duplicates.
+        """
+        self.adapter.create_many([
+            {
+                'text': 'testing',
+                'tags': ['ab', 'ab']
+            }
+        ])
+
+        results = self.adapter.filter()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0].get_tags()), 1)
+        self.assertEqual(results[0].get_tags(), ['ab'])
+
 
 class StorageAdapterUpdateTests(DjangoAdapterTestCase):
     """


### PR DESCRIPTION
This adds bulk-creation capabilities to storage adapters to decrease the amount of time that training requires.

* Closes #1419
* Related to #1256