### PR TITLE
Possible fix for "SystemCheckError: System check identified some issues" while using django 2.2.2

### DIFF
--- a/examples/django_app/example_app/settings.py
+++ b/examples/django_app/example_app/settings.py
@@ -47,6 +47,12 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
 )
 
+SILENCED_SYSTEM_CHECKS = [
+    'admin.E408',
+    'admin.E409',
+    'admin.E410'
+]
+
 ROOT_URLCONF = 'example_app.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
Errors produced when executing `python manage.py migrate django_chatterbot`:

```
[nltk_data] Downloading package averaged_perceptron_tagger to
[nltk_data]     /home/apoorv/nltk_data...
[nltk_data]   Package averaged_perceptron_tagger is already up-to-
[nltk_data]       date!
[nltk_data] Downloading package stopwords to /home/apoorv/nltk_data...
[nltk_data]   Package stopwords is already up-to-date!
SystemCheckError: System check identified some issues:

ERRORS:
?: (admin.E408) 'django.contrib.auth.middleware.AuthenticationMiddleware' must be in MIDDLEWARE in order to use the admin application.
?: (admin.E409) 'django.contrib.messages.middleware.MessageMiddleware' must be in MIDDLEWARE in order to use the admin application.
?: (admin.E410) 'django.contrib.sessions.middleware.SessionMiddleware' must be in MIDDLEWARE in order to use the admin application.
```

The [check](https://code.djangoproject.com/changeset/371ece2f0682e51f2f796854d3e091827a7cea63/) is possibly new in Django 2.2. It might be possible to modify it so that it detects `AuthenticationMiddleware`, `MessageMiddleware` and `SessionMiddleware` subclasses. One approach would be to simply add that error to SILENCED_SYSTEM_CHECKS in settings.py.