### PR TITLE
Fixed errors related with spacy models not found

### DIFF
--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -74,7 +74,10 @@ class SpacySimilarity(Comparator):
             )
             raise OptionalDependencyImportError(message)
 
-        self.nlp = spacy.load(self.language.ISO_639_1)
+        if 'SPACY_MODEL' in self.language:
+            self.nlp = spacy.load(self.language.SPACY_MODEL)
+        else:
+            self.nlp = spacy.load(self.language.ISO_639_1.lower())
 
     def compare(self, statement_a, statement_b):
         """
@@ -127,7 +130,10 @@ class JaccardSimilarity(Comparator):
             )
             raise OptionalDependencyImportError(message)
 
-        self.nlp = spacy.load(self.language.ISO_639_1)
+        if 'SPACY_MODEL' in self.language:
+            self.nlp = spacy.load(self.language.SPACY_MODEL)
+        else:
+            self.nlp = spacy.load(self.language.ISO_639_1.lower())
 
     def compare(self, statement_a, statement_b):
         """

--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -74,7 +74,7 @@ class SpacySimilarity(Comparator):
             )
             raise OptionalDependencyImportError(message)
 
-        if 'SPACY_MODEL' in self.language:
+        if hasattr(language, 'SPACY_MODEL'):
             self.nlp = spacy.load(self.language.SPACY_MODEL)
         else:
             self.nlp = spacy.load(self.language.ISO_639_1.lower())
@@ -130,7 +130,7 @@ class JaccardSimilarity(Comparator):
             )
             raise OptionalDependencyImportError(message)
 
-        if 'SPACY_MODEL' in self.language:
+        if hasattr(language, 'SPACY_MODEL'):
             self.nlp = spacy.load(self.language.SPACY_MODEL)
         else:
             self.nlp = spacy.load(self.language.ISO_639_1.lower())

--- a/chatterbot/languages.py
+++ b/chatterbot/languages.py
@@ -1,6 +1,3 @@
-from chatterbot.comparisons import SpacySimilarity
-
-
 class AAR:
     ISO_639_1 = ''
     ISO_639 = 'aar'

--- a/chatterbot/languages.py
+++ b/chatterbot/languages.py
@@ -1,3 +1,6 @@
+from chatterbot.comparisons import SpacySimilarity
+
+
 class AAR:
     ISO_639_1 = ''
     ISO_639 = 'aar'
@@ -20,6 +23,7 @@ class ACH:
     ISO_639_1 = ''
     ISO_639 = 'ach'
     ENGLISH_NAME = 'Acoli'
+    SPACY_MODEL = ''
 
 
 class ADA:
@@ -38,6 +42,7 @@ class AFH:
     ISO_639_1 = ''
     ISO_639 = 'afh'
     ENGLISH_NAME = 'Afrihili'
+    SPACY_MODEL = ''
 
 
 class AFR:
@@ -326,6 +331,7 @@ class CAT:
     ISO_639_1 = ''
     ISO_639 = 'cat'
     ENGLISH_NAME = 'Catalan'
+    SPACY_MODEL = 'ca_core_news_sm'
 
 
 class CEB:
@@ -362,6 +368,7 @@ class CHI:
     ISO_639_1 = 'zh'
     ISO_639 = 'chi'
     ENGLISH_NAME = 'Chinese'
+    SPACY_MODEL = 'zh_core_web_sm'
 
 
 class CHK:
@@ -494,6 +501,7 @@ class DAN:
     ISO_639_1 = ''
     ISO_639 = 'dan'
     ENGLISH_NAME = 'Danish'
+    SPACY_MODEL = 'da_core_news_sm'
 
 
 class DAR:
@@ -548,6 +556,7 @@ class DUT:
     ISO_639_1 = 'nl'
     ISO_639 = 'dut'
     ENGLISH_NAME = 'Dutch'
+    SPACY_MODEL = 'nl_core_news_sm'
 
 
 class DYU:
@@ -584,6 +593,7 @@ class ENG:
     ISO_639_1 = 'en'
     ISO_639 = 'eng'
     ENGLISH_NAME = 'English'
+    SPACY_MODEL = 'en_core_web_sm'
 
 
 class EPO:
@@ -656,6 +666,7 @@ class FRE:
     ISO_639_1 = ''
     ISO_639 = 'fre'
     ENGLISH_NAME = 'French'
+    SPACY_MODEL = 'fr_core_news_sm'
 
 
 class FRR:
@@ -716,6 +727,7 @@ class GER:
     ISO_639_1 = 'de'
     ISO_639 = 'ger'
     ENGLISH_NAME = 'German'
+    SPACY_MODEL = 'de_core_news_sm'
 
 
 class GEZ:
