### PR TITLE
Allow parameter to be passed in for response filter

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -92,6 +92,8 @@ class ChatBot(object):
         :returns: A response to the input.
         :rtype: Statement
         """
+        additional_response_selection_parameters = kwargs.pop('additional_response_selection_parameters', {})
+
         if isinstance(statement, str):
             kwargs['text'] = statement
 
@@ -116,7 +118,7 @@ class ChatBot(object):
         for preprocessor in self.preprocessors:
             input_statement = preprocessor(input_statement)
 
-        response = self.generate_response(input_statement)
+        response = self.generate_response(input_statement, additional_response_selection_parameters)
 
         # Learn that the user's input was a valid response to the chat bot's previous output
         previous_statement = self.get_latest_response(input_statement.conversation)
@@ -134,7 +136,7 @@ class ChatBot(object):
 
         return response
 
-    def generate_response(self, input_statement):
+    def generate_response(self, input_statement, additional_response_selection_parameters=None):
         """
         Return a response based on a given input statement.
 
@@ -149,7 +151,7 @@ class ChatBot(object):
         for adapter in self.logic_adapters:
             if adapter.can_process(input_statement):
 
-                output = adapter.process(input_statement)
+                output = adapter.process(input_statement, additional_response_selection_parameters)
                 results.append((output.confidence, output, ))
 
                 self.logger.info(

--- a/chatterbot/logic/logic_adapter.py
+++ b/chatterbot/logic/logic_adapter.py
@@ -77,7 +77,7 @@ class LogicAdapter(Adapter):
         """
         return True
 
-    def process(self, statement):
+    def process(self, statement, additional_response_selection_parameters=None):
         """
         Override this method and implement your logic for selecting a response to an input statement.
 
@@ -91,6 +91,10 @@ class LogicAdapter(Adapter):
 
         :param statement: An input statement to be processed by the logic adapter.
         :type statement: Statement
+
+        :param additional_response_selection_parameters: Parameters to be used when
+            filtering results to choose a response from.
+        :type additional_response_selection_parameters: dict
 
         :rtype: Statement
         """

--- a/chatterbot/logic/mathematical_evaluation.py
+++ b/chatterbot/logic/mathematical_evaluation.py
@@ -34,7 +34,7 @@ class MathematicalEvaluation(LogicAdapter):
         self.cache[statement.text] = response
         return response.confidence == 1
 
-    def process(self, statement):
+    def process(self, statement, additional_response_selection_parameters=None):
         """
         Takes a statement string.
         Returns the equation from the statement with the mathematical terms solved.

--- a/chatterbot/logic/specific_response.py
+++ b/chatterbot/logic/specific_response.py
@@ -27,7 +27,7 @@ class SpecificResponseAdapter(LogicAdapter):
 
         return False
 
-    def process(self, statement):
+    def process(self, statement, additional_response_selection_parameters=None):
 
         if statement == self.input_text:
             self.response_statement.confidence = 1

--- a/chatterbot/logic/time_adapter.py
+++ b/chatterbot/logic/time_adapter.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from chatterbot.logic import LogicAdapter
+from chatterbot.conversation import Statement
 
 
 class TimeLogicAdapter(LogicAdapter):
@@ -80,9 +81,7 @@ class TimeLogicAdapter(LogicAdapter):
 
         return features
 
-    def process(self, statement):
-        from chatterbot.conversation import Statement
-
+    def process(self, statement, additional_response_selection_parameters=None):
         now = datetime.now()
 
         time_features = self.time_question_features(statement.text.lower())

--- a/chatterbot/logic/unit_conversion.py
+++ b/chatterbot/logic/unit_conversion.py
@@ -139,7 +139,7 @@ class UnitConversion(LogicAdapter):
         self.cache[statement.text] = response
         return response.confidence == 1.0
 
-    def process(self, statement):
+    def process(self, statement, additional_response_selection_parameters=None):
         response = Statement(text='')
         input_text = statement.text
         try:

--- a/chatterbot/search.py
+++ b/chatterbot/search.py
@@ -28,13 +28,17 @@ class IndexedTextSearch:
             'search_page_size', 1000
         )
 
-    def search(self, input_statement):
+    def search(self, input_statement, **additional_parameters):
         """
         Search for close matches to the input. Confidence scores for
         subsequent results will order of increasing value.
 
         :param input_statement: A statement.
         :type input_statement: chatterbot.conversation.Statement
+
+        :param **additional_parameters: Additional parameters to be passed
+            to the ``filter`` method of the storage adapter when searching.
+
         :rtype: Generator yielding one closest matching statement at a time.
         """
         self.chatbot.logger.info('Beginning search for close text match')
@@ -50,11 +54,16 @@ class IndexedTextSearch:
                 input_statement.text
             )
 
