### PR TITLE
Read version from config instead of using import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ venv
 
 examples/settings.py
 examples/ubuntu_dialogs*
-sentence_tokenizer.pickle
 .env
 .out
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.md
 include requirements.txt
+include setup.cfg
 
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/chatterbot/__init__.py
+++ b/chatterbot/__init__.py
@@ -3,10 +3,6 @@ ChatterBot is a machine learning, conversational dialog engine.
 """
 from .chatterbot import ChatBot
 
-__version__ = '1.0.5'
-__author__ = 'Gunther Cox'
-__email__ = 'gunthercx@gmail.com'
-__url__ = 'https://github.com/gunthercox/ChatterBot'
 
 __all__ = (
     'ChatBot',

--- a/chatterbot/__main__.py
+++ b/chatterbot/__main__.py
@@ -1,10 +1,18 @@
-import importlib
+import configparser
 import sys
+import os
 
 
 def get_chatterbot_version():
-    chatterbot = importlib.import_module('chatterbot')
-    return chatterbot.__version__
+    config = configparser.ConfigParser()
+
+    current_directory = os.path.dirname(os.path.abspath(__file__))
+    parent_directory = os.path.abspath(os.path.join(current_directory, os.pardir))
+    config_file_path = os.path.join(parent_directory, 'setup.cfg')
+
+    config.read(config_file_path)
+
+    return config['chatterbot']['version']
 
 
 if __name__ == '__main__':

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,18 +1,22 @@
-import sys
 import os
+import sys
+import configparser
 from datetime import datetime
 import sphinx_rtd_theme
 
 
-# Insert the project root dir as the first element in the PYTHONPATH.
-# This lets us ensure that the source package is imported, and that its version is used.
+config = configparser.ConfigParser()
+
 current_directory = os.path.dirname(os.path.abspath(__file__))
 parent_directory = os.path.abspath(os.path.join(current_directory, os.pardir))
+config_file_path = os.path.join(parent_directory, 'setup.cfg')
+
+config.read(config_file_path)
+
+# Insert the project root dir as the first element in the PYTHONPATH.
+# This lets us ensure that the source package is imported, and used to generate the documentation.
 sys.path.insert(0, parent_directory)
 
-import chatterbot # NOQA
-
-# -- General configuration ------------------------------------------------
 
 # Sphinx extension modules
 extensions = [
@@ -41,14 +45,17 @@ master_doc = 'index'
 
 # General information about the project
 project = 'ChatterBot'
-copyright = '{}, {}'.format(datetime.now().year, chatterbot.__author__)
-author = chatterbot.__author__
-
-# The short X.Y version
-version = chatterbot.__version__
+author = config['chatterbot']['author']
+copyright = '{}, {}'.format(
+    datetime.now().year,
+    author
+)
 
 # The full version, including alpha/beta/rc tags
-release = chatterbot.__version__
+release = config['chatterbot']['version']
+
+# The short X.Y version
+version = config['chatterbot']['version'].rsplit('.', 1)[0]
 
 language = 'en'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,9 @@ cover-min-percentage = 40
 ignore = H306
 max_line_length = 175
 exclude = .eggs, .git, .tox, build,
+
+[chatterbot]
+version = 1.0.5
+author = Gunther Cox
+email = gunthercx@gmail.com
+url = https://github.com/gunthercox/ChatterBot

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@
 """
 ChatterBot setup file.
 """
+import os
 import sys
 import platform
+import configparser
 from setuptools import setup
 
 
@@ -15,13 +17,17 @@ if sys.version_info[0] < 3:
         )
     )
 
-# Dynamically retrieve the version information from the chatterbot module
-CHATTERBOT = __import__('chatterbot')
-VERSION = CHATTERBOT.__version__
-AUTHOR = CHATTERBOT.__author__
-AUTHOR_EMAIL = CHATTERBOT.__email__
-URL = CHATTERBOT.__url__
-DESCRIPTION = CHATTERBOT.__doc__
+config = configparser.ConfigParser()
+
+current_directory = os.path.dirname(os.path.abspath(__file__))
+config_file_path = os.path.join(current_directory, 'setup.cfg')
+
+config.read(config_file_path)
+
+VERSION = config['chatterbot']['version']
+AUTHOR = config['chatterbot']['author']
+AUTHOR_EMAIL = config['chatterbot']['email']
+URL = config['chatterbot']['url']
 
 with open('README.md') as f:
     LONG_DESCRIPTION = f.read()
@@ -45,7 +51,7 @@ setup(
     project_urls={
         'Documentation': 'https://chatterbot.readthedocs.io',
     },
-    description=DESCRIPTION,
+    description='ChatterBot is a machine learning, conversational dialog engine.',
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
     author=AUTHOR,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from chatterbot import __version__
 from chatterbot import __main__ as main
 
 
@@ -10,4 +9,7 @@ class CommandLineInterfaceTests(TestCase):
 
     def test_get_chatterbot_version(self):
         version = main.get_chatterbot_version()
-        self.assertEqual(version, __version__)
+        version_parts = version.split('.')
+        self.assertEqual(len(version_parts), 3)
+        self.assertTrue(version_parts[0].isdigit())
+        self.assertTrue(version_parts[1].isdigit())


### PR DESCRIPTION
This is a workaround for import errors that occur when installing directly from GitHub via pip.

For example:

```
pip install git+git://github.com/gunthercox/chatterbot@master#egg=chatterbot
```