### PR TITLE
Django FIX for no such table found

### DIFF
--- a/chatterbot/ext/django_chatterbot/models.py
+++ b/chatterbot/ext/django_chatterbot/models.py
@@ -6,11 +6,13 @@ class Statement(AbstractBaseStatement):
     A statement represents a single spoken entity, sentence or
     phrase that someone can say.
     """
-    pass
+    class Meta:
+        db_table = 'statement'
 
 
 class Tag(AbstractBaseTag):
     """
     A label that categorizes a statement.
     """
-    pass
+    class Meta:
+        db_table = 'tag' 


### PR DESCRIPTION
[FIXED] django.db.utils.OperationalError: no such table: django_chatterbot_statement
[FIXED] django.db.utils.OperationalError: no such table: django_chatterbot_tag