### PR TITLE
Add languages with iso-639 attributes

### DIFF
--- a/chatterbot/languages.py
+++ b/chatterbot/languages.py
@@ -1,0 +1,1998 @@
+class AAR:
+    ISO_639 = 'aar'
+    ENGLISH_NAME = 'Afar'
+
+
+class ABK:
+    ISO_639 = 'abk'
+    ENGLISH_NAME = 'Abkhazian'
+
+
+class ACE:
+    ISO_639 = 'ace'
+    ENGLISH_NAME = 'Achinese'
+
+
+class ACH:
+    ISO_639 = 'ach'
+    ENGLISH_NAME = 'Acoli'
+
+
+class ADA:
+    ISO_639 = 'ada'
+    ENGLISH_NAME = 'Adangme'
+
+
+class ADY:
+    ISO_639 = 'ady'
+    ENGLISH_NAME = 'Adyghe'
+
+
+class AFH:
+    ISO_639 = 'afh'
+    ENGLISH_NAME = 'Afrihili'
+
+
+class AFR:
+    ISO_639 = 'afr'
+    ENGLISH_NAME = 'Afrikaans'
+
+
+class AIN:
+    ISO_639 = 'ain'
+    ENGLISH_NAME = 'Ainu'
+
+
+class AKA:
+    ISO_639 = 'aka'
+    ENGLISH_NAME = 'Akan'
+
+
+class AKK:
+    ISO_639 = 'akk'
+    ENGLISH_NAME = 'Akkadian'
+
+
+class ALB:
+    ISO_639 = 'alb'
+    ENGLISH_NAME = 'Albanian'
+
+
+class ALE:
+    ISO_639 = 'ale'
+    ENGLISH_NAME = 'Aleut'
+
+
+class ALT:
+    ISO_639 = 'alt'
+    ENGLISH_NAME = 'SouthernAltai'
+
+
+class AMH:
+    ISO_639 = 'amh'
+    ENGLISH_NAME = 'Amharic'
+
+
+class ANP:
+    ISO_639 = 'anp'
+    ENGLISH_NAME = 'Angika'
+
+
+class ARA:
+    ISO_639 = 'ara'
+    ENGLISH_NAME = 'Arabic'
+
+
+class ARG:
+    ISO_639 = 'arg'
+    ENGLISH_NAME = 'Aragonese'
+
+
+class ARM:
+    ISO_639 = 'arm'
+    ENGLISH_NAME = 'Armenian'
+
+
+class ARN:
+    ISO_639 = 'arn'
+    ENGLISH_NAME = 'Mapudungun'
+
+
+class ARP:
+    ISO_639 = 'arp'
+    ENGLISH_NAME = 'Arapaho'
+
+
+class ARW:
+    ISO_639 = 'arw'
+    ENGLISH_NAME = 'Arawak'
+
+
+class ASM:
+    ISO_639 = 'asm'
+    ENGLISH_NAME = 'Assamese'
+
+
+class AST:
+    ISO_639 = 'ast'
+    ENGLISH_NAME = 'Asturian'
+
+
+class AVA:
+    ISO_639 = 'ava'
+    ENGLISH_NAME = 'Avaric'
+
+
+class AVE:
+    ISO_639 = 'ave'
+    ENGLISH_NAME = 'Avestan'
+
+
+class AWA:
+    ISO_639 = 'awa'
+    ENGLISH_NAME = 'Awadhi'
+
+
+class AYM:
+    ISO_639 = 'aym'
+    ENGLISH_NAME = 'Aymara'
+
+
+class AZE:
+    ISO_639 = 'aze'
+    ENGLISH_NAME = 'Azerbaijani'
+
+
+class BAK:
+    ISO_639 = 'bak'
+    ENGLISH_NAME = 'Bashkir'
+
+
+class BAL:
+    ISO_639 = 'bal'
+    ENGLISH_NAME = 'Baluchi'
+
+
+class BAM:
+    ISO_639 = 'bam'
+    ENGLISH_NAME = 'Bambara'
+
+
+class BAN:
+    ISO_639 = 'ban'
+    ENGLISH_NAME = 'Balinese'
+
+
+class BAQ:
+    ISO_639 = 'baq'
+    ENGLISH_NAME = 'Basque'
+
+
+class BAS:
+    ISO_639 = 'bas'
+    ENGLISH_NAME = 'Basa'
+
+
+class BEJ:
+    ISO_639 = 'bej'
+    ENGLISH_NAME = 'Beja'
+
+
+class BEL:
+    ISO_639 = 'bel'
+    ENGLISH_NAME = 'Belarusian'
+
+
+class BEM:
+    ISO_639 = 'bem'
+    ENGLISH_NAME = 'Bemba'
+
+
+class BEN:
+    ISO_639 = 'ben'
+    ENGLISH_NAME = 'Bengali'
+
+
+class BHO:
+    ISO_639 = 'bho'
+    ENGLISH_NAME = 'Bhojpuri'
+
+
+class BIK:
+    ISO_639 = 'bik'
+    ENGLISH_NAME = 'Bikol'
+
+
+class BIN:
+    ISO_639 = 'bin'
+    ENGLISH_NAME = 'Bini'
+
+
+class BIS:
+    ISO_639 = 'bis'
+    ENGLISH_NAME = 'Bislama'
+
+
+class BLA:
+    ISO_639 = 'bla'
+    ENGLISH_NAME = 'Siksika'
+
+
+class BOS:
+    ISO_639 = 'bos'
+    ENGLISH_NAME = 'Bosnian'
+
+
+class BRA:
+    ISO_639 = 'bra'
+    ENGLISH_NAME = 'Braj'
+
+
+class BRE:
+    ISO_639 = 'bre'
+    ENGLISH_NAME = 'Breton'
+
+
+class BUA:
+    ISO_639 = 'bua'
+    ENGLISH_NAME = 'Buriat'
+
+
+class BUG:
+    ISO_639 = 'bug'
+    ENGLISH_NAME = 'Buginese'
+
+
+class BUL:
+    ISO_639 = 'bul'
+    ENGLISH_NAME = 'Bulgarian'
+
+
+class BUR:
+    ISO_639 = 'bur'
+    ENGLISH_NAME = 'Burmese'
+
+
+class BYN:
+    ISO_639 = 'byn'
+    ENGLISH_NAME = 'Blin'
+
+
+class CAD:
+    ISO_639 = 'cad'
+    ENGLISH_NAME = 'Caddo'
+
+
+class CAR:
+    ISO_639 = 'car'
+    ENGLISH_NAME = 'GalibiCarib'
+
+
+class CAT:
+    ISO_639 = 'cat'
+    ENGLISH_NAME = 'Catalan'
+
+
+class CEB:
+    ISO_639 = 'ceb'
+    ENGLISH_NAME = 'Cebuano'
+
+
+class CHA:
+    ISO_639 = 'cha'
+    ENGLISH_NAME = 'Chamorro'
+
+
+class CHB:
+    ISO_639 = 'chb'
+    ENGLISH_NAME = 'Chibcha'
+
+
+class CHE:
+    ISO_639 = 'che'
+    ENGLISH_NAME = 'Chechen'
+
+
+class CHG:
+    ISO_639 = 'chg'
+    ENGLISH_NAME = 'Chagatai'
+
+
+class CHI:
+    ISO_639 = 'chi'
+    ENGLISH_NAME = 'Chinese'
+
+
+class CHK:
+    ISO_639 = 'chk'
+    ENGLISH_NAME = 'Chuukese'
+
+
+class CHM:
+    ISO_639 = 'chm'
+    ENGLISH_NAME = 'Mari'
+
+
+class CHN:
+    ISO_639 = 'chn'
+    ENGLISH_NAME = 'Chinookjargon'
+
+
+class CHO:
+    ISO_639 = 'cho'
+    ENGLISH_NAME = 'Choctaw'
+
+
+class CHP:
+    ISO_639 = 'chp'
+    ENGLISH_NAME = 'Chipewyan'
+
+
+class CHR:
+    ISO_639 = 'chr'
+    ENGLISH_NAME = 'Cherokee'
+
+
+class CHV:
+    ISO_639 = 'chv'
+    ENGLISH_NAME = 'Chuvash'
+
+
+class CHY:
+    ISO_639 = 'chy'
+    ENGLISH_NAME = 'Cheyenne'
+
+
+class CNR:
+    ISO_639 = 'cnr'
+    ENGLISH_NAME = 'Montenegrin'
+
+
+class COP:
+    ISO_639 = 'cop'
+    ENGLISH_NAME = 'Coptic'
+
+
+class COR:
+    ISO_639 = 'cor'
+    ENGLISH_NAME = 'Cornish'
+
+
+class COS:
+    ISO_639 = 'cos'
+    ENGLISH_NAME = 'Corsican'
+
+
+class CPE:
+    ISO_639 = 'cpe'
+    ENGLISH_NAME = 'Creolesandpidgins'
+
+
+class CPF:
+    ISO_639 = 'cpf'
+    ENGLISH_NAME = 'Creolesandpidgins'
+
+
+class CPP:
+    ISO_639 = 'cpp'
+    ENGLISH_NAME = 'Creolesandpidgins'
+
+
+class CRE:
+    ISO_639 = 'cre'
+    ENGLISH_NAME = 'Cree'
+
+
+class CRH:
+    ISO_639 = 'crh'
+    ENGLISH_NAME = 'CrimeanTatar'
+
+
+class CRP:
+    ISO_639 = 'crp'
+    ENGLISH_NAME = 'Creolesandpidgins'
+
+
+class CSB:
+    ISO_639 = 'csb'
+    ENGLISH_NAME = 'Kashubian'
+
+
+class CZE:
+    ISO_639 = 'cze'
+    ENGLISH_NAME = 'Czech'
+
+
+class DAK:
+    ISO_639 = 'dak'
+    ENGLISH_NAME = 'Dakota'
+
+
+class DAN:
+    ISO_639 = 'dan'
+    ENGLISH_NAME = 'Danish'
+
+
+class DAR:
+    ISO_639 = 'dar'
+    ENGLISH_NAME = 'Dargwa'
+
+
+class DEL:
+    ISO_639 = 'del'
+    ENGLISH_NAME = 'Delaware'
+
+
+class DEN:
+    ISO_639 = 'den'
+    ENGLISH_NAME = 'Slave'
+
+
+class DGR:
+    ISO_639 = 'dgr'
+    ENGLISH_NAME = 'Dogrib'
+
+
+class DIN:
+    ISO_639 = 'din'
+    ENGLISH_NAME = 'Dinka'
+
+
+class DIV:
+    ISO_639 = 'div'
+    ENGLISH_NAME = 'Divehi'
+
+
+class DOI:
+    ISO_639 = 'doi'
+    ENGLISH_NAME = 'Dogri'
+
+
+class DUA:
+    ISO_639 = 'dua'
+    ENGLISH_NAME = 'Duala'
+
+
+class DUT:
+    ISO_639 = 'dut'
+    ENGLISH_NAME = 'Dutch'
+
+
+class DYU:
+    ISO_639 = 'dyu'
+    ENGLISH_NAME = 'Dyula'
+
+
+class DZO:
+    ISO_639 = 'dzo'
+    ENGLISH_NAME = 'Dzongkha'
+
+
+class EFI:
+    ISO_639 = 'efi'
+    ENGLISH_NAME = 'Efik'
+
+
+class EKA:
+    ISO_639 = 'eka'
+    ENGLISH_NAME = 'Ekajuk'
+
+
+class ELX:
+    ISO_639 = 'elx'
+    ENGLISH_NAME = 'Elamite'
+
+
+class ENG:
+    ISO_639 = 'eng'
+    ENGLISH_NAME = 'English'
+
+
+class EPO:
+    ISO_639 = 'epo'
+    ENGLISH_NAME = 'Esperanto'
+
+
+class EST:
+    ISO_639 = 'est'
+    ENGLISH_NAME = 'Estonian'
+
+
+class EWE:
+    ISO_639 = 'ewe'
+    ENGLISH_NAME = 'Ewe'
+
+
+class EWO:
+    ISO_639 = 'ewo'
+    ENGLISH_NAME = 'Ewondo'
+
+
+class FAN:
+    ISO_639 = 'fan'
+    ENGLISH_NAME = 'Fang'
+
+
+class FAO:
+    ISO_639 = 'fao'
+    ENGLISH_NAME = 'Faroese'
+
+
+class FAT:
+    ISO_639 = 'fat'
+    ENGLISH_NAME = 'Fanti'
+
+
+class FIJ:
+    ISO_639 = 'fij'
+    ENGLISH_NAME = 'Fijian'
+
+
+class FIL:
+    ISO_639 = 'fil'
+    ENGLISH_NAME = 'Filipino'
+
+
+class FIN:
+    ISO_639 = 'fin'
+    ENGLISH_NAME = 'Finnish'
+
+
+class FON:
+    ISO_639 = 'fon'
+    ENGLISH_NAME = 'Fon'
+
+
+class FRE:
+    ISO_639 = 'fre'
+    ENGLISH_NAME = 'French'
+
+
+class FRR:
+    ISO_639 = 'frr'
+    ENGLISH_NAME = 'NorthernFrisian'
+
+
+class FRS:
+    ISO_639 = 'frs'
+    ENGLISH_NAME = 'EasternFrisian'
+
+
+class FRY:
+    ISO_639 = 'fry'
+    ENGLISH_NAME = 'WesternFrisian'
+
+
+class FUL:
+    ISO_639 = 'ful'
+    ENGLISH_NAME = 'Fulah'
+
+
+class FUR:
+    ISO_639 = 'fur'
+    ENGLISH_NAME = 'Friulian'
+
+
+class GAA:
+    ISO_639 = 'gaa'
+    ENGLISH_NAME = 'Ga'
+
+
+class GAY:
+    ISO_639 = 'gay'
+    ENGLISH_NAME = 'Gayo'
+
+
+class GBA:
+    ISO_639 = 'gba'
+    ENGLISH_NAME = 'Gbaya'
+
+
+class GEO:
+    ISO_639 = 'geo'
+    ENGLISH_NAME = 'Georgian'
+
+
+class GER:
+    ISO_639 = 'ger'
+    ENGLISH_NAME = 'German'
+
+
+class GEZ:
+    ISO_639 = 'gez'
+    ENGLISH_NAME = 'Geez'
+
+
+class GIL:
+    ISO_639 = 'gil'
+    ENGLISH_NAME = 'Gilbertese'
+
+
+class GLA:
+    ISO_639 = 'gla'
+    ENGLISH_NAME = 'Gaelic'
+
+
+class GLE:
+    ISO_639 = 'gle'
+    ENGLISH_NAME = 'Irish'
+
+
+class GLG:
+    ISO_639 = 'glg'
+    ENGLISH_NAME = 'Galician'
+
+
+class GLV:
+    ISO_639 = 'glv'
+    ENGLISH_NAME = 'Manx'
+
+
+class GON:
+    ISO_639 = 'gon'
+    ENGLISH_NAME = 'Gondi'
+
+
+class GOR:
+    ISO_639 = 'gor'
+    ENGLISH_NAME = 'Gorontalo'
+
+
+class GOT:
+    ISO_639 = 'got'
+    ENGLISH_NAME = 'Gothic'
+
+
+class GRB:
+    ISO_639 = 'grb'
+    ENGLISH_NAME = 'Grebo'
+
+
+class GRE:
+    ISO_639 = 'gre'
+    ENGLISH_NAME = 'Greek'
+
+
+class GRN:
+    ISO_639 = 'grn'
+    ENGLISH_NAME = 'Guarani'
+
+
+class GSW:
+    ISO_639 = 'gsw'
+    ENGLISH_NAME = 'SwissGerman'
+
+
+class GUJ:
+    ISO_639 = 'guj'
+    ENGLISH_NAME = 'Gujarati'
+
+
+class GWI:
+    ISO_639 = 'gwi'
+    ENGLISH_NAME = 'Gwichin'
+
+
+class HAI:
+    ISO_639 = 'hai'
+    ENGLISH_NAME = 'Haida'
+
+
+class HAT:
+    ISO_639 = 'hat'
+    ENGLISH_NAME = 'Haitian'
+
+
+class HAU:
+    ISO_639 = 'hau'
+    ENGLISH_NAME = 'Hausa'
+
+
+class HAW:
+    ISO_639 = 'haw'
+    ENGLISH_NAME = 'Hawaiian'
+
+
+class HEB:
+    ISO_639 = 'heb'
+    ENGLISH_NAME = 'Hebrew'
+
+
+class HER:
+    ISO_639 = 'her'
+    ENGLISH_NAME = 'Herero'
+
+
+class HIL:
+    ISO_639 = 'hil'
+    ENGLISH_NAME = 'Hiligaynon'
+
+
+class HIN:
+    ISO_639 = 'hin'
+    ENGLISH_NAME = 'Hindi'
+
+
+class HIT:
+    ISO_639 = 'hit'
+    ENGLISH_NAME = 'Hittite'
+
+
+class HMN:
+    ISO_639 = 'hmn'
+    ENGLISH_NAME = 'Hmong'
+
+
+class HMO:
+    ISO_639 = 'hmo'
+    ENGLISH_NAME = 'HiriMotu'
+
+
+class HRV:
+    ISO_639 = 'hrv'
+    ENGLISH_NAME = 'Croatian'
+
+
+class HSB:
+    ISO_639 = 'hsb'
+    ENGLISH_NAME = 'UpperSorbian'
+
+
+class HUN:
+    ISO_639 = 'hun'
+    ENGLISH_NAME = 'Hungarian'
+
+
+class HUP:
+    ISO_639 = 'hup'
+    ENGLISH_NAME = 'Hupa'
+
+
+class IBA:
+    ISO_639 = 'iba'
+    ENGLISH_NAME = 'Iban'
+
+
+class IBO:
+    ISO_639 = 'ibo'
+    ENGLISH_NAME = 'Igbo'
+
+
+class ICE:
+    ISO_639 = 'ice'
+    ENGLISH_NAME = 'Icelandic'
+
+
+class IDO:
+    ISO_639 = 'ido'
+    ENGLISH_NAME = 'Ido'
+
+
+class III:
+    ISO_639 = 'iii'
+    ENGLISH_NAME = 'SichuanYi'
+
+
+class IKU:
+    ISO_639 = 'iku'
+    ENGLISH_NAME = 'Inuktitut'
+
+
+class ILE:
+    ISO_639 = 'ile'
+    ENGLISH_NAME = 'Interlingue'
+
+
+class ILO:
+    ISO_639 = 'ilo'
+    ENGLISH_NAME = 'Iloko'
+
+
+class INA:
+    ISO_639 = 'ina'
+    ENGLISH_NAME = 'Interlingua'
+
+
+class IND:
+    ISO_639 = 'ind'
+    ENGLISH_NAME = 'Indonesian'
+
+
+class INH:
+    ISO_639 = 'inh'
+    ENGLISH_NAME = 'Ingush'
+
+
+class IPK:
+    ISO_639 = 'ipk'
+    ENGLISH_NAME = 'Inupiaq'
+
+
+class ITA:
+    ISO_639 = 'ita'
+    ENGLISH_NAME = 'Italian'
+
+
+class JAV:
+    ISO_639 = 'jav'
+    ENGLISH_NAME = 'Javanese'
+
+
+class JBO:
+    ISO_639 = 'jbo'
+    ENGLISH_NAME = 'Lojban'
+
+
+class JPN:
+    ISO_639 = 'jpn'
+    ENGLISH_NAME = 'Japanese'
+
+
+class JPR:
+    ISO_639 = 'jpr'
+    ENGLISH_NAME = 'JudeoPersian'
+
+
+class JRB:
+    ISO_639 = 'jrb'
+    ENGLISH_NAME = 'JudeoArabic'
+
+
+class KAA:
+    ISO_639 = 'kaa'
+    ENGLISH_NAME = 'KaraKalpak'
+
+
+class KAB:
+    ISO_639 = 'kab'
+    ENGLISH_NAME = 'Kabyle'
+
+
+class KAC:
+    ISO_639 = 'kac'
+    ENGLISH_NAME = 'Kachin'
+
+
+class KAL:
+    ISO_639 = 'kal'
+    ENGLISH_NAME = 'Kalaallisut'
+
+
+class KAM:
+    ISO_639 = 'kam'
+    ENGLISH_NAME = 'Kamba'
+
+
+class KAN:
+    ISO_639 = 'kan'
+    ENGLISH_NAME = 'Kannada'
+
+
+class KAS:
+    ISO_639 = 'kas'
+    ENGLISH_NAME = 'Kashmiri'
+
+
+class KAU:
+    ISO_639 = 'kau'
+    ENGLISH_NAME = 'Kanuri'
+
+
+class KAW:
+    ISO_639 = 'kaw'
+    ENGLISH_NAME = 'Kawi'
+
+
+class KAZ:
+    ISO_639 = 'kaz'
+    ENGLISH_NAME = 'Kazakh'
+
+
+class KBD:
+    ISO_639 = 'kbd'
+    ENGLISH_NAME = 'Kabardian'
+
+
+class KHA:
+    ISO_639 = 'kha'
+    ENGLISH_NAME = 'Khasi'
+
+
+class KHM:
+    ISO_639 = 'khm'
+    ENGLISH_NAME = 'CentralKhmer'
+
+
+class KHO:
+    ISO_639 = 'kho'
+    ENGLISH_NAME = 'Khotanese'
+
+
+class KIK:
+    ISO_639 = 'kik'
+    ENGLISH_NAME = 'Kikuyu'
+
+
+class KIN:
+    ISO_639 = 'kin'
+    ENGLISH_NAME = 'Kinyarwanda'
+
+
+class KIR:
+    ISO_639 = 'kir'
+    ENGLISH_NAME = 'Kirghiz'
+
+
+class KMB:
+    ISO_639 = 'kmb'
+    ENGLISH_NAME = 'Kimbundu'
+
+
+class KOK:
+    ISO_639 = 'kok'
+    ENGLISH_NAME = 'Konkani'
+
+
+class KOM:
+    ISO_639 = 'kom'
+    ENGLISH_NAME = 'Komi'
+
+
+class KON:
+    ISO_639 = 'kon'
+    ENGLISH_NAME = 'Kongo'
+
+
+class KOR:
+    ISO_639 = 'kor'
+    ENGLISH_NAME = 'Korean'
+
+
+class KOS:
+    ISO_639 = 'kos'
+    ENGLISH_NAME = 'Kosraean'
+
+
+class KPE:
+    ISO_639 = 'kpe'
+    ENGLISH_NAME = 'Kpelle'
+
+
+class KRC:
+    ISO_639 = 'krc'
+    ENGLISH_NAME = 'KarachayBalkar'
+
+
+class KRL:
+    ISO_639 = 'krl'
+    ENGLISH_NAME = 'Karelian'
+
+
+class KRU:
+    ISO_639 = 'kru'
+    ENGLISH_NAME = 'Kurukh'
+
+
+class KUA:
+    ISO_639 = 'kua'
+    ENGLISH_NAME = 'Kuanyama'
+
+
+class KUM:
+    ISO_639 = 'kum'
+    ENGLISH_NAME = 'Kumyk'
+
+
+class KUR:
+    ISO_639 = 'kur'
+    ENGLISH_NAME = 'Kurdish'
+
+
+class KUT:
+    ISO_639 = 'kut'
+    ENGLISH_NAME = 'Kutenai'
+
+
+class LAD:
+    ISO_639 = 'lad'
+    ENGLISH_NAME = 'Ladino'
+
+
+class LAH:
+    ISO_639 = 'lah'
+    ENGLISH_NAME = 'Lahnda'
+
+
+class LAM:
+    ISO_639 = 'lam'
+    ENGLISH_NAME = 'Lamba'
+
+
+class LAO:
+    ISO_639 = 'lao'
+    ENGLISH_NAME = 'Lao'
+
+
+class LAT:
+    ISO_639 = 'lat'
+    ENGLISH_NAME = 'Latin'
+
+
+class LAV:
+    ISO_639 = 'lav'
+    ENGLISH_NAME = 'Latvian'
+
+
+class LEZ:
+    ISO_639 = 'lez'
+    ENGLISH_NAME = 'Lezghian'
+
+
+class LIM:
+    ISO_639 = 'lim'
+    ENGLISH_NAME = 'Limburgan'
+
+
+class LIN:
+    ISO_639 = 'lin'
+    ENGLISH_NAME = 'Lingala'
+
+
+class LIT:
+    ISO_639 = 'lit'
+    ENGLISH_NAME = 'Lithuanian'
+
+
+class LOL:
+    ISO_639 = 'lol'
+    ENGLISH_NAME = 'Mongo'
+
+
+class LOZ:
+    ISO_639 = 'loz'
+    ENGLISH_NAME = 'Lozi'
+
+
+class LTZ:
+    ISO_639 = 'ltz'
+    ENGLISH_NAME = 'Luxembourgish'
+
+
+class LUA:
+    ISO_639 = 'lua'
+    ENGLISH_NAME = 'LubaLulua'
+
+
+class LUB:
+    ISO_639 = 'lub'
+    ENGLISH_NAME = 'LubaKatanga'
+
+
+class LUG:
+    ISO_639 = 'lug'
+    ENGLISH_NAME = 'Ganda'
+
+
+class LUI:
+    ISO_639 = 'lui'
+    ENGLISH_NAME = 'Luiseno'
+
+
+class LUN:
+    ISO_639 = 'lun'
+    ENGLISH_NAME = 'Lunda'
+
+
+class LUO:
+    ISO_639 = 'luo'
+    ENGLISH_NAME = 'Luo'
+
+
+class LUS:
+    ISO_639 = 'lus'
+    ENGLISH_NAME = 'Lushai'
+
+
+class MAC:
+    ISO_639 = 'mac'
+    ENGLISH_NAME = 'Macedonian'
+
+
+class MAD:
+    ISO_639 = 'mad'
+    ENGLISH_NAME = 'Madurese'
+
+
+class MAG:
+    ISO_639 = 'mag'
+    ENGLISH_NAME = 'Magahi'
+
+
+class MAH:
+    ISO_639 = 'mah'
+    ENGLISH_NAME = 'Marshallese'
+
+
+class MAI:
+    ISO_639 = 'mai'
+    ENGLISH_NAME = 'Maithili'
+
+
+class MAK:
+    ISO_639 = 'mak'
+    ENGLISH_NAME = 'Makasar'
+
+
+class MAL:
+    ISO_639 = 'mal'
+    ENGLISH_NAME = 'Malayalam'
+
+
+class MAN:
+    ISO_639 = 'man'
+    ENGLISH_NAME = 'Mandingo'
+
+
+class MAO:
+    ISO_639 = 'mao'
+    ENGLISH_NAME = 'Maori'
+
+
+class MAR:
+    ISO_639 = 'mar'
+    ENGLISH_NAME = 'Marathi'
+
+
+class MAS:
+    ISO_639 = 'mas'
+    ENGLISH_NAME = 'Masai'
+
+
+class MAY:
+    ISO_639 = 'may'
+    ENGLISH_NAME = 'Malay'
+
+
+class MDF:
+    ISO_639 = 'mdf'
+    ENGLISH_NAME = 'Moksha'
+
+
+class MDR:
+    ISO_639 = 'mdr'
+    ENGLISH_NAME = 'Mandar'
+
+
+class MEN:
+    ISO_639 = 'men'
+    ENGLISH_NAME = 'Mende'
+
+
+class MIC:
+    ISO_639 = 'mic'
+    ENGLISH_NAME = 'Mikmaq'
+
+
+class MIN:
+    ISO_639 = 'min'
+    ENGLISH_NAME = 'Minangkabau'
+
+
+class MLG:
+    ISO_639 = 'mlg'
+    ENGLISH_NAME = 'Malagasy'
+
+
+class MLT:
+    ISO_639 = 'mlt'
+    ENGLISH_NAME = 'Maltese'
+
+
+class MNC:
+    ISO_639 = 'mnc'
+    ENGLISH_NAME = 'Manchu'
+
+
+class MNI:
+    ISO_639 = 'mni'
+    ENGLISH_NAME = 'Manipuri'
+
+
+class MOH:
+    ISO_639 = 'moh'
+    ENGLISH_NAME = 'Mohawk'
+
+
+class MON:
+    ISO_639 = 'mon'
+    ENGLISH_NAME = 'Mongolian'
+
+
+class MOS:
+    ISO_639 = 'mos'
+    ENGLISH_NAME = 'Mossi'
+
+
+class MUS:
+    ISO_639 = 'mus'
+    ENGLISH_NAME = 'Creek'
+
+
+class MWL:
+    ISO_639 = 'mwl'
+    ENGLISH_NAME = 'Mirandese'
+
+
+class MWR:
+    ISO_639 = 'mwr'
+    ENGLISH_NAME = 'Marwari'
+
+
+class MYV:
+    ISO_639 = 'myv'
+    ENGLISH_NAME = 'Erzya'
+
+
+class NAP:
+    ISO_639 = 'nap'
+    ENGLISH_NAME = 'Neapolitan'
+
+
+class NAU:
+    ISO_639 = 'nau'
+    ENGLISH_NAME = 'Nauru'
+
+
+class NAV:
+    ISO_639 = 'nav'
+    ENGLISH_NAME = 'Navajo'
+
+
+class NBL:
+    ISO_639 = 'nbl'
+    ENGLISH_NAME = 'Ndebele'
+
+
+class NDE:
+    ISO_639 = 'nde'
+    ENGLISH_NAME = 'Ndebele'
+
+
+class NDO:
+    ISO_639 = 'ndo'
+    ENGLISH_NAME = 'Ndonga'
+
+
+class NEP:
+    ISO_639 = 'nep'
+    ENGLISH_NAME = 'Nepali'
+
+
+class NEW:
+    ISO_639 = 'new'
+    ENGLISH_NAME = 'NepalBhasa'
+
+
+class NIA:
+    ISO_639 = 'nia'
+    ENGLISH_NAME = 'Nias'
+
+
+class NIU:
+    ISO_639 = 'niu'
+    ENGLISH_NAME = 'Niuean'
+
+
+class NNO:
+    ISO_639 = 'nno'
+    ENGLISH_NAME = 'NorwegianNynorsk'
+
+
+class NOB:
+    ISO_639 = 'nob'
+    ENGLISH_NAME = 'Bokmål'
+
+
+class NOG:
+    ISO_639 = 'nog'
+    ENGLISH_NAME = 'Nogai'
+
+
+class NOR:
+    ISO_639 = 'nor'
+    ENGLISH_NAME = 'Norwegian'
+
+
+class NQO:
+    ISO_639 = 'nqo'
+    ENGLISH_NAME = 'NKo'
+
+
+class NSO:
+    ISO_639 = 'nso'
+    ENGLISH_NAME = 'Pedi'
+
+
+class NYA:
+    ISO_639 = 'nya'
+    ENGLISH_NAME = 'Chichewa'
+
+
+class NYM:
+    ISO_639 = 'nym'
+    ENGLISH_NAME = 'Nyamwezi'
+
+
+class NYN:
+    ISO_639 = 'nyn'
+    ENGLISH_NAME = 'Nyankole'
+
+
+class NYO:
+    ISO_639 = 'nyo'
+    ENGLISH_NAME = 'Nyoro'
+
+
+class NZI:
+    ISO_639 = 'nzi'
+    ENGLISH_NAME = 'Nzima'
+
+
+class OJI:
+    ISO_639 = 'oji'
+    ENGLISH_NAME = 'Ojibwa'
+
+
+class ORI:
+    ISO_639 = 'ori'
+    ENGLISH_NAME = 'Oriya'
+
+
+class ORM:
+    ISO_639 = 'orm'
+    ENGLISH_NAME = 'Oromo'
+
+
+class OSA:
+    ISO_639 = 'osa'
+    ENGLISH_NAME = 'Osage'
+
+
+class OSS:
+    ISO_639 = 'oss'
+    ENGLISH_NAME = 'Ossetian'
+
+
+class PAG:
+    ISO_639 = 'pag'
+    ENGLISH_NAME = 'Pangasinan'
+
+
+class PAL:
+    ISO_639 = 'pal'
+    ENGLISH_NAME = 'Pahlavi'
+
+
+class PAM:
+    ISO_639 = 'pam'
+    ENGLISH_NAME = 'Pampanga'
+
+
+class PAN:
+    ISO_639 = 'pan'
+    ENGLISH_NAME = 'Panjabi'
+
+
+class PAP:
+    ISO_639 = 'pap'
+    ENGLISH_NAME = 'Papiamento'
+
+
+class PAU:
+    ISO_639 = 'pau'
+    ENGLISH_NAME = 'Palauan'
+
+
+class PER:
+    ISO_639 = 'per'
+    ENGLISH_NAME = 'Persian'
+
+
+class PHN:
+    ISO_639 = 'phn'
+    ENGLISH_NAME = 'Phoenician'
+
+
+class PLI:
+    ISO_639 = 'pli'
+    ENGLISH_NAME = 'Pali'
+
+
+class POL:
+    ISO_639 = 'pol'
+    ENGLISH_NAME = 'Polish'
+
+
+class PON:
+    ISO_639 = 'pon'
+    ENGLISH_NAME = 'Pohnpeian'
+
+
+class POR:
+    ISO_639 = 'por'
+    ENGLISH_NAME = 'Portuguese'
+
+
+class PUS:
+    ISO_639 = 'pus'
+    ENGLISH_NAME = 'Pushto'
+
+
+class QUE:
+    ISO_639 = 'que'
+    ENGLISH_NAME = 'Quechua'
+
+
+class RAJ:
+    ISO_639 = 'raj'
+    ENGLISH_NAME = 'Rajasthani'
+
+
+class RAP:
+    ISO_639 = 'rap'
+    ENGLISH_NAME = 'Rapanui'
+
+
+class RAR:
+    ISO_639 = 'rar'
+    ENGLISH_NAME = 'Rarotongan'
+
+
+class ROH:
+    ISO_639 = 'roh'
+    ENGLISH_NAME = 'Romansh'
+
+
+class ROM:
+    ISO_639 = 'rom'
+    ENGLISH_NAME = 'Romany'
+
+
+class RUM:
+    ISO_639 = 'rum'
+    ENGLISH_NAME = 'Romanian'
+
+
+class RUN:
+    ISO_639 = 'run'
+    ENGLISH_NAME = 'Rundi'
+
+
+class RUP:
+    ISO_639 = 'rup'
+    ENGLISH_NAME = 'Aromanian'
+
+
+class RUS:
+    ISO_639 = 'rus'
+    ENGLISH_NAME = 'Russian'
+
+
+class SAD:
+    ISO_639 = 'sad'
+    ENGLISH_NAME = 'Sandawe'
+
+
+class SAG:
+    ISO_639 = 'sag'
+    ENGLISH_NAME = 'Sango'
+
+
+class SAH:
+    ISO_639 = 'sah'
+    ENGLISH_NAME = 'Yakut'
+
+
+class SAM:
+    ISO_639 = 'sam'
+    ENGLISH_NAME = 'SamaritanAramaic'
+
+
+class SAN:
+    ISO_639 = 'san'
+    ENGLISH_NAME = 'Sanskrit'
+
+
+class SAS:
+    ISO_639 = 'sas'
+    ENGLISH_NAME = 'Sasak'
+
+
+class SAT:
+    ISO_639 = 'sat'
+    ENGLISH_NAME = 'Santali'
+
+
+class SCN:
+    ISO_639 = 'scn'
+    ENGLISH_NAME = 'Sicilian'
+
+
+class SCO:
+    ISO_639 = 'sco'
+    ENGLISH_NAME = 'Scots'
+
+
+class SEL:
+    ISO_639 = 'sel'
+    ENGLISH_NAME = 'Selkup'
+
+
+class SHN:
+    ISO_639 = 'shn'
+    ENGLISH_NAME = 'Shan'
+
+
+class SID:
+    ISO_639 = 'sid'
+    ENGLISH_NAME = 'Sidamo'
+
+
+class SIN:
+    ISO_639 = 'sin'
+    ENGLISH_NAME = 'Sinhala'
+
+
+class SLO:
+    ISO_639 = 'slo'
+    ENGLISH_NAME = 'Slovak'
+
+
+class SLV:
+    ISO_639 = 'slv'
+    ENGLISH_NAME = 'Slovenian'
+
+
+class SMA:
+    ISO_639 = 'sma'
+    ENGLISH_NAME = 'SouthernSami'
+
+
+class SME:
+    ISO_639 = 'sme'
+    ENGLISH_NAME = 'NorthernSami'
+
+
+class SMJ:
+    ISO_639 = 'smj'
+    ENGLISH_NAME = 'LuleSami'
+
+
+class SMN:
+    ISO_639 = 'smn'
+    ENGLISH_NAME = 'InariSami'
+
+
+class SMO:
+    ISO_639 = 'smo'
+    ENGLISH_NAME = 'Samoan'
+
+
+class SMS:
+    ISO_639 = 'sms'
+    ENGLISH_NAME = 'SkoltSami'
+
+
+class SNA:
+    ISO_639 = 'sna'
+    ENGLISH_NAME = 'Shona'
+
+
+class SND:
+    ISO_639 = 'snd'
+    ENGLISH_NAME = 'Sindhi'
+
+
+class SNK:
+    ISO_639 = 'snk'
+    ENGLISH_NAME = 'Soninke'
+
+
+class SOG:
+    ISO_639 = 'sog'
+    ENGLISH_NAME = 'Sogdian'
+
+
+class SOM:
+    ISO_639 = 'som'
+    ENGLISH_NAME = 'Somali'
+
+
+class SOT:
+    ISO_639 = 'sot'
+    ENGLISH_NAME = 'Sotho'
+
+
+class SPA:
+    ISO_639 = 'spa'
+    ENGLISH_NAME = 'Spanish'
+
+
+class SRD:
+    ISO_639 = 'srd'
+    ENGLISH_NAME = 'Sardinian'
+
+
+class SRN:
+    ISO_639 = 'srn'
+    ENGLISH_NAME = 'SrananTongo'
+
+
+class SRP:
+    ISO_639 = 'srp'
+    ENGLISH_NAME = 'Serbian'
+
+
+class SRR:
+    ISO_639 = 'srr'
+    ENGLISH_NAME = 'Serer'
+
+
+class SSW:
+    ISO_639 = 'ssw'
+    ENGLISH_NAME = 'Swati'
+
+
+class SUK:
+    ISO_639 = 'suk'
+    ENGLISH_NAME = 'Sukuma'
+
+
+class SUN:
+    ISO_639 = 'sun'
+    ENGLISH_NAME = 'Sundanese'
+
+
+class SUS:
+    ISO_639 = 'sus'
+    ENGLISH_NAME = 'Susu'
+
+
+class SUX:
+    ISO_639 = 'sux'
+    ENGLISH_NAME = 'Sumerian'
+
+
+class SWA:
+    ISO_639 = 'swa'
+    ENGLISH_NAME = 'Swahili'
+
+
+class SWE:
+    ISO_639 = 'swe'
+    ENGLISH_NAME = 'Swedish'
+
+
+class SYC:
+    ISO_639 = 'syc'
+    ENGLISH_NAME = 'ClassicalSyriac'
+
+
+class SYR:
+    ISO_639 = 'syr'
+    ENGLISH_NAME = 'Syriac'
+
+
+class TAH:
+    ISO_639 = 'tah'
+    ENGLISH_NAME = 'Tahitian'
+
+
+class TAM:
+    ISO_639 = 'tam'
+    ENGLISH_NAME = 'Tamil'
+
+
+class TAT:
+    ISO_639 = 'tat'
+    ENGLISH_NAME = 'Tatar'
+
+
+class TEL:
+    ISO_639 = 'tel'
+    ENGLISH_NAME = 'Telugu'
+
+
+class TEM:
+    ISO_639 = 'tem'
+    ENGLISH_NAME = 'Timne'
+
+
+class TER:
+    ISO_639 = 'ter'
+    ENGLISH_NAME = 'Tereno'
+
+
+class TET:
+    ISO_639 = 'tet'
+    ENGLISH_NAME = 'Tetum'
+
+
+class TGK:
+    ISO_639 = 'tgk'
+    ENGLISH_NAME = 'Tajik'
+
+
+class TGL:
+    ISO_639 = 'tgl'
+    ENGLISH_NAME = 'Tagalog'
+
+
+class THA:
+    ISO_639 = 'tha'
+    ENGLISH_NAME = 'Thai'
+
+
+class TIB:
+    ISO_639 = 'tib'
+    ENGLISH_NAME = 'Tibetan'
+
+
+class TIG:
+    ISO_639 = 'tig'
+    ENGLISH_NAME = 'Tigre'
+
+
+class TIR:
+    ISO_639 = 'tir'
+    ENGLISH_NAME = 'Tigrinya'
+
+
+class TIV:
+    ISO_639 = 'tiv'
+    ENGLISH_NAME = 'Tiv'
+
+
+class TKL:
+    ISO_639 = 'tkl'
+    ENGLISH_NAME = 'Tokelau'
+
+
+class TLH:
+    ISO_639 = 'tlh'
+    ENGLISH_NAME = 'Klingon'
+
+
+class TLI:
+    ISO_639 = 'tli'
+    ENGLISH_NAME = 'Tlingit'
+
+
+class TMH:
+    ISO_639 = 'tmh'
+    ENGLISH_NAME = 'Tamashek'
+
+
+class TOG:
+    ISO_639 = 'tog'
+    ENGLISH_NAME = 'Tonga'
+
+
+class TON:
+    ISO_639 = 'ton'
+    ENGLISH_NAME = 'Tonga'
+
+
+class TPI:
+    ISO_639 = 'tpi'
+    ENGLISH_NAME = 'TokPisin'
+
+
+class TSI:
+    ISO_639 = 'tsi'
+    ENGLISH_NAME = 'Tsimshian'
+
+
+class TSN:
+    ISO_639 = 'tsn'
+    ENGLISH_NAME = 'Tswana'
+
+
+class TSO:
+    ISO_639 = 'tso'
+    ENGLISH_NAME = 'Tsonga'
+
+
+class TUK:
+    ISO_639 = 'tuk'
+    ENGLISH_NAME = 'Turkmen'
+
+
+class TUM:
+    ISO_639 = 'tum'
+    ENGLISH_NAME = 'Tumbuka'
+
+
+class TUR:
+    ISO_639 = 'tur'
+    ENGLISH_NAME = 'Turkish'
+
+
+class TVL:
+    ISO_639 = 'tvl'
+    ENGLISH_NAME = 'Tuvalu'
+
+
+class TWI:
+    ISO_639 = 'twi'
+    ENGLISH_NAME = 'Twi'
+
+
+class TYV:
+    ISO_639 = 'tyv'
+    ENGLISH_NAME = 'Tuvinian'
+
+
+class UDM:
+    ISO_639 = 'udm'
+    ENGLISH_NAME = 'Udmurt'
+
+
+class UGA:
+    ISO_639 = 'uga'
+    ENGLISH_NAME = 'Ugaritic'
+
+
+class UIG:
+    ISO_639 = 'uig'
+    ENGLISH_NAME = 'Uighur'
+
+
+class UKR:
+    ISO_639 = 'ukr'
+    ENGLISH_NAME = 'Ukrainian'
+
+
+class UMB:
+    ISO_639 = 'umb'
+    ENGLISH_NAME = 'Umbundu'
+
+
+class UND:
+    ISO_639 = 'und'
+    ENGLISH_NAME = 'Undetermined'
+
+
+class URD:
+    ISO_639 = 'urd'
+    ENGLISH_NAME = 'Urdu'
+
+
+class UZB:
+    ISO_639 = 'uzb'
+    ENGLISH_NAME = 'Uzbek'
+
+
+class VAI:
+    ISO_639 = 'vai'
+    ENGLISH_NAME = 'Vai'
+
+
+class VEN:
+    ISO_639 = 'ven'
+    ENGLISH_NAME = 'Venda'
+
+
+class VIE:
+    ISO_639 = 'vie'
+    ENGLISH_NAME = 'Vietnamese'
+
+
+class VOL:
+    ISO_639 = 'vol'
+    ENGLISH_NAME = 'Volapük'
+
+
+class VOT:
+    ISO_639 = 'vot'
+    ENGLISH_NAME = 'Votic'
+
+
+class WAL:
+    ISO_639 = 'wal'
+    ENGLISH_NAME = 'Wolaitta'
+
+
+class WAR:
+    ISO_639 = 'war'
+    ENGLISH_NAME = 'Waray'
+
+
+class WAS:
+    ISO_639 = 'was'
+    ENGLISH_NAME = 'Washo'
+
+
+class WEL:
+    ISO_639 = 'wel'
+    ENGLISH_NAME = 'Welsh'
+
+
+class WLN:
+    ISO_639 = 'wln'
+    ENGLISH_NAME = 'Walloon'
+
+
+class WOL:
+    ISO_639 = 'wol'
+    ENGLISH_NAME = 'Wolof'
+
+
+class XAL:
+    ISO_639 = 'xal'
+    ENGLISH_NAME = 'Kalmyk'
+
+
+class XHO:
+    ISO_639 = 'xho'
+    ENGLISH_NAME = 'Xhosa'
+
+
+class YAO:
+    ISO_639 = 'yao'
+    ENGLISH_NAME = 'Yao'
+
+
+class YAP:
+    ISO_639 = 'yap'
+    ENGLISH_NAME = 'Yapese'
+
+
+class YID:
+    ISO_639 = 'yid'
+    ENGLISH_NAME = 'Yiddish'
+
+
+class YOR:
+    ISO_639 = 'yor'
+    ENGLISH_NAME = 'Yoruba'
+
+
+class ZAP:
+    ISO_639 = 'zap'
+    ENGLISH_NAME = 'Zapotec'
+
+
+class ZBL:
+    ISO_639 = 'zbl'
+    ENGLISH_NAME = 'Blissymbols'
+
+
+class ZEN:
+    ISO_639 = 'zen'
+    ENGLISH_NAME = 'Zenaga'
+
+
+class ZGH:
+    ISO_639 = 'zgh'
+    ENGLISH_NAME = 'StandardMoroccanTamazight'
+
+
+class ZHA:
+    ISO_639 = 'zha'
+    ENGLISH_NAME = 'Zhuang'
+
+
+class ZUL:
+    ISO_639 = 'zul'
+    ENGLISH_NAME = 'Zulu'
+
+
+class ZUN:
+    ISO_639 = 'zun'
+    ENGLISH_NAME = 'Zuni'
+
+
+class ZZA:
+    ISO_639 = 'zza'
+    ENGLISH_NAME = 'Zaza'

