### PR TITLE
make can_process function use __str__ of Statement class

### DIFF
--- a/chatterbot/logic/specific_response.py
+++ b/chatterbot/logic/specific_response.py
@@ -22,7 +22,7 @@ class SpecificResponseAdapter(LogicAdapter):
         self.response_statement = Statement(text=output_text)
 
     def can_process(self, statement):
-        if statement == self.input_text:
+        if statement.text == self.input_text:
             return True
 
         return False

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -170,7 +170,8 @@ class ChatterBotCorpusTrainer(Trainer):
 
                     statements_to_create.append(statement)
 
-            self.chatbot.storage.create_many(statements_to_create)
+            if statements_to_create:
+                self.chatbot.storage.create_many(statements_to_create)
 
 
 class UbuntuCorpusTrainer(Trainer):


### PR DESCRIPTION
This pull request is intended to solve [this issue](https://github.com/gunthercox/ChatterBot/issues/1677).

It appears that you are trying to compare the member variable `text` and `self.input_text` of statement.

However, this does not call the `__str__` function, it simply compares the id of two objects and will always return false.

Therefore, I call the `str` function to explicitly call the `__str__` function.

I tested this branch using this [test code](https://github.com/gunthercox/ChatterBot/blob/master/examples/specific_response_example.py).

Before, Chatterbot returns invaild answer.
![before](https://user-images.githubusercontent.com/48241766/58614077-5a49e700-82f2-11e9-9a16-db241fefbe10.png)
After revision, Chatterbot return vaild answer.
![after](https://user-images.githubusercontent.com/48241766/58614087-603fc800-82f2-11e9-902b-59732a7c1d62.png)

