### PR TITLE
Repair python version error for python versions >3.8 <3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     dependency_links=DEPENDENCIES,
-    python_requires='>=3.4, <=3.8',
+    python_requires='>=3.4, <3.9',
     license='BSD',
     zip_safe=True,
     platforms=['any'],


### PR DESCRIPTION
Chatterbot refuses to install via pip3 on python 3.8.10 for me due to 3.8.10 > 3.8 .  Changing to <3.9 fixes this for me.