### PR TITLE
fix bug in tagging.py with spacy en model

### DIFF
--- a/chatterbot/tagging.py
+++ b/chatterbot/tagging.py
@@ -23,7 +23,10 @@ class PosLemmaTagger(object):
 
         self.punctuation_table = str.maketrans(dict.fromkeys(string.punctuation))
 
-        self.nlp = spacy.load(self.language.ISO_639_1.lower())
+        if self.language.ISO_639_1.lower() == 'en':
+            self.nlp = spacy.load('en_core_web_sm')
+        else:
+            self.nlp = spacy.load(self.language.ISO_639_1.lower())
 
     def get_text_index_string(self, text):
         """


### PR DESCRIPTION
This PR fixes a bug in the `chatterbot/tagging.py` file

# Implementation
* A description of the bug and solution can be found in this stack overflow [thread](https://stackoverflow.com/questions/66087475/chatterbot-error-oserror-e941-cant-find-model-en)
  * Basically one of the lines in tagging.py is updated to cater for when chatterbot tries to load a model titled `en`. It ensures that the correct naming of the English model is used, i.e. `en_core_web_sm` 