### PR TITLE
Change where / how hashing is done for statements

### DIFF
--- a/chatterbot/conversation.py
+++ b/chatterbot/conversation.py
@@ -91,19 +91,6 @@ class Statement(StatementMixin):
     def __repr__(self):
         return '<Statement text:%s>' % (self.text)
 
-    def __hash__(self):
-        in_response_to = self.in_response_to or ''
-        return hash(self.text + ':' + in_response_to)
-
-    def __eq__(self, other):
-        if not other:
-            return False
-
-        if isinstance(other, Statement):
-            return self.text == other.text
-
-        return self.text == other
-
     def save(self):
         """
         Save the statement in the database.

--- a/chatterbot/logic/specific_response.py
+++ b/chatterbot/logic/specific_response.py
@@ -29,7 +29,7 @@ class SpecificResponseAdapter(LogicAdapter):
 
     def process(self, statement, additional_response_selection_parameters=None):
 
-        if statement == self.input_text:
+        if statement.text == self.input_text:
             self.response_statement.confidence = 1
         else:
             self.response_statement.confidence = 0

--- a/tests/storage/test_mongo_adapter.py
+++ b/tests/storage/test_mongo_adapter.py
@@ -183,9 +183,14 @@ class MongoAdapterFilterTestCase(MongoAdapterTestCase):
         self.adapter.update(statement2)
 
         results = list(self.adapter.filter(in_response_to=[]))
+
+        results_text = [
+            result.text for result in results
+        ]
+
         self.assertEqual(len(results), 2)
-        self.assertIn(statement1, results)
-        self.assertIn(statement2, results)
+        self.assertIn(statement1.text, results_text)
+        self.assertIn(statement2.text, results_text)
 
     def test_filter_no_parameters(self):
         """
@@ -330,8 +335,8 @@ class MongoOrderingTestCase(MongoAdapterTestCase):
         results = list(self.adapter.filter(order_by=['text']))
 
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0], statement_a)
-        self.assertEqual(results[1], statement_b)
+        self.assertEqual(statement_a.text, results[0].text)
+        self.assertEqual(statement_b.text, results[1].text)
 
     def test_order_by_created_at(self):
         from datetime import datetime, timedelta
@@ -354,8 +359,8 @@ class MongoOrderingTestCase(MongoAdapterTestCase):
         results = list(self.adapter.filter(order_by=['created_at']))
 
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0], statement_a)
-        self.assertEqual(results[1], statement_b)
+        self.assertEqual(statement_a.text, results[0].text)
+        self.assertEqual(statement_b.text, results[1].text)
 
 
 class StorageAdapterCreateTestCase(MongoAdapterTestCase):

--- a/tests/storage/test_sql_adapter.py
+++ b/tests/storage/test_sql_adapter.py
@@ -148,9 +148,13 @@ class SQLStorageAdapterFilterTests(SQLStorageAdapterTestCase):
 
         results = list(self.adapter.filter(in_response_to=None))
 
+        results_text = [
+            result.text for result in results
+        ]
+
         self.assertEqual(len(results), 2)
-        self.assertIn(statement1, results)
-        self.assertIn(statement2, results)
+        self.assertIn(statement1.text, results_text)
+        self.assertIn(statement2.text, results_text)
 
     def test_filter_no_parameters(self):
         """
@@ -281,8 +285,8 @@ class SQLOrderingTests(SQLStorageAdapterTestCase):
         results = list(self.adapter.filter(order_by=['text']))
 
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0], statement_a)
-        self.assertEqual(results[1], statement_b)
+        self.assertEqual(statement_a.text, results[0].text)
+        self.assertEqual(statement_b.text, results[1].text)
 
     def test_order_by_created_at(self):
         from datetime import datetime, timedelta
@@ -305,8 +309,8 @@ class SQLOrderingTests(SQLStorageAdapterTestCase):
         results = list(self.adapter.filter(order_by=['created_at']))
 
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0], statement_a)
-        self.assertEqual(results[1], statement_b)
+        self.assertEqual(statement_a.text, results[0].text)
+        self.assertEqual(statement_b.text, results[1].text)
 
 
 class StorageAdapterCreateTests(SQLStorageAdapterTestCase):

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -5,25 +5,8 @@ from chatterbot.conversation import Statement
 class StatementTests(TestCase):
 
     def setUp(self):
-        self.statement = Statement(text="A test statement.")
-
-    def test_string_equality(self):
-        """
-        It should be possible to check if a statement
-        is the same as the statement text that another
-        statement lists as a response.
-        """
-        self.assertEqual(self.statement, "A test statement.")
-
-    def test_string_equality_unicode(self):
-        """
-        Test that it is possible to check if a statement
-        is in a list of other statements when the
-        statements text is unicode.
-        """
-        self.statement.text = "我很好太感谢"
-        self.assertEqual(self.statement, "我很好太感谢")
+        self.statement = Statement(text='A test statement.')
 
     def test_serializer(self):
         data = self.statement.serialize()
-        self.assertEqual(self.statement.text, data["text"])
+        self.assertEqual(self.statement.text, data['text'])

--- a/tests/test_response_selection.py
+++ b/tests/test_response_selection.py
@@ -41,7 +41,7 @@ class ResponseSelectionTests(ChatBotSQLTestCase):
 
         output = response_selection.get_first_response(Statement(text='Hello'), statement_list)
 
-        self.assertEqual('What... is your quest?', output)
+        self.assertEqual(output.text, 'What... is your quest?')
 
     def test_get_random_response(self):
         statement_list = [

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -80,7 +80,7 @@ class SearchComparisonFunctionSynsetDistanceTests(ChatBotTestCase):
         results = list(self.search_algorithm.search(statement))
 
         self.assertIsLength(results, 1)
-        self.assertEqual(results[0], 'This is a lovely bog.')
+        self.assertEqual(results[0].text, 'This is a lovely bog.')
         self.assertGreater(results[0].confidence, 0)
 
     def test_different_punctuation(self):
@@ -94,7 +94,7 @@ class SearchComparisonFunctionSynsetDistanceTests(ChatBotTestCase):
         results = list(self.search_algorithm.search(statement))
 
         self.assertIsLength(results, 1)
-        self.assertEqual(results[0], 'Are you good?')
+        self.assertEqual(results[0].text, 'Are you good?')
 
 
 class SearchComparisonFunctionSentimentComparisonTests(ChatBotTestCase):
@@ -179,7 +179,7 @@ class SearchComparisonFunctionLevenshteinDistanceComparisonTests(ChatBotTestCase
         results = list(self.search_algorithm.search(statement))
 
         self.assertIsLength(results, 1)
-        self.assertEqual(results[0], 'What... is your quest?')
+        self.assertEqual(results[0].text, 'What... is your quest?')
 
     def test_confidence_exact_match(self):
         self.chatbot.storage.create(text='What is your quest?', in_response_to='What is your quest?')


### PR DESCRIPTION
The original Statement object had a __hash__ function defined which was yielding different results when other Statement object types were used. This removes the hash method and makes a change to how similar statements are counted.

Possibly related to #1375