-        statement_list = self.chatbot.storage.filter(
-            search_text_contains=input_search_text,
-            persona_not_startswith='bot:',
-            page_size=self.search_page_size
-        )
+        search_parameters = {
+            'search_text_contains': input_search_text,
+            'persona_not_startswith': 'bot:',
+            'page_size': self.search_page_size
+        }
+
+        if additional_parameters:
+            search_parameters.update(additional_parameters)
+
+        statement_list = self.chatbot.storage.filter(**search_parameters)
 
         closest_match = Statement(text='')
         closest_match.confidence = 0

--- a/examples/tagged_dataset_example.py
+++ b/examples/tagged_dataset_example.py
@@ -1,0 +1,44 @@
+from chatterbot import ChatBot
+from chatterbot.conversation import Statement
+
+
+chatbot = ChatBot(
+    'Example Bot',
+    # This database will be a temporary in-memory database
+    database_uri=None
+)
+
+label_a_statements = [
+    Statement(text='Hello', tags=['label_a']),
+    Statement(text='Hi', tags=['label_a']),
+    Statement(text='How are you?', tags=['label_a'])
+]
+
+label_b_statements = [
+    Statement(text='I like dogs.', tags=['label_b']),
+    Statement(text='I like cats.', tags=['label_b']),
+    Statement(text='I like animals.', tags=['label_b'])
+]
+
+chatbot.storage.create_many(
+    label_a_statements + label_b_statements
+)
+
+# Return a response from "label_a_statements"
+response_from_label_a = chatbot.get_response(
+    'How are you?',
+    additional_response_selection_parameters={
+        'tags': ['label_a']
+    }
+)
+
+# Return a response from "label_b_statements"
+response_from_label_b = chatbot.get_response(
+    'How are you?',
+    additional_response_selection_parameters={
+        'tags': ['label_b']
+    }
+)
+
+print('Response from label_a collection:', response_from_label_a.text)
+print('Response from label_b collection:', response_from_label_b.text)

--- a/tests/logic/test_data_cache.py
+++ b/tests/logic/test_data_cache.py
@@ -9,7 +9,7 @@ class DummyMutatorLogicAdapter(LogicAdapter):
     the resulting statement before it is returned.
     """
 
-    def process(self, statement):
+    def process(self, statement, additional_response_selection_parameters=None):
         statement.add_tags('pos_tags:NN')
 
         self.chatbot.storage.update(statement)

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -179,6 +179,22 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
         self.assertEqual(statement.text, response)
         self.assertEqual(response.conversation, 'test')
 
+    def test_get_response_additional_response_selection_parameters(self):
+        self.chatbot.storage.create_many([
+            Statement('A', conversation='test_1'),
+            Statement('B', conversation='test_1', in_response_to='A'),
+            Statement('A', conversation='test_2'),
+            Statement('C', conversation='test_2', in_response_to='A'),
+        ])
+
+        statement = Statement(text='A', conversation='test_3')
+        response = self.chatbot.get_response(statement, additional_response_selection_parameters={
+            'conversation': 'test_2'
+        })
+
+        self.assertEqual(response.text, 'C')
+        self.assertEqual(response.conversation, 'test_3')
+
     def test_get_response_unicode(self):
         """
         Test the case that a unicode string is passed in.
@@ -330,7 +346,7 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
 
 class TestAdapterA(LogicAdapter):
 
-    def process(self, statement):
+    def process(self, statement, additional_response_selection_parameters=None):
         response = Statement(text='Good morning.')
         response.confidence = 0.2
         return response
@@ -338,7 +354,7 @@ class TestAdapterA(LogicAdapter):
 
 class TestAdapterB(LogicAdapter):
 
-    def process(self, statement):
+    def process(self, statement, additional_response_selection_parameters=None):
         response = Statement(text='Good morning.')
         response.confidence = 0.5
         return response
@@ -346,7 +362,7 @@ class TestAdapterB(LogicAdapter):
 
 class TestAdapterC(LogicAdapter):
 
-    def process(self, statement):
+    def process(self, statement, additional_response_selection_parameters=None):
         response = Statement(text='Good night.')
         response.confidence = 0.7
         return response

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,6 +31,25 @@ class SearchTestCase(ChatBotTestCase):
 
         self.assertEqual(results, [])
 
+    def test_search_additional_parameters(self):
+        """
+        It should be possible to pass additional parameters in to use for searching.
+        """
+        self.chatbot.storage.create_many([
+            Statement(text='A', conversation='test_1'),
+            Statement(text='A', conversation='test_2')
+        ])
+
+        statement = Statement(text='A')
+
+        results = list(self.search_algorithm.search(
+            statement, conversation='test_1'
+        ))
+
+        self.assertIsLength(results, 1)
+        self.assertEqual(results[0].text, 'A')
+        self.assertEqual(results[0].conversation, 'test_1')
+
 
 class SearchComparisonFunctionSynsetDistanceTests(ChatBotTestCase):
     """


### PR DESCRIPTION
This allows an additional parameter to be passed in to control what statements get selected when generating the list of possible responses.

* For #1542 item 2
* For #1232
* Closes #1179
* Closes #1541
* Resolves #1536