### PR TITLE
Fixed issue that do not correctly recognize am and pm in re_time.

### DIFF
--- a/chatterbot/parsing.py
+++ b/chatterbot/parsing.py
@@ -28,7 +28,7 @@ re_duration = r'(before|after|earlier|later|ago|from\snow)'
 re_year = r'(19|20)\d{2}|^(19|20)\d{2}'
 re_timeframe = r'this|coming|next|following|previous|last|end\sof\sthe'
 re_ordinal = r'st|nd|rd|th|first|second|third|fourth|fourth|' + re_timeframe
-re_time = r'(?P<hour>\d{1,2})(\:(?P<minute>\d{1,2})(\sam|pm)?|\s?(?P<convention>am|pm))'
+re_time = r'(?P<hour>\d{1,2})(?=\s?(\:\d|(a|p)m))(\:(?P<minute>\d{1,2}))?(\s?(?P<convention>(am|pm)))?'
 re_separator = r'of|at|on'
 
 NUMBERS = {

--- a/chatterbot/parsing.py
+++ b/chatterbot/parsing.py
@@ -645,7 +645,7 @@ def date_from_adverb(base_date, name):
     # Reset date to start of the day
     adverb_date = datetime(base_date.year, base_date.month, base_date.day)
     if name == 'today' or name == 'tonite' or name == 'tonight':
-        return adverb_date.today()
+        return adverb_date.today().replace(hour=0, minute=0, second=0, microsecond=0)
     elif name == 'yesterday':
         return adverb_date - timedelta(days=1)
     elif name == 'tomorrow' or name == 'tom':


### PR DESCRIPTION
This Pull Request is to address this [issues](https://github.com/gunthercox/ChatterBot/issues/1347).


First, In this code
https://github.com/gunthercox/ChatterBot/blob/c429fa50c5edf9198030880b9d9151de73a6dced/chatterbot/parsing.py#L648
`today` return datetime instance include time, not only date.
So I solved this problem by setting the time element to zero.

Second, In this code
https://github.com/gunthercox/ChatterBot/blob/c429fa50c5edf9198030880b9d9151de73a6dced/chatterbot/parsing.py#L31
If the string is matched to `(\sam|pm)?`, am or pm is not assigned for the `convention` group.

So I solved this problem by modifying this regex.



And as a result, if you run this code,
```python
from chatterbot import parsing

print(parsing.datetime_parsing(u"Your dental appointment with Dr P. Delvour is scheduled today at 9:00pm."))
print(parsing.datetime_parsing(u"meeting today at 9pm."))
print(parsing.datetime_parsing(u"Your dental appointment with Dr P. Delvour is scheduled for October 29, 16:00. ABC Dentist, 555-555-555."))
print(parsing.datetime_parsing(u"Your dental appointment with Dr P. Delvour is scheduled for October 29, 4 pm. ABC Dentist, 555-555-555."))
print(parsing.datetime_parsing(u"Your dental appointment with Dr P. Delvour is scheduled for October 29, 4:00pm. ABC Dentist, 555-555-555."))
```
The right result comes out.
```
[('today at 9:00pm', datetime.datetime(2019, 6, 2, 21, 0), (56, 71))]
[('today at 9pm', datetime.datetime(2019, 6, 2, 21, 0), (8, 20))]
[('October 29, 16:00', datetime.datetime(2019, 10, 29, 16, 0), (60, 77))]
[('October 29, 4 pm', datetime.datetime(2019, 10, 29, 16, 0), (60, 76))]
[('October 29, 4:00pm', datetime.datetime(2019, 10, 29, 16, 0), (60, 78))]
```