--- a/chatterbot/storage/storage_adapter.py
+++ b/chatterbot/storage/storage_adapter.py
@@ -1,4 +1,5 @@
 import logging
+from chatterbot import languages
 from chatterbot.tagging import PosHypernymTagger
 
 
@@ -17,7 +18,7 @@ class StorageAdapter(object):
         self.adapter_supports_queries = True
 
         self.tagger = PosHypernymTagger(language=kwargs.get(
-            'tagger_language', 'english'
+            'tagger_language', languages.ENG
         ))
 
     def get_model(self, model_name):

--- a/chatterbot/tagging.py
+++ b/chatterbot/tagging.py
@@ -1,4 +1,5 @@
 import string
+from chatterbot import languages
 from chatterbot.utils import treebank_to_wordnet
 from nltk import pos_tag
 from nltk.data import load as load_data
@@ -11,8 +12,8 @@ class PosHypernymTagger(object):
     hypernym preceded by the part of speech of the word before it.
     """
 
-    def __init__(self, language='english'):
-        self.language = language
+    def __init__(self, language=None):
+        self.language = language or languages.ENG
 
         self.sentence_detector = None
 
@@ -56,7 +57,7 @@ class PosHypernymTagger(object):
         Get the list of stopwords from the NLTK corpus.
         """
         if self.stopwords is None:
