### PR TITLE
Python_requires 3.8 syntax 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     dependency_links=DEPENDENCIES,
-    python_requires='>=3.4, <=3.8',
+    python_requires='>=3.4, <=3.8.*',
     license='BSD',
     zip_safe=True,
     platforms=['any'],

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     dependency_links=DEPENDENCIES,
-    python_requires='>=3.4, <=3.8.*',
+    python_requires='>=3.4, <3.9',
     license='BSD',
     zip_safe=True,
     platforms=['any'],


### PR DESCRIPTION
`<=3.8` explicitly only allows 3.8.0, and disallows 3.8.1 and above.

This fixes it by swapping it with `<3.9`