### PR TITLE
Modify create_many to use objects instead of dictionaries

### DIFF
--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -171,18 +171,29 @@ class MongoDatabaseAdapter(StorageAdapter):
         """
         Creates multiple statement entries.
         """
+        create_statements = []
+
         for statement in statements:
-            if 'tags' in statement:
-                statement['tags'] = list(set(statement['tags']))
+            statement_data = {
+                'text': statement.text,
+                'search_text': statement.search_text,
+                'conversation': statement.conversation,
+                'persona': statement.persona,
+                'in_response_to': statement.in_response_to,
+                'search_in_response_to': statement.search_in_response_to,
+                'created_at': statement.created_at,
+                'tags': list(set(statement.tags))
+            }
 
-            if 'search_text' not in statement:
-                statement['search_text'] = self.stemmer.stem(statement['text'])
+            if not statement.search_text:
+                statement_data['search_text'] = self.stemmer.stem(statement.text)
 
-            if 'search_in_response_to' not in statement:
-                if statement.get('in_response_to'):
-                    statement['search_in_response_to'] = self.stemmer.stem(statement['in_response_to'])
+            if not statement.search_in_response_to and statement.in_response_to:
+                statement_data['search_in_response_to'] = self.stemmer.stem(statement.in_response_to)
 
-        self.statements.insert_many(statements)
+            create_statements.append(statement_data)
+
+        self.statements.insert_many(create_statements)
 
     def update(self, statement):
         data = statement.serialize()

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -198,20 +198,25 @@ class SQLStorageAdapter(StorageAdapter):
         create_statements = []
         create_tags = {}
 
-        for statement_data in statements:
+        for statement in statements:
 
-            tags = set(statement_data.pop('tags', []))
+            statement_model_object = Statement(
+                text=statement.text,
+                search_text=statement.search_text,
+                conversation=statement.conversation,
+                persona=statement.persona,
+                in_response_to=statement.in_response_to,
+                search_in_response_to=statement.search_in_response_to,
+                created_at=statement.created_at
+            )
 
-            if 'search_text' not in statement_data:
-                statement_data['search_text'] = self.stemmer.stem(statement_data['text'])
+            if not statement.search_text:
+                statement_model_object.search_text = self.stemmer.stem(statement.text)
 
-            if 'search_in_response_to' not in statement_data:
-                if statement_data.get('in_response_to'):
-                    statement_data['search_in_response_to'] = self.stemmer.stem(statement_data['in_response_to'])
+            if not statement.search_in_response_to and statement.in_response_to:
+                statement_model_object.search_in_response_to = self.stemmer.stem(statement.in_response_to)
 
-            statement = Statement(**statement_data)
-
-            for tag_name in tags:
+            for tag_name in statement.tags:
                 if tag_name in create_tags:
                     tag = create_tags[tag_name]
                 else:
@@ -223,8 +228,8 @@ class SQLStorageAdapter(StorageAdapter):
 
                     create_tags[tag_name] = tag
 
-                statement.tags.append(tag)
-            create_statements.append(statement)
+                statement_model_object.tags.append(tag)
+            create_statements.append(statement_model_object)
 
         session.add_all(create_statements)
         session.commit()

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -103,12 +103,7 @@ class ListTrainer(Trainer):
             previous_statement_text = statement.text
             previous_statement_search_text = statement_search_text
 
-            statements_to_create.append({
-                'text': statement.text,
-                'in_response_to': statement.in_response_to,
-                'conversation': statement.conversation,
-                'tags': statement.tags
-            })
+            statements_to_create.append(statement)
 
         self.chatbot.storage.create_many(statements_to_create)
 
@@ -149,7 +144,7 @@ class ChatterBotCorpusTrainer(Trainer):
 
                     statement_search_text = self.stemmer.stem(text)
 