-            self.stopwords = stopwords.words(self.language)
+            self.stopwords = stopwords.words(self.language.ENGLISH_NAME.lower())
 
         return self.stopwords
 

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -30,10 +30,6 @@ class Trainer(object):
             environment_default
         )
 
-        self.tagger = PosHypernymTagger(language=kwargs.get(
-            'tagger_language', 'english'
-        ))
-
     def get_preprocessed_statement(self, input_statement):
         """
         Preprocess the input statement.
@@ -104,7 +100,7 @@ class ListTrainer(Trainer):
                     conversation_count + 1, len(conversation)
                 )
 
-            statement_search_text = self.tagger.get_bigram_pair_string(text)
+            statement_search_text = self.chatbot.storage.tagger.get_bigram_pair_string(text)
 
             statement = self.get_preprocessed_statement(
                 Statement(
@@ -158,7 +154,7 @@ class ChatterBotCorpusTrainer(Trainer):
 
                 for text in conversation:
 
-                    statement_search_text = self.tagger.get_bigram_pair_string(text)
+                    statement_search_text = self.chatbot.storage.tagger.get_bigram_pair_string(text)
 
                     statement = Statement(
                         text=text,
@@ -430,7 +426,7 @@ class UbuntuCorpusTrainer(Trainer):
     def train(self):
         import glob
 
-        tagger = PosHypernymTagger(language=self.tagger.language)
+        tagger = PosHypernymTagger(language=self.chatbot.storage.tagger.language)
 
         # Download and extract the Ubuntu dialog corpus if needed
         corpus_download_path = self.download(self.data_download_url)

--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -141,27 +141,6 @@ def treebank_to_wordnet(pos):
     return data_map.get(pos[0])
 
 
-def remove_stopwords(tokens, language):
-    """
-    Takes a language (i.e. 'english'), and a set of word tokens.
-    Returns the tokenized text with any stopwords removed.
-    Stop words are words like "is, the, a, ..."
-
-    Be sure to download the required NLTK corpus before calling this function:
-    - from chatterbot.utils import nltk_download_corpus
-    - nltk_download_corpus('corpora/stopwords')
-    """
-    from nltk.corpus import stopwords
-
-    # Get the stopwords for the specified language
-    stop_words = stopwords.words(language)
-
-    # Remove the stop words from the set of word tokens
-    tokens = set(tokens) - set(stop_words)
-
-    return tokens
-
-
 def get_greatest_confidence(statement, options):
     """
     Returns the greatest confidence value for a statement that occurs

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -23,12 +23,6 @@ NLTK corpus downloader
 .. autofunction:: chatterbot.utils.nltk_download_corpus
 
 
