### PR TITLE
Switch to bigram strategy for text indexing

### DIFF
--- a/chatterbot/stemming.py
+++ b/chatterbot/stemming.py
@@ -21,7 +21,7 @@ class SimpleStemmer(object):
         self.stopwords = nltk.corpus.stopwords.words(language)
         self.stopwords.append('')
 
-    def stem(self, text):
+    def get_stemmed_word_list(self, text):
 
         # Remove punctuation
         text = text.translate(self.punctuation_table)
@@ -42,6 +42,36 @@ class SimpleStemmer(object):
                 stop = start * -1
                 word = word[start:stop]
 
-                words.append(word)
+                if word:
+                    words.append(word)
 
-        return ' '.join(words)[:-1]
+        return words
+
+    def get_bigram_pair_string(self, text):
+        """
+        Return bigram pairs of stemmed text for a given string.
+        For example:
+
+        "Hello Dr. Salazar. How are you today?"
+        "[ell alaza] [alaza oda]"
+        "ellalaza alazaoda"
+        """
+        words = self.get_stemmed_word_list(text)
+
+        bigrams = []
+
+        word_count = len(words)
+
+        if word_count <= 1:
+            bigrams = words
+
+        for index in range(0, word_count - 1):
+            bigram = words[index] + words[index + 1]
+            bigrams.append(bigram)
+
+        return ' '.join(bigrams)
+
+    def stem(self, text):
+        words = self.get_stemmed_word_list(text)
+
+        return ' '.join(words)

--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -64,11 +64,11 @@ class DjangoStorageAdapter(StorageAdapter):
         tags = kwargs.pop('tags', [])
 
         if 'search_text' not in kwargs:
-            kwargs['search_text'] = self.stemmer.stem(kwargs['text'])
+            kwargs['search_text'] = self.stemmer.get_bigram_pair_string(kwargs['text'])
 
         if 'search_in_response_to' not in kwargs:
             if kwargs.get('in_response_to'):
-                kwargs['search_in_response_to'] = self.stemmer.stem(kwargs['in_response_to'])
+                kwargs['search_in_response_to'] = self.stemmer.get_bigram_pair_string(kwargs['in_response_to'])
 
         statement = Statement(**kwargs)
 
@@ -106,10 +106,10 @@ class DjangoStorageAdapter(StorageAdapter):
             )
 
             if not statement.search_text:
-                statement_model_object.search_text = self.stemmer.stem(statement.text)
+                statement_model_object.search_text = self.stemmer.get_bigram_pair_string(statement.text)
 
             if not statement.search_in_response_to and statement.in_response_to:
-                statement_model_object.search_in_response_to = self.stemmer.stem(statement.in_response_to)
+                statement_model_object.search_in_response_to = self.stemmer.get_bigram_pair_string(statement.in_response_to)
 
             statement_model_object.save()
 
@@ -137,10 +137,10 @@ class DjangoStorageAdapter(StorageAdapter):
         else:
             statement = Statement.objects.create(
                 text=statement.text,
-                search_text=self.stemmer.stem(statement.text),
+                search_text=self.stemmer.get_bigram_pair_string(statement.text),
                 conversation=statement.conversation,
                 in_response_to=statement.in_response_to,
-                search_in_response_to=self.stemmer.stem(statement.in_response_to),
+                search_in_response_to=self.stemmer.get_bigram_pair_string(statement.in_response_to),
                 created_at=statement.created_at
             )
 

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -155,11 +155,11 @@ class MongoDatabaseAdapter(StorageAdapter):
             kwargs['tags'] = list(set(kwargs['tags']))
 
         if 'search_text' not in kwargs:
-            kwargs['search_text'] = self.stemmer.stem(kwargs['text'])
+            kwargs['search_text'] = self.stemmer.get_bigram_pair_string(kwargs['text'])
 
         if 'search_in_response_to' not in kwargs:
             if kwargs.get('in_response_to'):
-                kwargs['search_in_response_to'] = self.stemmer.stem(kwargs['in_response_to'])
+                kwargs['search_in_response_to'] = self.stemmer.get_bigram_pair_string(kwargs['in_response_to'])
 
         inserted = self.statements.insert_one(kwargs)
 
