### PR TITLE
Use chatterbot-corpus to train PunktSentenceTokenizer

### DIFF
--- a/chatterbot/tagging.py
+++ b/chatterbot/tagging.py
@@ -1,8 +1,8 @@
 import string
 from chatterbot import languages
 from chatterbot import utils
+from chatterbot.tokenizers import get_sentence_tokenizer
 from nltk import pos_tag
-from nltk.data import load as load_data
 from nltk.corpus import wordnet, stopwords
 from nltk.corpus.reader.wordnet import WordNetError
 
@@ -32,12 +32,6 @@ class PosHypernymTagger(object):
         """
         utils.nltk_download_corpus('corpora/wordnet')
 
-    def initialize_nltk_punkt(self):
-        """
-        Download required NLTK punkt corpus if it has not already been downloaded.
-        """
-        utils.nltk_download_corpus('punkt')
-
     def initialize_nltk_averaged_perceptron_tagger(self):
         """
         Download the NLTK averaged perceptron tagger that is required for this algorithm
@@ -59,15 +53,7 @@ class PosHypernymTagger(object):
         Tokenize the provided sentence.
         """
         if self.sentence_tokenizer is None:
-            try:
-                self.sentence_tokenizer = load_data('tokenizers/punkt/{language}.pickle'.format(
-                    language=self.language.ENGLISH_NAME.lower()
-                ))
-            except LookupError:
-                # Fall back to English sentence splitting rules if a language is not supported
-                self.sentence_tokenizer = load_data('tokenizers/punkt/{language}.pickle'.format(
-                    language=languages.ENG.ENGLISH_NAME.lower()
-                ))
+            self.sentence_tokenizer = get_sentence_tokenizer(self.language)
 
         return self.sentence_tokenizer.tokenize(sentence)
 

--- a/chatterbot/tokenizers.py
+++ b/chatterbot/tokenizers.py
@@ -1,0 +1,62 @@
+from pickle import dump, load
+from nltk.tokenize.punkt import PunktSentenceTokenizer, PunktTrainer
+from nltk.tokenize import _treebank_word_tokenizer
+from chatterbot.corpus import load_corpus, list_corpus_files
+from chatterbot import languages
+
+
+def get_sentence_tokenizer(language):
+    """
+    Return the sentence tokenizer callable.
+    """
+
+    pickle_path = 'sentence_tokenizer.pickle'
+
+    try:
+        input_file = open(pickle_path, 'rb')
+        sentence_tokenizer = load(input_file)
+        input_file.close()
+    except FileNotFoundError:
+
+        data_file_paths = []
+
+        sentences = []
+
+        try:
+            # Get the paths to each file the bot will be trained with
+            corpus_files = list_corpus_files('chatterbot.corpus.{language}'.format(
+                language=language.ENGLISH_NAME.lower()
+            ))
+        except LookupError:
+            # Fall back to English sentence splitting rules if a language is not supported
+            corpus_files = list_corpus_files('chatterbot.corpus.{language}'.format(
+                language=languages.ENG.ENGLISH_NAME.lower()
+            ))
+
+        data_file_paths.extend(corpus_files)
+
+        for corpus, _categories, _file_path in load_corpus(*data_file_paths):
+            for conversation in corpus:
+                for text in conversation:
+                    sentences.append(text.upper())
+                    sentences.append(text.lower())
+
+        trainer = PunktTrainer()
+        trainer.INCLUDE_ALL_COLLOCS = True
+        trainer.train('\n'.join(sentences))
+
+        sentence_tokenizer = PunktSentenceTokenizer(trainer.get_params())
+
+        # Pickle the sentence tokenizer for future use
+        output_file = open(pickle_path, 'wb')
+        dump(sentence_tokenizer, output_file, -1)
+        output_file.close()
+
+    return sentence_tokenizer
+
+
+def get_word_tokenizer(language):
+    """
+    Return the word tokenizer callable.
+    """
+    return _treebank_word_tokenizer

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -45,9 +45,8 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
 
         self.assertIn('initialize_nltk_stopwords', functions)
         self.assertIn('initialize_nltk_wordnet', functions)
-        self.assertIn('initialize_nltk_punkt', functions)
         self.assertIn('initialize_nltk_averaged_perceptron_tagger', functions)
-        self.assertIsLength(functions, 4)
+        self.assertIsLength(functions, 3)
 
     def test_get_initialization_functions_synset_distance(self):
         """
@@ -60,9 +59,8 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
 
         self.assertIn('initialize_nltk_stopwords', functions)
         self.assertIn('initialize_nltk_wordnet', functions)
-        self.assertIn('initialize_nltk_punkt', functions)
         self.assertIn('initialize_nltk_averaged_perceptron_tagger', functions)
-        self.assertIsLength(functions, 4)
+        self.assertIsLength(functions, 3)
 
     def test_get_initialization_functions_sentiment_comparison(self):
         """
@@ -76,9 +74,8 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
         self.assertIn('initialize_nltk_stopwords', functions)
         self.assertIn('initialize_nltk_wordnet', functions)
         self.assertIn('initialize_nltk_vader_lexicon', functions)
-        self.assertIn('initialize_nltk_punkt', functions)
         self.assertIn('initialize_nltk_averaged_perceptron_tagger', functions)
-        self.assertIsLength(functions, 5)
+        self.assertIsLength(functions, 4)
 
     def test_get_initialization_functions_jaccard_similarity(self):
         """
@@ -92,8 +89,7 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
         self.assertIn('initialize_nltk_wordnet', functions)
         self.assertIn('initialize_nltk_stopwords', functions)
         self.assertIn('initialize_nltk_averaged_perceptron_tagger', functions)
-        self.assertIn('initialize_nltk_punkt', functions)
-        self.assertIsLength(functions, 4)
+        self.assertIsLength(functions, 3)
 
     def test_no_statements_known(self):
         """


### PR DESCRIPTION
This makes better use of the chatterbot-corpus module to train the `PunktSentenceTokenizer`.

In addition, this allows more languages to be supported for splitting sentences.