-Stopword removal
-----------------
-
-.. autofunction:: chatterbot.utils.remove_stopwords
-
-
 ChatBot response time
 ---------------------
 

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -58,6 +58,17 @@ class LevenshteinDistanceTestCase(TestCase):
 
 class SynsetDistanceTestCase(TestCase):
 
+    def test_exact_match_different_stopwords(self):
+        """
+        Test that stopwords are ignored.
+        """
+        statement = Statement(text='What is matter?')
+        other_statement = Statement(text='What is the matter?')
+
+        value = comparisons.synset_distance(statement, other_statement)
+
+        self.assertEqual(value, 1)
+
     def test_exact_match_different_capitalization(self):
         """
         Test that text capitalization is ignored.

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,0 +1,18 @@
+import sys
+import inspect
+from chatterbot import languages
+from unittest import TestCase
+
+
+class LanguageClassTests(TestCase):
+
+    def test_classes_have_correct_attributes(self):
+        language_classes = inspect.getmembers(sys.modules[languages.__name__])
+
+        for name, obj in language_classes:
+            if inspect.isclass(obj):
+                self.assertTrue(hasattr(obj, 'ISO_639'))
+                self.assertTrue(hasattr(obj, 'ENGLISH_NAME'))
+                self.assertEqual(name, obj.ISO_639.upper())
+
+        self.assertEqual(len(language_classes), 408)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,19 +13,6 @@ class UtilityTests(TestCase):
         downloaded = utils.nltk_download_corpus('wordnet')
         self.assertTrue(downloaded)
 
-    def test_remove_stop_words(self):
-        from chatterbot.utils import nltk_download_corpus
-
-        nltk_download_corpus('stopwords')
-
-        tokens = ['this', 'is', 'a', 'test', 'string']
-        words = utils.remove_stopwords(tokens, 'english')
-
-        # This example list of words should end up with only two elements
-        self.assertEqual(len(words), 2)
-        self.assertIn('test', list(words))
-        self.assertIn('string', list(words))
-
     def test_get_greatest_confidence(self):
         statement = 'Hello'
         options = [


### PR DESCRIPTION
This will allow a single language attribute to be shared among different methods that need either 'english' or 'eng' as parameters.

```python
def generate_language_classes():
    """
    pip install beautifulsoup4==4.6
    """
    import requests
    from bs4 import BeautifulSoup

    DOWNLOAD_URL = 'https://www.loc.gov/standards/iso639-2/php/code_list.php'

    SKIP_IF_LANGUAGE_NAME_CONTAINS = (
        'Old',
        'Ancient',
        'Low',
        'Middle',
        'High',
        '00',
        'ca.',
        'languages',
        'Languages',
        'Reserved',
        'Not applicable',
    )

    BIBLIOGRAPHIC_INDICATOR = ' (B)'

    # Download the language-code HTML page from the Library of Congress
    response = requests.get(DOWNLOAD_URL)

    soup = BeautifulSoup(response.content, 'lxml')

    table = soup.find('table', attrs={
        'border': '1'
    })

    extracted_data = {}

    for row in table.find_all('tr'):
        columns = [td.text for td in row.find_all('td')]

        if not columns:
            continue

        iso_code = columns[0]
        english_name = columns[2]

        if any(term in english_name for term in SKIP_IF_LANGUAGE_NAME_CONTAINS):
            continue

        if BIBLIOGRAPHIC_INDICATOR in iso_code:
            iso_code = iso_code.split(BIBLIOGRAPHIC_INDICATOR)[0]

        if ';' in english_name:
            english_name = english_name.split(';')[0]

        if ',' in english_name:
            english_name = english_name.split(',')[0]

        if ' (' in english_name:
            english_name = english_name.split(' (')[0]

        english_name = english_name.replace('-', '')

        english_name = english_name.replace(' ', '')

        english_name = english_name.replace("'", '')

        extracted_data[iso_code] = english_name

    with open('./out.py', 'w+') as output:
        for iso_code in sorted(extracted_data.keys()):
            output.write(
                "class {class_name}:\n"
                "    ISO_639 = '{iso_code}'\n"
                "    ENGLISH_NAME = '{english_name}'\n\n\n".format(
                    class_name=iso_code.upper(),
                    english_name=extracted_data[iso_code],
                    iso_code=iso_code
                )
            )


generate_language_classes()
```