### PR TITLE
Remove unused stem method from stemmer

### DIFF
--- a/chatterbot/stemming.py
+++ b/chatterbot/stemming.py
@@ -21,7 +21,7 @@ class SimpleStemmer(object):
         self.stopwords = nltk.corpus.stopwords.words(language)
         self.stopwords.append('')
 
-    def get_stemmed_word_list(self, text, size=4):
+    def get_stemmed_words(self, text, size=4):
 
         stemmed_words = []
 
@@ -69,7 +69,7 @@ class SimpleStemmer(object):
         "[ell alaza] [alaza oda]"
         "ellalaza alazaoda"
         """
-        words = self.get_stemmed_word_list(text)
+        words = self.get_stemmed_words(text)
 
         bigrams = []
 
@@ -83,8 +83,3 @@ class SimpleStemmer(object):
             bigrams.append(bigram)
 
         return ' '.join(bigrams)
-
-    def stem(self, text):
-        words = self.get_stemmed_word_list(text)
-
-        return ' '.join(words)

--- a/tests/test_stemming.py
+++ b/tests/test_stemming.py
@@ -8,24 +8,26 @@ class StemmerTests(TestCase):
         self.stemmer = stemming.SimpleStemmer()
 
     def test_stemming(self):
-        stemmed_text = self.stemmer.stem('Hello, how are you doing on this awesome day?')
+        stemmed_text = self.stemmer.get_stemmed_words(
+            'Hello, how are you doing on this awesome day?'
+        )
 
-        self.assertEqual(stemmed_text, 'ell wesom')
+        self.assertEqual(stemmed_text, ['ell', 'wesom'])
 
     def test_string_becomes_lowercase(self):
-        stemmed_text = self.stemmer.stem('THIS IS HOW IT BEGINS!')
+        stemmed_text = self.stemmer.get_stemmed_words('THIS IS HOW IT BEGINS!')
 
-        self.assertEqual(stemmed_text, 'egin')
+        self.assertEqual(stemmed_text, ['egin'])
 
     def test_stemming_medium_sized_words(self):
-        stemmed_text = self.stemmer.stem('Hello, my name is Gunther.')
+        stemmed_text = self.stemmer.get_stemmed_words('Hello, my name is Gunther.')
 
-        self.assertEqual(stemmed_text, 'ell am unthe')
+        self.assertEqual(stemmed_text, ['ell', 'am', 'unthe'])
 
     def test_stemming_long_words(self):
-        stemmed_text = self.stemmer.stem('I play several orchestra instruments for pleasuer.')
+        stemmed_text = self.stemmer.get_stemmed_words('I play several orchestra instruments for pleasuer.')
 
-        self.assertEqual(stemmed_text, 'la evera chest strumen easu')
+        self.assertEqual(stemmed_text, ['la', 'evera', 'chest', 'strumen', 'easu'])
 
     def test_get_bigram_pair_string_punctuation_only(self):
         bigram_string = self.stemmer.get_bigram_pair_string(


### PR DESCRIPTION
This revises the class added in #1462. The `stem` method is not needed because in all cases, only either the stemmed word list, or the bigram pair string are required.