### PR TITLE
Relax Python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     dependency_links=DEPENDENCIES,
-    python_requires='>=3.4, <=3.8',
+    python_requires='>=3.4, <3.9',
     license='BSD',
     zip_safe=True,
     platforms=['any'],


### PR DESCRIPTION
Fixes installation when Python version has a patch release:

```
ERROR: Package 'ChatterBot' requires a different Python: 3.8.3 not in '>=3.4, <=3.8'
```