### PR TITLE
Fix error in return variable documentation

### DIFF
--- a/docs/logic/create-a-logic-adapter.rst
+++ b/docs/logic/create-a-logic-adapter.rst
@@ -116,8 +116,9 @@ For this example we will use a fictitious API endpoint that returns the current 
        temperature = data.get('temperature', 'unavailable')
 
        response_statement = Statement(text='The current temperature is {}'.format(temperature))
+       response_statement.confidence = confidence
 
-       return confidence, response_statement
+       return response_statement
 
 Providing extra arguments
 =========================


### PR DESCRIPTION
If `.process()` in your custom Logic Adapter returns a tuple with `(confidence, return_statement)`, like currently described in the docs, then running the bot gives an error:

```
AttributeError: 'tuple' object has no attribute 'text' chatterbot
```

This was addressed also in https://github.com/gunthercox/ChatterBot/issues/1208 and it's probably worth to update the docs to reflect that `.confidence` is an attribute on a `Statement()`.