@@ -186,10 +186,10 @@ class MongoDatabaseAdapter(StorageAdapter):
             }
 
             if not statement.search_text:
-                statement_data['search_text'] = self.stemmer.stem(statement.text)
+                statement_data['search_text'] = self.stemmer.get_bigram_pair_string(statement.text)
 
             if not statement.search_in_response_to and statement.in_response_to:
-                statement_data['search_in_response_to'] = self.stemmer.stem(statement.in_response_to)
+                statement_data['search_in_response_to'] = self.stemmer.get_bigram_pair_string(statement.in_response_to)
 
             create_statements.append(statement_data)
 
@@ -200,10 +200,10 @@ class MongoDatabaseAdapter(StorageAdapter):
         data.pop('id', None)
         data.pop('tags', None)
 
-        data['search_text'] = self.stemmer.stem(data['text'])
+        data['search_text'] = self.stemmer.get_bigram_pair_string(data['text'])
 
         if data.get('in_response_to'):
-            data['search_in_response_to'] = self.stemmer.stem(data['in_response_to'])
+            data['search_in_response_to'] = self.stemmer.get_bigram_pair_string(data['in_response_to'])
 
         update_data = {
             '$set': data

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -157,11 +157,11 @@ class SQLStorageAdapter(StorageAdapter):
         tags = set(kwargs.pop('tags', []))
 
         if 'search_text' not in kwargs:
-            kwargs['search_text'] = self.stemmer.stem(kwargs['text'])
+            kwargs['search_text'] = self.stemmer.get_bigram_pair_string(kwargs['text'])
 
         if 'search_in_response_to' not in kwargs:
             if kwargs.get('in_response_to'):
-                kwargs['search_in_response_to'] = self.stemmer.stem(kwargs['in_response_to'])
+                kwargs['search_in_response_to'] = self.stemmer.get_bigram_pair_string(kwargs['in_response_to'])
 
         statement = Statement(**kwargs)
 
@@ -211,10 +211,10 @@ class SQLStorageAdapter(StorageAdapter):
             )
 
             if not statement.search_text:
-                statement_model_object.search_text = self.stemmer.stem(statement.text)
+                statement_model_object.search_text = self.stemmer.get_bigram_pair_string(statement.text)
 
             if not statement.search_in_response_to and statement.in_response_to:
-                statement_model_object.search_in_response_to = self.stemmer.stem(statement.in_response_to)
+                statement_model_object.search_in_response_to = self.stemmer.get_bigram_pair_string(statement.in_response_to)
 
             for tag_name in statement.tags:
                 if tag_name in create_tags:
@@ -267,10 +267,10 @@ class SQLStorageAdapter(StorageAdapter):
 
             record.created_at = statement.created_at
 
-            record.search_text = self.stemmer.stem(statement.text)
+            record.search_text = self.stemmer.get_bigram_pair_string(statement.text)
 
             if statement.in_response_to:
-                record.search_in_response_to = self.stemmer.stem(statement.in_response_to)
+                record.search_in_response_to = self.stemmer.get_bigram_pair_string(statement.in_response_to)
 
             for tag_name in statement.tags:
                 tag = session.query(Tag).get(tag_name)

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -92,7 +92,7 @@ class ListTrainer(Trainer):
                     conversation_count + 1, len(conversation)
                 )
 