@@ -782,6 +794,7 @@ class GRE:
     ISO_639_1 = 'el'
     ISO_639 = 'gre'
     ENGLISH_NAME = 'Greek'
+    SPACY_MODEL = 'el_core_news_sm'
 
 
 class GRN:
@@ -974,6 +987,7 @@ class ITA:
     ISO_639_1 = ''
     ISO_639 = 'ita'
     ENGLISH_NAME = 'Italian'
+    SPACY_MODEL = 'it_core_news_sm'
 
 
 class JAV:
@@ -992,6 +1006,7 @@ class JPN:
     ISO_639_1 = 'ja'
     ISO_639 = 'jpn'
     ENGLISH_NAME = 'Japanese'
+    SPACY_MODEL = 'ja_core_news_sm'
 
 
 class JPR:
@@ -1250,6 +1265,7 @@ class LIT:
     ISO_639_1 = ''
     ISO_639 = 'lit'
     ENGLISH_NAME = 'Lithuanian'
+    SPACY_MODEL = 'lt_core_news_sm'
 
 
 class LOL:
@@ -1316,6 +1332,7 @@ class MAC:
     ISO_639_1 = ''
     ISO_639 = 'mac'
     ENGLISH_NAME = 'Macedonian'
+    SPACY_MODEL = 'mk_core_news_sm'
 
 
 class MAD:
@@ -1544,6 +1561,7 @@ class NNO:
     ISO_639_1 = ''
     ISO_639 = 'nno'
     ENGLISH_NAME = 'NorwegianNynorsk'
+    SPACY_MODEL = 'nb_core_news_sm'
 
 
 class NOB:
@@ -1694,6 +1712,7 @@ class POL:
     ISO_639_1 = ''
     ISO_639 = 'pol'
     ENGLISH_NAME = 'Polish'
+    SPACY_MODEL = 'pl_core_news_sm'
 
 
 class PON:
@@ -1706,6 +1725,7 @@ class POR:
     ISO_639_1 = 'pt'
     ISO_639 = 'por'
     ENGLISH_NAME = 'Portuguese'
+    SPACY_MODEL = 'pt_core_news_sm'
 
 
 class PUS:
@@ -1754,6 +1774,7 @@ class RUM:
     ISO_639_1 = ''
     ISO_639 = 'rum'
     ENGLISH_NAME = 'Romanian'
+    SPACY_MODEL = 'ro_core_news_sm'
 
 
 class RUN:
@@ -1772,6 +1793,7 @@ class RUS:
     ISO_639_1 = 'ru'
     ISO_639 = 'rus'
     ENGLISH_NAME = 'Russian'
+    SPACY_MODEL = 'ru_core_news_sm'
 
 
 class SAD:
@@ -1940,6 +1962,7 @@ class SPA:
     ISO_639_1 = 'es'
     ISO_639 = 'spa'
     ENGLISH_NAME = 'Spanish'
+    SPACY_MODEL = 'es_core_news_sm'
 
 
 class SRD:

--- a/chatterbot/tagging.py
+++ b/chatterbot/tagging.py
@@ -23,7 +23,10 @@ class PosLemmaTagger(object):
 
         self.punctuation_table = str.maketrans(dict.fromkeys(string.punctuation))
 
-        self.nlp = spacy.load(self.language.ISO_639_1.lower())
+        if 'SPACY_MODEL' in self.language:
+            self.nlp = spacy.load(self.language.SPACY_MODEL)
+        else:
+            self.nlp = spacy.load(self.language.ISO_639_1.lower())
 
     def get_text_index_string(self, text):
         """

--- a/chatterbot/tagging.py
+++ b/chatterbot/tagging.py
@@ -23,7 +23,7 @@ class PosLemmaTagger(object):
 
         self.punctuation_table = str.maketrans(dict.fromkeys(string.punctuation))
 
-        if 'SPACY_MODEL' in self.language:
+        if hasattr(language, 'SPACY_MODEL'):
             self.nlp = spacy.load(self.language.SPACY_MODEL)
         else:
             self.nlp = spacy.load(self.language.ISO_639_1.lower())


### PR DESCRIPTION
For the most common issues related with the error "osError: [E050] Can't find model 'en'" I created this pull request which has an updated version on the languages module with a new field called `SPACY_MODEL` which contains the new Spacy model names and will be used for both `tagging` and `comparisons` modules instead of the `ISO_639_1` field only if available.

*Important notes regarding this pull request:*
  - SPACY_MODEL field of language module only contains the small variant of the related language not the large and more accurate one, which is smaller, faster and less precise.
  - Only supported languages (those which already have models for them in the official Spacy page) have the SPACY_MODEL field, not supported ones will have no such field