### PR TITLE
Don't install several dependencies by default

### DIFF
--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -2,6 +2,7 @@
 This module contains various text-comparison algorithms
 designed to compare one statement to another.
 """
+from chatterbot.exceptions import OptionalDependencyImportError
 from difflib import SequenceMatcher
 
 
@@ -63,7 +64,15 @@ class SpacySimilarity(Comparator):
 
     def __init__(self, language):
         super().__init__(language)
-        import spacy
+        try:
+            import spacy
+        except ImportError:
+            message = (
+                'Unable to import "spacy".\n'
+                'Please install "spacy" before using the SpacySimilarity comparator:\n'
+                'pip3 install "spacy>=2.1,<2.2"'
+            )
+            raise OptionalDependencyImportError(message)
 
         self.nlp = spacy.load(self.language.ISO_639_1)
 
@@ -108,7 +117,15 @@ class JaccardSimilarity(Comparator):
 
     def __init__(self, language):
         super().__init__(language)
-        import spacy
+        try:
+            import spacy
+        except ImportError:
+            message = (
+                'Unable to import "spacy".\n'
+                'Please install "spacy" before using the JaccardSimilarity comparator:\n'
+                'pip3 install "spacy>=2.1,<2.2"'
+            )
+            raise OptionalDependencyImportError(message)
 
         self.nlp = spacy.load(self.language.ISO_639_1)
 

--- a/chatterbot/corpus.py
+++ b/chatterbot/corpus.py
@@ -1,11 +1,18 @@
 import os
 import io
 import glob
-import yaml
+from pathlib import Path
+from chatterbot.exceptions import OptionalDependencyImportError
+
 try:
     from chatterbot_corpus.corpus import DATA_DIRECTORY
 except (ImportError, ModuleNotFoundError):
-    DATA_DIRECTORY = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+    # Default to the home directory of the current user
+    DATA_DIRECTORY = os.path.join(
+        Path.home(),
+        'chatterbot_corpus',
+        'data'
+    )
 
 
 CORPUS_EXTENSION = 'yml'
@@ -38,6 +45,16 @@ def read_corpus(file_name):
     """
     Read and return the data from a corpus json file.
     """
+    try:
+        import yaml
+    except ImportError:
+        message = (
+            'Unable to import "yaml".\n'
+            'Please install "pyyaml" to enable chatterbot corpus functionality:\n'
+            'pip3 install pyyaml'
+        )
+        raise OptionalDependencyImportError(message)
+
     with io.open(file_name, encoding='utf-8') as data_file:
         return yaml.safe_load(data_file)
 

--- a/chatterbot/exceptions.py
+++ b/chatterbot/exceptions.py
@@ -1,0 +1,5 @@
+class OptionalDependencyImportError(ImportError):
+    """
+    An exception raised when a feature requires an optional dependency to be installed.
+    """
+    pass

--- a/chatterbot/logic/time_adapter.py
+++ b/chatterbot/logic/time_adapter.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from chatterbot.logic import LogicAdapter
 from chatterbot.conversation import Statement
+from chatterbot.exceptions import OptionalDependencyImportError
 
 
 class TimeLogicAdapter(LogicAdapter):
@@ -18,7 +19,15 @@ class TimeLogicAdapter(LogicAdapter):
 
     def __init__(self, chatbot, **kwargs):
         super().__init__(chatbot, **kwargs)
-        from nltk import NaiveBayesClassifier
+        try:
+            from nltk import NaiveBayesClassifier
+        except ImportError:
+            message = (
+                'Unable to import "nltk".\n'
+                'Please install "nltk" before using the TimeLogicAdapter:\n'
+                'pip3 install nltk'
+            )
+            raise OptionalDependencyImportError(message)
 
         self.positive = kwargs.get('positive', [
             'what time is it',

--- a/chatterbot/logic/unit_conversion.py
+++ b/chatterbot/logic/unit_conversion.py
@@ -1,5 +1,6 @@
 from chatterbot.logic import LogicAdapter
 from chatterbot.conversation import Statement
+from chatterbot.exceptions import OptionalDependencyImportError
 from chatterbot import languages
 from chatterbot import parsing
 from mathparse import mathparse
@@ -22,7 +23,15 @@ class UnitConversion(LogicAdapter):
 
     def __init__(self, chatbot, **kwargs):
         super().__init__(chatbot, **kwargs)
-        from pint import UnitRegistry
+        try:
+            from pint import UnitRegistry
+        except ImportError:
+            message = (
+                'Unable to import "pint".\n'
+                'Please install "pint" before using the UnitConversion logic adapter:\n'
+                'pip3 install pint'
+            )
+            raise OptionalDependencyImportError(message)
 
         self.language = kwargs.get('language', languages.ENG)
         self.cache = {}
@@ -82,7 +91,7 @@ class UnitConversion(LogicAdapter):
 
     def get_valid_units(self, from_unit, target_unit):
         """
-        Returns the firt match `pint.unit.Unit` object for from_unit and
+        Returns the first match `pint.unit.Unit` object for from_unit and
         target_unit strings from a possible variation of metric unit names
         supported by pint library.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,15 @@
 coveralls
 flake8
+nltk>=3.2,<4.0
 nose
+pint>=0.8.1
 pymongo>=3.3,<4.0
 twine
 twython
+spacy>=2.1,<2.2
 sphinx>=3.0,<3.1
 sphinx_rtd_theme
+pyyaml>=5.3,<5.4
+git+git://github.com/gunthercox/chatterbot-corpus@master#egg=chatterbot_corpus
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz#egg=en_core_web_sm
 https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.1.0/de_core_news_sm-2.1.0.tar.gz#egg=de_core_news_sm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
-git+git://github.com/gunthercox/chatterbot-corpus@master#egg=chatterbot_corpus
 mathparse>=0.1,<0.2
-nltk>=3.2,<4.0
-pint>=0.8.1
 python-dateutil>=2.8,<2.9
-pyyaml>=5.3,<5.4
-spacy>=2.1,<2.2
 sqlalchemy>=1.3,<1.4
 pytz


### PR DESCRIPTION
Right now the issue tracker is prolific with tickets that have titles similar to "Help, I had an error while installing ChatterBot". The intention of this pull request is to make changes that eliminate a number of dependencies that could be considered optional from the primary installation process. Although I think `spacy` and `chatterbot_corpus` are the primary culprits; `spacy` requiring build dependencies to compile, and `chatterbot_coupus` currently installing via a GitHub url... I think the the idea of having dependencies required in order to enable features might be an advantage in general to reduce the footprint and efficiency of the overall ChatterBot installation.