### PR TITLE
Fix indentation in docs

### DIFF
--- a/docs/logic/create-a-logic-adapter.rst
+++ b/docs/logic/create-a-logic-adapter.rst
@@ -15,9 +15,8 @@ Example logic adapter
 
 
    class MyLogicAdapter(LogicAdapter):
-
-    def __init__(self, chatbot, **kwargs):
-        super().__init__(chatbot, **kwargs)
+       def __init__(self, chatbot, **kwargs):
+           super().__init__(chatbot, **kwargs)
 
        def can_process(self, statement):
            return True


### PR DESCRIPTION
I noticed the indentation in one of the examples was off creating some confusion for me at first.