### PR TITLE
Fix tests for getting language classes

### DIFF
--- a/chatterbot/languages.py
+++ b/chatterbot/languages.py
@@ -2408,3 +2408,10 @@ class ZZA:
     ISO_639_1 = ''
     ISO_639 = 'zza'
     ENGLISH_NAME = 'Zaza'
+
+
+def get_language_classes():
+    import sys
+    import inspect
+
+    return inspect.getmembers(sys.modules[__name__], inspect.isclass)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,4 +1,3 @@
-import sys
 import inspect
 from chatterbot import languages
 from unittest import TestCase
@@ -7,12 +6,13 @@ from unittest import TestCase
 class LanguageClassTests(TestCase):
 
     def test_classes_have_correct_attributes(self):
-        language_classes = inspect.getmembers(sys.modules[languages.__name__])
+        language_classes = languages.get_language_classes()
 
         for name, obj in language_classes:
-            if inspect.isclass(obj):
-                self.assertTrue(hasattr(obj, 'ISO_639'))
-                self.assertTrue(hasattr(obj, 'ENGLISH_NAME'))
-                self.assertEqual(name, obj.ISO_639.upper())
+            self.assertTrue(inspect.isclass(obj))
+            self.assertTrue(hasattr(obj, 'ISO_639'))
+            self.assertTrue(hasattr(obj, 'ISO_639_1'))
+            self.assertTrue(hasattr(obj, 'ENGLISH_NAME'))
+            self.assertEqual(name, obj.ISO_639.upper())
 
-        self.assertEqual(len(language_classes), 410)
+        self.assertEqual(len(language_classes), 402)


### PR DESCRIPTION
The incorrect number of classes was being returned.
This also adds a convenience function to return the classes.