### PR TITLE
Prevent generating duplicate export data

### DIFF
--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -58,8 +58,9 @@ class Trainer(object):
     def _generate_export_data(self):
         result = []
         for statement in self.chatbot.storage.filter():
-            if statement.in_response_to:
-                result.append([statement.in_response_to, statement.text])
+            conversation = [statement.in_response_to, statement.text]
+            if statement.in_response_to and conversation not in result:
+                result.append(conversation)
 
         return result
 

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -56,13 +56,12 @@ class Trainer(object):
             super().__init__(message or default)
 
     def _generate_export_data(self):
-        result = []
+        result = set()
         for statement in self.chatbot.storage.filter():
-            conversation = [statement.in_response_to, statement.text]
-            if statement.in_response_to and conversation not in result:
-                result.append(conversation)
+            if statement.in_response_to:
+                result.add((statement.in_response_to, statement.text))
 
-        return result
+        return list(map(list, result))
 
     def export_for_training(self, file_path='./export.json'):
         """


### PR DESCRIPTION
This pull request is related to this [issue](https://github.com/gunthercox/ChatterBot/issues/1733).

I thought it was meaningless to create duplicate data sets for learning data.

When this pull request is applied, the _generate_export_data function does not create duplicate data sets.
