### PR TITLE
Remove pymongo from main dependency list

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 coveralls
 flake8
 nose
+pymongo>=3.3,<4.0
 twine
 twython
 sphinx>=1.8,<1.9

--- a/docs/storage/index.rst
+++ b/docs/storage/index.rst
@@ -41,6 +41,13 @@ SQL Storage Adapter
 MongoDB Storage Adapter
 =======================
 
+.. note::
+
+   Before you can use this storage adapter you will need to install
+   `pymongo`_. Consider adding ``pymongo`` to your project's
+   ``requirements.txt`` file so you can keep track of your dependencies
+   and their versions.
+
 .. autoclass:: chatterbot.storage.MongoDatabaseAdapter
    :members:
 
@@ -64,3 +71,4 @@ each of the databases that ChatterBot comes with support for.
 * MongoDB: No migrations are provided.
 
 .. _Alembic: https://alembic.sqlalchemy.org
+.. _pymongo: https://pypi.org/project/pymongo/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ git+git://github.com/gunthercox/chatterbot-corpus@master#egg=chatterbot_corpus
 mathparse>=0.1,<0.2
 nltk>=3.2,<4.0
 pint>=0.8.1
-pymongo>=3.3,<4.0
 python-dateutil>=2.7,<2.8
 pyyaml>=5.1,<5.2
 spacy>=2.1,<2.2


### PR DESCRIPTION
Pymongo isn't required unless the Mongo DB storage adapter is being used. By not installing pymongo automatically, the installation footprint of ChatterBot is decreased in size, which can be useful when installing on devices that have limited storage space.