### PR TITLE
Patch ModuleNotFoundError (No module named 'chatterbot_corpus')

### DIFF
--- a/chatterbot/corpus.py
+++ b/chatterbot/corpus.py
@@ -2,7 +2,10 @@ import os
 import io
 import glob
 import yaml
-from chatterbot_corpus.corpus import DATA_DIRECTORY
+try:
+    from chatterbot_corpus.corpus import DATA_DIRECTORY
+except (ImportError, ModuleNotFoundError):
+    DATA_DIRECTORY = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
 
 CORPUS_EXTENSION = 'yml'


### PR DESCRIPTION
While this can be patched by installing chatterbot_corpus I feel we should just define the variable here, and prevent people in the future from opening issues regarding the same.

Issues this patches: #1894 , #1852, #1757, #1727, #1689,  #1708, #833

Also chatterbot_corpus is not installed by pip, for some reason