### PR TITLE
Fixed issue for tags

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -200,7 +200,8 @@ class ChatBot(object):
             text=result.text,
             in_response_to=input_statement.text,
             conversation=input_statement.conversation,
-            persona='bot:' + self.name
+            persona='bot:' + self.name,
+            tags=result.tags
         )
 
         response.confidence = result.confidence


### PR DESCRIPTION
get_response() / generate_response/( did not read trained category (e. g. from corpus)

Solution: in generate_response() the variable respone is created for return-ing.
I added 'tags=result.tags'

Aim: Now the regular get_response() and generate_response deliver the tag from thee training data (id est what has been learned)
In case of using persist_values_to_response, this chatterbot (at least veriosn >=1.0.8) copies the tags from statement given.

Behaviour: generate_response() will deliver the tags of the response phrase.
           get_response() will delive the tags of the response unless persist_value_to_response is used.

IMHO ChatterBott wasn't working correctly without this fix. Unless using persist_value_to_response tags was always an empty list [].