### PR TITLE
Django 3

### DIFF
--- a/examples/django_app/example_app/settings.py
+++ b/examples/django_app/example_app/settings.py
@@ -13,7 +13,7 @@ SECRET_KEY = 'fsch+6!=q+@ol&%0x!nwdl@48^ixbd4clx5f1i!5n^66y+pmn*'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['localhost','127.0.0.1']
 
 
 # Application definition

--- a/examples/django_app/example_app/templates/app.html
+++ b/examples/django_app/example_app/templates/app.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!doctype html>
 <html>
   <head>

--- a/examples/django_app/example_app/templates/nav.html
+++ b/examples/django_app/example_app/templates/nav.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <nav class="navbar navbar-dark bg-inverse navbar-full">
 

--- a/examples/django_app/example_app/urls.py
+++ b/examples/django_app/example_app/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import path
 from django.contrib import admin
 from example_app.views import ChatterBotAppView, ChatterBotApiView
 
 
 urlpatterns = [
-    url(r'^$', ChatterBotAppView.as_view(), name='main'),
-    url(r'^admin/', admin.site.urls, name='admin'),
-    url(r'^api/chatterbot/', ChatterBotApiView.as_view(), name='chatterbot'),
+    path('', ChatterBotAppView.as_view(), name='main'),
+    path('admin/', admin.site.urls),
+    path('api/chatterbot/', ChatterBotApiView.as_view(), name='chatterbot'),
 ]

--- a/examples/django_app/example_app/urls.py
+++ b/examples/django_app/example_app/urls.py
@@ -5,6 +5,6 @@ from example_app.views import ChatterBotAppView, ChatterBotApiView
 
 urlpatterns = [
     path('', ChatterBotAppView.as_view(), name='main'),
-    path('admin/', admin.site.urls),
+    path('admin/', admin.site.urls, name='admin'),
     path('api/chatterbot/', ChatterBotApiView.as_view(), name='chatterbot'),
 ]


### PR DESCRIPTION
The example Django app needed a few updates to be compatible with Django 3. Specifically: {% load staticfiles %} was deprecated in Django 2.1, and removed in Django 3.0.