### PR TITLE
Include imports in view code for django example

### DIFF
--- a/docs/django/views.rst
+++ b/docs/django/views.rst
@@ -18,7 +18,6 @@ The endpoint expects a JSON request in the following format:
 
 .. literalinclude:: ../../examples/django_app/example_app/views.py
    :language: python
-   :pyobject: ChatterBotApiView
 
 
 .. note::


### PR DESCRIPTION
As I followed along with the tutorial, when I got to view code for the django example, I thought it would be helpful to include the imports required to follow along. This allows the user to copy and paste the example in full and continue building their app, rather than having to track down imports required to make the example work. Great project!