### PR TITLE
Fix export_for_training to encode utf8

### DIFF
--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -70,7 +70,7 @@ class Trainer(object):
         """
         import json
         export = {'conversations': self._generate_export_data()}
-        with open(file_path, 'w+') as jsonfile:
+        with open(file_path, 'w+', encoding='utf8') as jsonfile:
             json.dump(export, jsonfile, ensure_ascii=False)
 
 


### PR DESCRIPTION
This makes possible utf8 chat bot's database to be exported.