-                    _statement = Statement(
+                    statement = Statement(
                         text=text,
                         search_text=statement_search_text,
                         in_response_to=previous_statement_text,
@@ -157,19 +152,14 @@ class ChatterBotCorpusTrainer(Trainer):
                         conversation='training'
                     )
 
-                    _statement.add_tags(*categories)
+                    statement.add_tags(*categories)
 
-                    statement = self.get_preprocessed_statement(_statement)
+                    statement = self.get_preprocessed_statement(statement)
 
                     previous_statement_text = statement.text
                     previous_statement_search_text = statement_search_text
 
-                    statements_to_create.append({
-                        'text': statement.text,
-                        'in_response_to': statement.in_response_to,
-                        'conversation': statement.conversation,
-                        'tags': statement.tags
-                    })
+                    statements_to_create.append(statement)
 
             self.chatbot.storage.create_many(statements_to_create)
 
@@ -436,12 +426,7 @@ class UbuntuCorpusTrainer(Trainer):
                         if row[2].strip():
                             statement.add_tags('addressing_speaker:', row[2])
 
-                        statements_to_create.append({
-                            'text': statement.text,
-                            'in_response_to': statement.in_response_to,
-                            'conversation': statement.conversation,
-                            'tags': statement.tags
-                        })
+                        statements_to_create.append(statement)
                         statement_count += 1
 
                         previous_statement_text = statement.text

--- a/tests/storage/test_mongo_adapter.py
+++ b/tests/storage/test_mongo_adapter.py
@@ -376,12 +376,8 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
 
     def test_create_many_text(self):
         self.adapter.create_many([
-            {
-                'text': 'A'
-            },
-            {
-                'text': 'B'
-            }
+            Statement(text='A'),
+            Statement(text='B')
         ])
 
         results = self.adapter.filter()
@@ -392,14 +388,8 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
 
     def test_create_many_search_text(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'search_text': 'a'
-            },
-            {
-                'text': 'B',
-                'search_text': 'b'
-            }
+            Statement(text='A', search_text='a'),
+            Statement(text='B', search_text='b')
         ])
 
         results = self.adapter.filter()
@@ -410,14 +400,8 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
 
     def test_create_many_search_in_response_to(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'search_in_response_to': 'a'
-            },
-            {
-                'text': 'B',
-                'search_in_response_to': 'b'
-            }
+            Statement(text='A', search_in_response_to='a'),
+            Statement(text='B', search_in_response_to='b')
         ])
 
         results = self.adapter.filter()
@@ -428,14 +412,8 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
 
     def test_create_many_tags(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'tags': ['first', 'letter']
-            },
-            {
-                'text': 'B',
-                'tags': ['second', 'letter']
-            }
+            Statement(text='A', tags=['first', 'letter']),
+            Statement(text='B', tags=['second', 'letter'])
         ])
         results = self.adapter.filter()
 
@@ -451,10 +429,7 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
         that are duplicates.
         """
         self.adapter.create_many([
-            {
-                'text': 'testing',
-                'tags': ['ab', 'ab']
-            }
+            Statement(text='testing', tags=['ab', 'ab'])
         ])
 
         results = self.adapter.filter()

--- a/tests/storage/test_sql_adapter.py
+++ b/tests/storage/test_sql_adapter.py
@@ -324,12 +324,8 @@ class StorageAdapterCreateTests(SQLStorageAdapterTestCase):
 
     def test_create_many_text(self):
         self.adapter.create_many([
-            {
-                'text': 'A'
-            },
-            {
-                'text': 'B'
-            }
+            Statement(text='A'),
+            Statement(text='B')
         ])
 
         results = self.adapter.filter()
@@ -340,14 +336,8 @@ class StorageAdapterCreateTests(SQLStorageAdapterTestCase):
 
     def test_create_many_search_text(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'search_text': 'a'
-            },
-            {
-                'text': 'B',
-                'search_text': 'b'
-            }
+            Statement(text='A', search_text='a'),
+            Statement(text='B', search_text='b')
         ])
 
         results = self.adapter.filter()
@@ -358,14 +348,8 @@ class StorageAdapterCreateTests(SQLStorageAdapterTestCase):
 
     def test_create_many_search_in_response_to(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'search_in_response_to': 'a'
-            },
-            {
-                'text': 'B',
-                'search_in_response_to': 'b'
-            }
+            Statement(text='A', search_in_response_to='a'),
+            Statement(text='B', search_in_response_to='b')
         ])
 
         results = self.adapter.filter()
@@ -376,14 +360,8 @@ class StorageAdapterCreateTests(SQLStorageAdapterTestCase):
 
     def test_create_many_tags(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'tags': ['first', 'letter']
-            },
-            {
-                'text': 'B',
-                'tags': ['second', 'letter']
-            }
+            Statement(text='A', tags=['first', 'letter']),
+            Statement(text='B', tags=['second', 'letter'])
         ])
         results = self.adapter.filter()
 
@@ -399,10 +377,7 @@ class StorageAdapterCreateTests(SQLStorageAdapterTestCase):
         that are duplicates.
         """
         self.adapter.create_many([
-            {
-                'text': 'testing',
-                'tags': ['ab', 'ab']
-            }
+            Statement(text='testing', tags=['ab', 'ab'])
         ])
 
         results = self.adapter.filter()

