### PR TITLE
Generate search_text before searching

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -126,6 +126,14 @@ class ChatBot(object):
         for preprocessor in self.preprocessors:
             input_statement = preprocessor(input_statement)
 
+        # Make sure the input statement has its search text saved
+
+        if not input_statement.search_text:
+            input_statement.search_text = self.storage.tagger.get_bigram_pair_string(input_statement.text)
+
+        if not input_statement.search_in_response_to and input_statement.in_response_to:
+            input_statement.search_in_response_to = self.storage.tagger.get_bigram_pair_string(input_statement.in_response_to)
+
         response = self.generate_response(input_statement, additional_response_selection_parameters)
 
         # Update any response data that needs to be changed


### PR DESCRIPTION
I'm adding in a few lines to generate the search text values before the input statement is given to the logic adapters. This will silence the warning described in #1589.

Closes #1589