### PR TITLE
Change maximum allowed text length

### DIFF
--- a/chatterbot/constants.py
+++ b/chatterbot/constants.py
@@ -4,10 +4,11 @@ ChatterBot constants
 
 '''
 The maximum length of characters that the text of a statement can contain.
-This should be enforced on a per-model basis by the data model for each
-storage adapter.
+The number 255 is used because that is the maximum length of a char field
+in most databases. This value should be enforced on a per-model basis by
+the data model for each storage adapter.
 '''
-STATEMENT_TEXT_MAX_LENGTH = 400
+STATEMENT_TEXT_MAX_LENGTH = 255
 
 '''
 The maximum length of characters that the text label of a conversation can contain.

--- a/chatterbot/ext/django_chatterbot/migrations/0018_text_max_length.py
+++ b/chatterbot/ext/django_chatterbot/migrations/0018_text_max_length.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_chatterbot', '0017_tags_unique'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='statement',
+            name='in_response_to',
+            field=models.CharField(max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name='statement',
+            name='search_in_response_to',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='statement',
+            name='search_text',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='statement',
+            name='text',
+            field=models.CharField(max_length=255),
+        ),
+    ]


### PR DESCRIPTION
Most databases have a maximum allowed length of 255 characters for char fields.

Closes #1546