### PR TITLE
Add QuestionAnswerTrainer

### DIFF
--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -117,6 +117,59 @@ class ListTrainer(Trainer):
         self.chatbot.storage.create_many(statements_to_create)
 
 
+class QuestionAnswerTrainer(Trainer):
+    """
+    Allows a chat bot to be trained using a list of strings
+    where the list represents questions and answers.
+    """
+
+    def train(self, qa_list):
+        """
+        Train the chat bot based on the provided list of Questions and 
+        Answers. The question should come before the answer
+        """
+
+        statements_to_create = []
+
+
+        i = 1 # Skip question and start with answer
+        while i < len(qa_list):
+
+            if self.show_training_progress:
+                utils.print_progress_bar(
+                    'Q/A Trainer',
+                    i + 1, len(qa_list)
+                )
+
+            question_search_text = self.chatbot.storage.tagger.get_text_index_string(qa_list[i-1])
+
+            question = self.get_preprocessed_statement(
+                    Statement(
+                        text=qa_list[i-1],
+                        search_text=question_search_text,
+                        in_response_to=None,
+                        search_in_response_to=None,
+                        conversation='training'
+                    )
+                )
+
+            answer_search_text = self.chatbot.storage.tagger.get_text_index_string(qa_list[i])
+
+            answer = self.get_preprocessed_statement(
+                Statement(
+                    text=qa_list[i],
+                    search_text=None,
+                    in_response_to=question.text,
+                    search_in_response_to=question_search_text,
+                    conversation='training'
+                )
+            )
+
+            statements_to_create.append(answer)
+            i += 2
+
+        self.chatbot.storage.create_many(statements_to_create)
+
 class ChatterBotCorpusTrainer(Trainer):
     """
     Allows the chat bot to be trained using data from the


### PR DESCRIPTION
There is a desire to have a basic question and answer trainer, so that the flow an ongoing conversation does not "ruin" the training set by linking an answer to the following question in a list of question and answers. 

**Unwanted:**
Q: What is your favorite color?
A: Blue
Q: What is your favorite number?
A: 13
Using the ListTrainer would associate "Blue" with "What is your favorite number?"

This QuestionAnswerTrainer solves that problem by only creating Statements that associate the question with the answer, and then moves to the next question in the list to begin new Statement creation.

Fixes #1898