### PR TITLE
Use search_in_response_to value for selecting response statements

### DIFF
--- a/chatterbot/logic/best_match.py
+++ b/chatterbot/logic/best_match.py
@@ -46,7 +46,7 @@ class BestMatch(LogicAdapter):
         # Select the closest match to the input statement
         closest_match = self.get(input_statement)
         self.chatbot.logger.info('Using "{}" as a close match to "{}"'.format(
-            input_statement.text, closest_match.text
+            closest_match.text, input_statement.text
         ))
 
         recent_repeated_responses = filters.get_recent_repeated_responses(
@@ -56,7 +56,7 @@ class BestMatch(LogicAdapter):
 
         # Get all statements that are in response to the closest match
         response_list = self.chatbot.storage.filter(
-            in_response_to=closest_match.text,
+            search_in_response_to=closest_match.search_text,
             exclude_text=recent_repeated_responses
         )
 

--- a/chatterbot/stemming.py
+++ b/chatterbot/stemming.py
@@ -21,31 +21,44 @@ class SimpleStemmer(object):
         self.stopwords = nltk.corpus.stopwords.words(language)
         self.stopwords.append('')
 
-    def get_stemmed_word_list(self, text):
+    def get_stemmed_word_list(self, text, size=4):
 
-        # Remove punctuation
-        text = text.translate(self.punctuation_table)
+        stemmed_words = []
 
         # Make the text lowercase
         text = text.lower()
 
-        words = []
+        # Remove punctuation
+        text_with_punctuation_removed = text.translate(self.punctuation_table)
+
+        if text_with_punctuation_removed:
+            text = text_with_punctuation_removed
+
+        words = text.split(' ')
+
+        # Do not stem singe-word strings that are less than the size limit for characters
+        if len(words) == 1 and len(words[0]) < size:
+            return words
 
         # Generate the stemmed text
-        for word in text.split(' '):
+        for word in words:
 
             # Remove stopwords
             if word not in self.stopwords:
 
                 # Chop off the ends of the word
-                start = len(word) // 4
+                start = len(word) // size
                 stop = start * -1
                 word = word[start:stop]
 
                 if word:
-                    words.append(word)
+                    stemmed_words.append(word)
 
-        return words
+        # Return the word list if it could not be stemmed
+        if not stemmed_words and words:
+            return words
+
+        return stemmed_words
 
     def get_bigram_pair_string(self, text):
         """

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -78,10 +78,6 @@ class MongoDatabaseAdapter(StorageAdapter):
         tags = kwargs.pop('tags', [])
         exclude_text = kwargs.pop('exclude_text', None)
 
-        # Convert a single sting into a list if only one tag is provided
-        if type(tags) == str:
-            tags = [tags]
-
         if tags:
             kwargs['tags'] = {
                 '$in': tags
@@ -277,7 +273,7 @@ class MongoDatabaseAdapter(StorageAdapter):
 
             statement_query = self.statements.find(_statement_query)
 
-            for statement in list(statement_query):
+            for statement in statement_query:
                 yield self.mongo_to_object(statement)
 
     def drop(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -29,7 +29,7 @@ class RepetitiveResponseFilterTestCase(ChatBotMongoTestCase):
             'Hi',
             'Hello',
             'How are you?',
-            'I am good.',
+            'I am good',
             'Glad to hear',
             'How are you?'
         ])

--- a/tests/test_stemming.py
+++ b/tests/test_stemming.py
@@ -27,6 +27,55 @@ class StemmerTests(TestCase):
 
         self.assertEqual(stemmed_text, 'la evera chest strumen easu')
 
+    def test_get_bigram_pair_string_punctuation_only(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            '?'
+        )
+
+        self.assertEqual(bigram_string, '?')
+
+    def test_get_bigram_pair_string_single_character(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            '🙂'
+        )
+
+        self.assertEqual(bigram_string, '🙂')
+
+    def test_get_bigram_pair_string_single_character_punctuated(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            '🤷?'
+        )
+
+        self.assertEqual(bigram_string, '🤷')
+
+    def test_get_bigram_pair_string_two_characters(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            'AB'
+        )
+
+        self.assertEqual(bigram_string, 'ab')
+
+    def test_get_bigram_pair_string_three_characters(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            'ABC'
+        )
+
+        self.assertEqual(bigram_string, 'abc')
+
+    def test_get_bigram_pair_string_four_characters(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            'ABCD'
+        )
+
+        self.assertEqual(bigram_string, 'bc')
+
+    def test_get_bigram_pair_string_five_characters(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            'ABCDE'
+        )
+
+        self.assertEqual(bigram_string, 'bcd')
+
     def test_get_bigram_pair_string_single_word(self):
         bigram_string = self.stemmer.get_bigram_pair_string(
             'Hello'
@@ -40,3 +89,17 @@ class StemmerTests(TestCase):
         )
 
         self.assertEqual(bigram_string, 'ellalaza alazaoda')
+
+    def test_get_bigram_pair_string_single_character_words(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            'a e i o u'
+        )
+
+        self.assertEqual(bigram_string, 'ae ei io ou')
+
+    def test_get_bigram_pair_string_two_character_words(self):
+        bigram_string = self.stemmer.get_bigram_pair_string(
+            'Lo my mu it is of us'
+        )
+
+        self.assertEqual(bigram_string, 'lomy mymu muit itis isof ofus')

--- a/tests/training/test_list_training.py
+++ b/tests/training/test_list_training.py
@@ -6,7 +6,7 @@ from chatterbot.trainers import ListTrainer
 class ListTrainingTests(ChatBotTestCase):
 
     def setUp(self):
-        super(ListTrainingTests, self).setUp()
+        super().setUp()
         self.trainer = ListTrainer(
             self.chatbot,
             show_training_progress=False
@@ -213,7 +213,7 @@ class ListTrainingTests(ChatBotTestCase):
 class ChatterBotResponseTests(ChatBotTestCase):
 
     def setUp(self):
-        super(ChatterBotResponseTests, self).setUp()
+        super().setUp()
         """
         Set up a database for testing.
         """

--- a/tests_django/test_logic_adapter_integration.py
+++ b/tests_django/test_logic_adapter_integration.py
@@ -1,5 +1,5 @@
 from tests_django.base_case import ChatterBotTestCase
-from chatterbot.ext.django_chatterbot.models import Statement
+from chatterbot.conversation import Statement
 
 
 class LogicIntegrationTestCase(ChatterBotTestCase):
@@ -11,19 +11,19 @@ class LogicIntegrationTestCase(ChatterBotTestCase):
     def setUp(self):
         super().setUp()
 
-        Statement.objects.create(text='Default statement')
+        self.chatbot.storage.create(text='Default statement')
 
     def test_best_match(self):
         from chatterbot.logic import BestMatch
 
         adapter = BestMatch(self.chatbot)
 
-        statement1 = Statement.objects.create(
+        statement1 = self.chatbot.storage.create(
             text='Do you like programming?',
             conversation='test'
         )
 
-        Statement.objects.create(
+        self.chatbot.storage.create(
             text='Yes',
             in_response_to=statement1.text,
             conversation='test'


### PR DESCRIPTION
Using the value of this field increases the possible number of matches that can be returned. For example, matches with only differing punctuation would now be returned.

Closes #310