### PR TITLE
Remove chatbot parameter from preprocessors

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -114,7 +114,7 @@ class ChatBot(object):
 
         # Preprocess the input statement
         for preprocessor in self.preprocessors:
-            input_statement = preprocessor(self, input_statement)
+            input_statement = preprocessor(input_statement)
 
         response = self.generate_response(input_statement)
 

--- a/chatterbot/preprocessors.py
+++ b/chatterbot/preprocessors.py
@@ -4,7 +4,7 @@ Statement pre-processors.
 """
 
 
-def clean_whitespace(chatbot, statement):
+def clean_whitespace(statement):
     """
     Remove any consecutive whitespace characters from the statement text.
     """
@@ -22,7 +22,7 @@ def clean_whitespace(chatbot, statement):
     return statement
 
 
-def unescape_html(chatbot, statement):
+def unescape_html(statement):
     """
     Convert escaped html characters into unescaped html characters.
     For example: "&lt;b&gt;" becomes "<b>".
@@ -34,7 +34,7 @@ def unescape_html(chatbot, statement):
     return statement
 
 
-def convert_to_ascii(chatbot, statement):
+def convert_to_ascii(statement):
     """
     Converts unicode characters to ASCII character equivalents.
     For example: "på fédéral" becomes "pa federal".

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -23,7 +23,7 @@ class Trainer(object):
         Preprocess the input statement.
         """
         for preprocessor in self.chatbot.preprocessors:
-            input_statement = preprocessor(self, input_statement)
+            input_statement = preprocessor(input_statement)
 
         return input_statement
 

--- a/docs/preprocessors.rst
+++ b/docs/preprocessors.rst
@@ -35,5 +35,5 @@ Creating new preprocessors
 It is simple to create your own preprocessors. A preprocessor is just a function
 with a few requirements.
 
-1. It must take two parameters, the first is a ``ChatBot`` instance, the second is a ``Statement`` instance.
+1. It must take one parameter, a ``Statement`` instance.
 2. It must return a statement instance.

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -23,21 +23,21 @@ class CleanWhitespacePreprocessorTestCase(ChatBotTestCase):
 
     def test_clean_whitespace(self):
         statement = Statement(text='\tThe quick \nbrown fox \rjumps over \vthe \alazy \fdog\\.')
-        cleaned = preprocessors.clean_whitespace(self.chatbot, statement)
+        cleaned = preprocessors.clean_whitespace(statement)
         normal_text = 'The quick brown fox jumps over \vthe \alazy \fdog\\.'
 
         self.assertEqual(cleaned.text, normal_text)
 
     def test_leading_or_trailing_whitespace_removed(self):
         statement = Statement(text='     The quick brown fox jumps over the lazy dog.   ')
-        cleaned = preprocessors.clean_whitespace(self.chatbot, statement)
+        cleaned = preprocessors.clean_whitespace(statement)
         normal_text = 'The quick brown fox jumps over the lazy dog.'
 
         self.assertEqual(cleaned.text, normal_text)
 
     def test_consecutive_spaces_removed(self):
         statement = Statement(text='The       quick brown     fox      jumps over the lazy dog.')
-        cleaned = preprocessors.clean_whitespace(self.chatbot, statement)
+        cleaned = preprocessors.clean_whitespace(statement)
         normal_text = 'The quick brown fox jumps over the lazy dog.'
 
         self.assertEqual(cleaned.text, normal_text)
@@ -63,7 +63,7 @@ class HTMLUnescapePreprocessorTestCase(ChatBotTestCase):
             ' the <a href="http://lazy.com">lazy</a> dog.'
         )
 
-        cleaned = preprocessors.unescape_html(self.chatbot, statement)
+        cleaned = preprocessors.unescape_html(statement)
 
         self.assertEqual(cleaned.text, normal_text)
 
@@ -75,7 +75,7 @@ class ConvertToASCIIPreprocessorTestCase(ChatBotTestCase):
 
     def test_convert_to_ascii(self):
         statement = Statement(text=u'Klüft skräms inför på fédéral électoral große')
-        cleaned = preprocessors.convert_to_ascii(self.chatbot, statement)
+        cleaned = preprocessors.convert_to_ascii(statement)
         normal_text = 'Kluft skrams infor pa federal electoral groe'
 
         self.assertEqual(cleaned.text, normal_text)


### PR DESCRIPTION
This change is because the chatbot parameter is unused and removing it allows these methods to be passed in as parameters to a multiprocessing map function (related to #1470).