-            statement_search_text = self.stemmer.stem(text)
+            statement_search_text = self.stemmer.get_bigram_pair_string(text)
 
             statement = self.get_preprocessed_statement(
                 Statement(
@@ -146,7 +146,7 @@ class ChatterBotCorpusTrainer(Trainer):
 
                 for text in conversation:
 
-                    statement_search_text = self.stemmer.stem(text)
+                    statement_search_text = self.stemmer.get_bigram_pair_string(text)
 
                     statement = Statement(
                         text=text,
@@ -292,7 +292,7 @@ def read_file(files, queue, preprocessors, stemmer):
                     for preprocessor in preprocessors:
                         statement = preprocessor(statement)
 
-                    statement.search_text = stemmer.stem(statement.text)
+                    statement.search_text = stemmer.get_bigram_pair_string(statement.text)
                     statement.search_in_response_to = previous_statement_search_text
 
                     previous_statement_text = statement.text

--- a/tests/test_stemming.py
+++ b/tests/test_stemming.py
@@ -15,14 +15,28 @@ class StemmerTests(TestCase):
     def test_string_becomes_lowercase(self):
         stemmed_text = self.stemmer.stem('THIS IS HOW IT BEGINS!')
 
-        self.assertEqual(stemmed_text, 'egi')
+        self.assertEqual(stemmed_text, 'egin')
 
     def test_stemming_medium_sized_words(self):
         stemmed_text = self.stemmer.stem('Hello, my name is Gunther.')
 
-        self.assertEqual(stemmed_text, 'ell am unth')
+        self.assertEqual(stemmed_text, 'ell am unthe')
 
     def test_stemming_long_words(self):
         stemmed_text = self.stemmer.stem('I play several orchestra instruments for pleasuer.')
 
-        self.assertEqual(stemmed_text, 'la evera chest strumen eas')
+        self.assertEqual(stemmed_text, 'la evera chest strumen easu')
+
+    def test_get_bigram_pair_string_single_word(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            'Hello'
+        )
+
+        self.assertEqual(bigram_string, 'ell')
+
+    def test_get_bigram_pair_string_multiple_words(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            'Hello Dr. Salazar. How are you today?'
+        )
+
+        self.assertEqual(bigram_string, 'ellalaza alazaoda')

--- a/tests/training/test_chatterbot_corpus_training.py
+++ b/tests/training/test_chatterbot_corpus_training.py
@@ -29,7 +29,7 @@ class ChatterBotCorpusTrainingTestCase(ChatBotTestCase):
         results = self.chatbot.storage.filter(text='Hello')
 
         self.assertGreater(len(results), 1)
-        self.assertEqual(results[0].search_text, 'el')
+        self.assertEqual(results[0].search_text, 'ell')
 
     def test_train_with_english_greeting_corpus_search_in_response_to(self):
         self.trainer.train('chatterbot.corpus.english.greetings')
@@ -37,7 +37,7 @@ class ChatterBotCorpusTrainingTestCase(ChatBotTestCase):
         results = self.chatbot.storage.filter(in_response_to='Hello')
 
         self.assertGreater(len(results), 1)
-        self.assertEqual(results[0].search_in_response_to, 'el')
+        self.assertEqual(results[0].search_in_response_to, 'ell')
 
     def test_train_with_english_greeting_corpus_tags(self):
         self.trainer.train('chatterbot.corpus.english.greetings')

--- a/tests/training/test_twitter_trainer.py
+++ b/tests/training/test_twitter_trainer.py
@@ -88,11 +88,11 @@ class TwitterTrainerTestCase(ChatBotTestCase):
         statements = self.trainer.chatbot.storage.filter()
 
         self.assertGreater(len(statements), 1)
-        self.assertEqual(statements[0].search_text, 'ur u')
+        self.assertEqual(statements[0].search_text, 'urub')
 
     def test_train_sets_search_in_response_to(self):
         self.trainer.train()
         statements = self.trainer.chatbot.storage.filter()
 
         self.assertGreater(len(statements), 1)
-        self.assertEqual(statements[0].search_in_response_to, 'ur u')
+        self.assertEqual(statements[0].search_in_response_to, 'urub')

--- a/tests/training/test_ubuntu_corpus_training.py
+++ b/tests/training/test_ubuntu_corpus_training.py
@@ -175,7 +175,7 @@ class UbuntuCorpusTrainerTestCase(ChatBotTestCase):
 
         results = self.chatbot.storage.filter(text='Is anyone there?')
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].search_text, 'nyo')
+        self.assertEqual(results[0].search_text, 'nyon')
 
     def test_train_sets_search_in_response_to(self):
         """
@@ -188,7 +188,7 @@ class UbuntuCorpusTrainerTestCase(ChatBotTestCase):
 
         results = self.chatbot.storage.filter(in_response_to='Is anyone there?')
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].search_in_response_to, 'nyo')
+        self.assertEqual(results[0].search_in_response_to, 'nyon')
 
     def test_is_extracted(self):
         """


### PR DESCRIPTION
This change will reduce the size of the result matching set by decreasing the number of possible matches based on the need for similar text to have at least two neighboring matches.

For #1452