### PR TITLE
updating class ENG ISO_639_1 for spacy dependency

### DIFF
--- a/chatterbot/languages.py
+++ b/chatterbot/languages.py
@@ -581,7 +581,7 @@ class ELX:
 
 
 class ENG:
-    ISO_639_1 = 'en'
+    ISO_639_1 = 'en_core_web_sm'
     ISO_639 = 'eng'
     ENGLISH_NAME = 'English'
 


### PR DESCRIPTION
SpaCY deprecated the shortcut 'en', updated the shortcut in the languages.py file to limit change to only the problem language. 

Built and ran both unit and integration tests with passing results. Manually tested by following tutorial and was able to successfully build a ChatBot using default constructor, providing the name "Norman"