### PR TITLE
Modify stemmer to only download stopwords once

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -78,8 +78,19 @@ class ChatBot(object):
         """
         Do any work that needs to be done before the responses can be returned.
         """
+        initialization_functions = {}
+
+        initialization_functions.update(
+            self.storage.stemmer.get_initialization_functions()
+        )
+
         for logic_adapter in self.get_logic_adapters():
-            logic_adapter.initialize()
+            initialization_functions.update(
+                logic_adapter.get_initialization_functions()
+            )
+
+        for function in initialization_functions.values():
+            function()
 
     def get_response(self, statement=None, **kwargs):
         """

--- a/chatterbot/stemming.py
+++ b/chatterbot/stemming.py
@@ -12,8 +12,18 @@ class SimpleStemmer(object):
     def __init__(self, language='english'):
         self.punctuation_table = str.maketrans(dict.fromkeys(string.punctuation))
 
-        # Get list of stopwords from the NLTK corpus
-        self.stopwords = nltk.corpus.stopwords.words(language)
+        self.language = language
+
+        self.stopwords = None
+
+    def get_stopwords(self):
+        """
+        Get the list of stopwords from the NLTK corpus.
+        """
+        if not self.stopwords:
+            self.stopwords = nltk.corpus.stopwords.words(self.language)
+
+        return self.stopwords
 
     def get_initialization_functions(self):
         """
@@ -67,7 +77,7 @@ class SimpleStemmer(object):
         for word in words:
 
             # Remove stopwords
-            if word not in self.stopwords:
+            if word not in self.get_stopwords():
 
                 # Chop off the ends of the word
                 start = len(word) // size

--- a/chatterbot/stemming.py
+++ b/chatterbot/stemming.py
@@ -10,15 +10,39 @@ class SimpleStemmer(object):
     """
 
     def __init__(self, language='english'):
-        from chatterbot.utils import nltk_download_corpus
-
         self.punctuation_table = str.maketrans(dict.fromkeys(string.punctuation))
-
-        # Download the stopwords corpus if needed
-        nltk_download_corpus('stopwords')
 
         # Get list of stopwords from the NLTK corpus
         self.stopwords = nltk.corpus.stopwords.words(language)
+
+    def get_initialization_functions(self):
+        """
+        Return all initialization methods for the comparison algorithm.
+        Initialization methods must start with 'initialize_' and
+        take no parameters.
+        """
+        initialization_methods = [
+            (
+                method,
+                getattr(self, method),
+            ) for method in dir(self) if method.startswith('initialize_')
+        ]
+
+        return {
+            key: value for (key, value) in initialization_methods
+        }
+
+    def initialize(self):
+        for function in self.get_initialization_functions().values():
+            function()
+
+    def initialize_nltk_stopwords(self):
+        """
+        Download required NLTK stopwords corpus if it has not already been downloaded.
+        """
+        from chatterbot.utils import nltk_download_corpus
+
+        nltk_download_corpus('stopwords')
 
     def get_stemmed_words(self, text, size=4):
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+from chatterbot import ChatBot
+
+
+def setup_module():
+    ChatBot('setup').initialize()

--- a/tests/base_case.py
+++ b/tests/base_case.py
@@ -24,10 +24,10 @@ class ChatBotTestCase(TestCase):
 
     def get_kwargs(self):
         return {
-            'input_adapter': 'chatterbot.input.InputAdapter',
-            'output_adapter': 'chatterbot.output.OutputAdapter',
             # Run the test database in-memory
-            'database_uri': None
+            'database_uri': None,
+            # Don't execute initialization processes such as downloading required data
+            'initialize': False
         }
 
 


### PR DESCRIPTION
NLTK corpus check logs were being printed numerous times in test output. This change allows the initialization process for the stemmer to be easily controlled so that it can be run once.