### PR TITLE
Add pytz to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dateutil>=2.7,<2.8
 pyyaml>=4.2b1,<4.3
 spacy>=2.0,<2.1
 sqlalchemy>=1.2,<1.3
+pytz


### PR DESCRIPTION
Fixes #1664. Not sure if `pytz` had to be pinned, if so don't hesitate to point at which version should be used. :+1: