### PR TITLE
Added a Greek Preprocessor

### DIFF
--- a/chatterbot/preprocessors_greek.py
+++ b/chatterbot/preprocessors_greek.py
@@ -1,0 +1,18 @@
+"""
+Statement pre-processors for Greek language.
+"""
+def fix_final_sigma(statement):
+    '''
+    If there is a word that ends with "σ" it replaces it with "ς".
+    '''
+    
+    data = statement.text.split()
+    text = ""
+    
+    for word in data:
+        if word[-1]=="σ":
+            word = word[:-1] + "ς" 
+        text = text + word + " "
+    statement.text = text
+    
+    return statement


### PR DESCRIPTION
Added a preprocessor for Greek language in the file preprocessors_greek.py. This preprocessor can be used for fixing final sigma in statements. In Greek the words that end with sigma should use final sigma "ς" instead of the normal sigma "σ". It is very useful in Greek language because it is very common to type words that end with normal sigma in chats.