### PR TITLE
modified line-21 in examples/django_app/example_app/templates/nav.html

### DIFF
--- a/examples/django_app/example_app/templates/nav.html
+++ b/examples/django_app/example_app/templates/nav.html
@@ -18,7 +18,7 @@
 
   <ul class="nav navbar-nav float-xs-right">
     <li class="nav-item">
-      <a class="nav-link" href="{% url 'chatterbot:chatterbot' %}">API</a>
+      <a class="nav-link" href="{% url 'chatterbot' %}">API</a>
     </li>
     <li class="nav-item">
       <a class="nav-link" href="{% url 'admin:index' %}">Admin</a>


### PR DESCRIPTION
Replaced `line 21` of "examples/django_app/example_app/templates/nav.html" i.e., 
`<a class="nav-link" href="{% url 'chatterbot:chatterbot' %}">API</a>` with 
`<a class="nav-link" href="{% url 'chatterbot' %}">API</a>`.

This resolved the issue 

> 'chatterbot' is not a registered namespace