--- a/tests_django/test_django_adapter.py
+++ b/tests_django/test_django_adapter.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from chatterbot.storage import DjangoStorageAdapter
-from chatterbot.ext.django_chatterbot.models import Statement as StatementModel
+from chatterbot.conversation import Statement as StatementObject
+from chatterbot.ext.django_chatterbot.models import Statement
 
 
 class DjangoAdapterTestCase(TestCase):
@@ -54,7 +55,7 @@ class DjangoStorageAdapterTests(DjangoAdapterTestCase):
         self.assertEqual(results.first().text, statement.text)
 
     def test_update_adds_new_statement(self):
-        statement = StatementModel(text="New statement")
+        statement = Statement(text="New statement")
         self.adapter.update(statement)
 
         results = self.adapter.filter(text="New statement")
@@ -157,12 +158,12 @@ class DjangoAdapterFilterTests(DjangoAdapterTestCase):
     def setUp(self):
         super().setUp()
 
-        self.statement1 = StatementModel(
+        self.statement1 = Statement(
             text="Testing...",
             in_response_to="Why are you counting?"
         )
 
-        self.statement2 = StatementModel(
+        self.statement2 = Statement(
             text="Testing one, two, three.",
             in_response_to=self.statement1.text
         )
@@ -258,7 +259,7 @@ class DjangoAdapterFilterTests(DjangoAdapterTestCase):
         statement = self.adapter.create(text='Test statement')
         statement.confidence = 0.5
 
-        statement_updated = StatementModel.objects.get(pk=statement.id)
+        statement_updated = Statement.objects.get(pk=statement.id)
 
         self.assertEqual(statement_updated.confidence, 0)
 
@@ -348,12 +349,8 @@ class StorageAdapterCreateTests(DjangoAdapterTestCase):
 
     def test_create_many_text(self):
         self.adapter.create_many([
-            {
-                'text': 'A'
-            },
-            {
-                'text': 'B'
-            }
+            StatementObject(text='A'),
+            StatementObject(text='B')
         ])
 
         results = self.adapter.filter()
@@ -364,14 +361,8 @@ class StorageAdapterCreateTests(DjangoAdapterTestCase):
 
     def test_create_many_search_text(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'search_text': 'a'
-            },
-            {
-                'text': 'B',
-                'search_text': 'b'
-            }
+            StatementObject(text='A', search_text='a'),
+            StatementObject(text='B', search_text='b')
         ])
 
         results = self.adapter.filter()
@@ -382,14 +373,8 @@ class StorageAdapterCreateTests(DjangoAdapterTestCase):
 
     def test_create_many_search_in_response_to(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'search_in_response_to': 'a'
-            },
-            {
-                'text': 'B',
-                'search_in_response_to': 'b'
-            }
+            StatementObject(text='A', search_in_response_to='a'),
+            StatementObject(text='B', search_in_response_to='b')
         ])
 
         results = self.adapter.filter()
@@ -400,14 +385,8 @@ class StorageAdapterCreateTests(DjangoAdapterTestCase):
 
     def test_create_many_tags(self):
         self.adapter.create_many([
-            {
-                'text': 'A',
-                'tags': ['first', 'letter']
-            },
-            {
-                'text': 'B',
-                'tags': ['second', 'letter']
-            }
+            StatementObject(text='A', tags=['first', 'letter']),
+            StatementObject(text='B', tags=['second', 'letter'])
         ])
         results = self.adapter.filter()
 
@@ -423,10 +402,7 @@ class StorageAdapterCreateTests(DjangoAdapterTestCase):
         that are duplicates.
         """
         self.adapter.create_many([
-            {
-                'text': 'testing',
-                'tags': ['ab', 'ab']
-            }
+            StatementObject(text='testing', tags=['ab', 'ab'])
         ])
 
         results = self.adapter.filter()


### PR DESCRIPTION
Objects have a better ability to be optimized for better memory and processing usage than dictionaries do.

A revision for #1449