### PR TITLE
Use tag name as primary key

### DIFF
--- a/chatterbot/ext/django_chatterbot/abstract_models.py
+++ b/chatterbot/ext/django_chatterbot/abstract_models.py
@@ -90,8 +90,7 @@ class AbstractBaseStatement(models.Model, StatementMixin):
         (Overrides the method from StatementMixin)
         """
         for _tag in tags:
-            if not self.tags.filter(name=_tag).exists():
-                self.tags.create(name=_tag)
+            self.tags.get_or_create(name=_tag)
 
 
 class AbstractBaseTag(models.Model):
@@ -102,6 +101,7 @@ class AbstractBaseTag(models.Model):
     """
 
     name = models.SlugField(
+        primary_key=True,
         max_length=constants.TAG_NAME_MAX_LENGTH
     )
 

--- a/chatterbot/ext/django_chatterbot/migrations/0017_name_primary_key.py
+++ b/chatterbot/ext/django_chatterbot/migrations/0017_name_primary_key.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_chatterbot', '0016_statement_stemmed_text'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='tag',
+            name='id',
+        ),
+        migrations.AlterField(
+            model_name='tag',
+            name='name',
+            field=models.SlugField(primary_key=True, serialize=False),
+        ),
+        migrations.AlterField(
+            model_name='tag',
+            name='statements',
+            field=models.ManyToManyField(related_name='tags', to='django_chatterbot.Statement'),
+        ),
+    ]

--- a/chatterbot/ext/sqlalchemy_app/models.py
+++ b/chatterbot/ext/sqlalchemy_app/models.py
@@ -19,12 +19,6 @@ class ModelBase(object):
         """
         return cls.__name__.lower()
 
-    id = Column(
-        Integer,
-        primary_key=True,
-        autoincrement=True
-    )
-
 
 Base = declarative_base(cls=ModelBase)
 
@@ -32,7 +26,7 @@ Base = declarative_base(cls=ModelBase)
 tag_association_table = Table(
     'tag_association',
     Base.metadata,
-    Column('tag_id', Integer, ForeignKey('tag.id')),
+    Column('tag_name', Integer, ForeignKey('tag.name')),
     Column('statement_id', Integer, ForeignKey('statement.id'))
 )
 
@@ -43,7 +37,8 @@ class Tag(Base):
     """
 
     name = Column(
-        String(constants.TAG_NAME_MAX_LENGTH)
+        String(constants.TAG_NAME_MAX_LENGTH),
+        primary_key=True
     )
 
 
@@ -51,6 +46,12 @@ class Statement(Base, StatementMixin):
     """
     A Statement represents a sentence or phrase.
     """
+
+    id = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True
+    )
 
     text = Column(
         String(constants.STATEMENT_TEXT_MAX_LENGTH)

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -165,12 +165,12 @@ class SQLStorageAdapter(StorageAdapter):
 
         statement = Statement(**kwargs)
 
-        for _tag in tags:
-            tag = session.query(Tag).filter_by(name=_tag).first()
+        for tag_name in tags:
+            tag = session.query(Tag).get(tag_name)
 
             if not tag:
                 # Create the tag
-                tag = Tag(name=_tag)
+                tag = Tag(name=tag_name)
 
             statement.tags.append(tag)
 
@@ -215,7 +215,7 @@ class SQLStorageAdapter(StorageAdapter):
                 if tag_name in create_tags:
                     tag = create_tags[tag_name]
                 else:
-                    tag = session.query(Tag).filter_by(name=tag_name).first()
+                    tag = session.query(Tag).get(tag_name)
 
                     if not tag:
                         # Create the tag if it does not exist
@@ -267,12 +267,12 @@ class SQLStorageAdapter(StorageAdapter):
             if statement.in_response_to:
                 record.search_in_response_to = self.stemmer.stem(statement.in_response_to)
 
-            for _tag in statement.tags:
-                tag = session.query(Tag).filter_by(name=_tag).first()
+            for tag_name in statement.tags:
+                tag = session.query(Tag).get(tag_name)
 
                 if not tag:
                     # Create the record
-                    tag = Tag(name=_tag)
+                    tag = Tag(name=tag_name)
 
                 record.tags.append(tag)
 


### PR DESCRIPTION
* This prevents duplicate tags and allows more efficient operations to be performed to retrieve tags.