### PR TITLE
Use bulk processing from spacy pipeline

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -108,7 +108,8 @@ class ChatBot(object):
         # Make sure the input statement has its search text saved
 
         if not input_statement.search_text:
-            input_statement.search_text = self.storage.tagger.get_text_index_string(input_statement.text)
+            _search_text = self.storage.tagger.get_text_index_string(input_statement.text)
+            input_statement.search_text = _search_text
 
         if not input_statement.search_in_response_to and input_statement.in_response_to:
             input_statement.search_in_response_to = self.storage.tagger.get_text_index_string(input_statement.in_response_to)

--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -8,6 +8,9 @@ from difflib import SequenceMatcher
 
 
 class Comparator:
+    """
+    Base class establishing the interface that all comparators should implement.
+    """
 
     def __init__(self, language):
 
@@ -17,6 +20,12 @@ class Comparator:
         return self.compare(statement_a, statement_b)
 
     def compare(self, statement_a, statement_b):
+        """
+        Implemented in subclasses: compare statement_a to statement_b.
+
+        :return: The percent of similarity between the statements based on the implemented algorithm.
+        :rtype: float
+        """
         return 0
 
 
@@ -100,7 +109,8 @@ class SpacySimilarity(Comparator):
                 f'Spacy model is not available for language {self.language}'
             ) from e
 
-        self.nlp = spacy.load(model)
+        # Disable the Named Entity Recognition (NER) component because it is not necessary
+        self.nlp = spacy.load(model, exclude=['ner'])
 
     def compare(self, statement_a, statement_b):
         """
@@ -160,7 +170,8 @@ class JaccardSimilarity(Comparator):
                 f'Spacy model is not available for language {self.language}'
             ) from e
 
-        self.nlp = spacy.load(model)
+        # Disable the Named Entity Recognition (NER) component because it is not necessary
+        self.nlp = spacy.load(model, exclude=['ner'])
 
     def compare(self, statement_a, statement_b):
         """

--- a/chatterbot/components.py
+++ b/chatterbot/components.py
@@ -1,0 +1,52 @@
+"""
+Custom components for Spacy processing pipelines.
+https://spacy.io/usage/processing-pipelines#custom-components
+"""
+import string
+from spacy.language import Language
+from spacy.tokens import Doc
+
+
+punctuation_table = str.maketrans(dict.fromkeys(string.punctuation))
+
+
+@Language.component('chatterbot_bigram_indexer')
+def chatterbot_bigram_indexer(document):
+    """
+    Generate the text string for a bigram-based search index.
+    """
+
+    if not Doc.has_extension('bigram_index'):
+        Doc.set_extension('bigram_index', default='')
+
+    tokens = [
+        token for token in document if not (token.is_punct or token.is_stop)
+    ]
+
+    # Fall back to including stop words if needed
+    if not tokens or len(tokens) == 1:
+        tokens = [
+            token for token in document if not (token.is_punct)
+        ]
+
+    bigram_pairs = [
+        f"{tokens[i - 1].pos_}:{tokens[i].lemma_.lower()}"
+        for i in range(1, len(tokens))
+    ]
+
+    if not bigram_pairs:
+
+        text_without_punctuation = document.text.translate(
+            punctuation_table
+        )
+        if len(text_without_punctuation) >= 1:
+            text = text_without_punctuation.lower()
+        else:
+            text = document.text.lower()
+
+        bigram_pairs = [text]
+
+    # Assign a custom attribute at the Doc level
+    document._.bigram_index = ' '.join(bigram_pairs)
+
+    return document

--- a/chatterbot/components.py
+++ b/chatterbot/components.py
@@ -16,8 +16,8 @@ def chatterbot_bigram_indexer(document):
     Generate the text string for a bigram-based search index.
     """
 
-    if not Doc.has_extension('bigram_index'):
-        Doc.set_extension('bigram_index', default='')
+    if not Doc.has_extension('search_index'):
+        Doc.set_extension('search_index', default='')
 
     tokens = [
         token for token in document if not (token.is_punct or token.is_stop)
@@ -47,6 +47,21 @@ def chatterbot_bigram_indexer(document):
         bigram_pairs = [text]
 
     # Assign a custom attribute at the Doc level
-    document._.bigram_index = ' '.join(bigram_pairs)
+    document._.search_index = ' '.join(bigram_pairs)
+
+    return document
+
+
+@Language.component('chatterbot_lowercase_indexer')
+def chatterbot_lowercase_indexer(document):
+    """
+    Generate the a lowercase text string for search index.
+    """
+
+    if not Doc.has_extension('search_index'):
+        Doc.set_extension('search_index', default='')
+
+    # Assign a custom attribute at the Doc level
+    document._.search_index = document.text.lower()
 
     return document

--- a/chatterbot/languages.py
+++ b/chatterbot/languages.py
@@ -1,3 +1,7 @@
+import sys
+import inspect
+
+
 class AAR:
     ISO_639_1 = ''
     ISO_639 = 'aar'
@@ -2411,7 +2415,4 @@ class ZZA:
 
 
 def get_language_classes():
-    import sys
-    import inspect
-
     return inspect.getmembers(sys.modules[__name__], inspect.isclass)

--- a/chatterbot/logic/logic_adapter.py
+++ b/chatterbot/logic/logic_adapter.py
@@ -1,3 +1,5 @@
+from random import choice
+
 from chatterbot.adapters import Adapter
 from chatterbot.storage import StorageAdapter
 from chatterbot.search import IndexedTextSearch
@@ -105,8 +107,6 @@ class LogicAdapter(Adapter):
         This method is called when a logic adapter is unable to generate any
         other meaningful response.
         """
-        from random import choice
-
         if self.default_responses:
             response = choice(self.default_responses)
         else:

--- a/chatterbot/preprocessors.py
+++ b/chatterbot/preprocessors.py
@@ -1,22 +1,25 @@
 """
 Statement pre-processors.
 """
+from unicodedata import normalize
+from re import sub as re_sub
+from html import unescape
 
 
 def clean_whitespace(statement):
     """
     Remove any consecutive whitespace characters from the statement text.
     """
-    import re
-
     # Replace linebreaks and tabs with spaces
-    statement.text = statement.text.replace('\n', ' ').replace('\r', ' ').replace('\t', ' ')
+    # Uses splitlines() which includes a superset of universal newlines:
+    # https://docs.python.org/3/library/stdtypes.html#str.splitlines
+    statement.text = ' '.join(statement.text.splitlines()).replace('\t', ' ')
 
-    # Remove any leeding or trailing whitespace
+    # Remove any leading or trailing whitespace
     statement.text = statement.text.strip()
 
     # Remove consecutive spaces
-    statement.text = re.sub(' +', ' ', statement.text)
+    statement.text = re_sub(' +', ' ', statement.text)
 
     return statement
 
@@ -26,9 +29,7 @@ def unescape_html(statement):
     Convert escaped html characters into unescaped html characters.
     For example: "&lt;b&gt;" becomes "<b>".
     """
-    import html
-
-    statement.text = html.unescape(statement.text)
+    statement.text = unescape(statement.text)
 
     return statement
 
@@ -38,9 +39,7 @@ def convert_to_ascii(statement):
     Converts unicode characters to ASCII character equivalents.
     For example: "på fédéral" becomes "pa federal".
     """
-    import unicodedata
-
-    text = unicodedata.normalize('NFKD', statement.text)
+    text = normalize('NFKD', statement.text)
     text = text.encode('ascii', 'ignore').decode('utf-8')
 
     statement.text = str(text)

--- a/chatterbot/search.py
+++ b/chatterbot/search.py
@@ -46,7 +46,7 @@ class IndexedTextSearch:
         input_search_text = input_statement.search_text
 
         if not input_statement.search_text:
-            self.chatbot.logger.warn(
+            self.chatbot.logger.warning(
                 'No value for search_text was available on the provided input'
             )
 

--- a/chatterbot/storage/django_storage.py
+++ b/chatterbot/storage/django_storage.py
@@ -129,18 +129,26 @@ class DjangoStorageAdapter(StorageAdapter):
 
         tag_cache = {}
 
+        # Check if any statements already have a search text
+        have_search_text = any(statement.search_text for statement in statements)
+
+        # Generate search text values in bulk
+        if not have_search_text:
+            search_text_documents = self.tagger.as_nlp_pipeline([statement.text for statement in statements])
+            response_search_text_documents = self.tagger.as_nlp_pipeline([statement.in_response_to or '' for statement in statements])
+
+            for statement, search_text_document, response_search_text_document in zip(
+                statements, search_text_documents, response_search_text_documents
+            ):
+                statement.search_text = search_text_document._.search_index
+                statement.search_in_response_to = response_search_text_document._.search_index
+
         for statement in statements:
 
             statement_data = statement.serialize()
             tag_data = statement_data.pop('tags', [])
 
             statement_model_object = Statement(**statement_data)
-
-            if not statement.search_text:
-                statement_model_object.search_text = self.tagger.get_text_index_string(statement.text)
-
-            if not statement.search_in_response_to and statement.in_response_to:
-                statement_model_object.search_in_response_to = self.tagger.get_text_index_string(statement.in_response_to)
 
             statement_model_object.save()
 

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -1,4 +1,5 @@
 import re
+from random import randint
 from chatterbot.storage import StorageAdapter
 
 
@@ -244,8 +245,6 @@ class MongoDatabaseAdapter(StorageAdapter):
         """
         Returns a random statement from the database
         """
-        from random import randint
-
         count = self.count()
 
         if count < 1:

--- a/chatterbot/storage/mongodb.py
+++ b/chatterbot/storage/mongodb.py
@@ -177,16 +177,24 @@ class MongoDatabaseAdapter(StorageAdapter):
         """
         create_statements = []
 
+        # Check if any statements already have a search text
+        have_search_text = any(statement.search_text for statement in statements)
+
+        # Generate search text values in bulk
+        if not have_search_text:
+            search_text_documents = self.tagger.as_nlp_pipeline([statement.text for statement in statements])
+            response_search_text_documents = self.tagger.as_nlp_pipeline([statement.in_response_to or '' for statement in statements])
+
+            for statement, search_text_document, response_search_text_document in zip(
+                statements, search_text_documents, response_search_text_documents
+            ):
+                statement.search_text = search_text_document._.search_index
+                statement.search_in_response_to = response_search_text_document._.search_index
+
         for statement in statements:
             statement_data = statement.serialize()
             tag_data = list(set(statement_data.pop('tags', [])))
             statement_data['tags'] = tag_data
-
-            if not statement.search_text:
-                statement_data['search_text'] = self.tagger.get_text_index_string(statement.text)
-
-            if not statement.search_in_response_to and statement.in_response_to:
-                statement_data['search_in_response_to'] = self.tagger.get_text_index_string(statement.in_response_to)
 
             create_statements.append(statement_data)
 

--- a/chatterbot/storage/sql_storage.py
+++ b/chatterbot/storage/sql_storage.py
@@ -1,3 +1,4 @@
+import random
 from chatterbot.storage import StorageAdapter
 
 
@@ -351,8 +352,6 @@ class SQLStorageAdapter(StorageAdapter):
         """
         Returns a random statement from the database.
         """
-        import random
-
         Statement = self.get_model('statement')
 
         session = self.Session()

--- a/chatterbot/tagging.py
+++ b/chatterbot/tagging.py
@@ -30,8 +30,8 @@ class PosLemmaTagger(object):
                 f'Spacy model is not available for language {self.language}'
             ) from e
 
-        # Load the spacy model, only the 'tagger'-related pipeline is needed for POS tagging
-        self.nlp = spacy.load(model)
+        # Disable the Named Entity Recognition (NER) component because it is not necessary
+        self.nlp = spacy.load(model, exclude=['ner'])
 
     def _get_bigram_pairs(self, document):
         tokens = [

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -95,7 +95,7 @@ class ListTrainer(Trainer):
         documents = self.chatbot.storage.tagger.as_nlp_pipeline(conversation)
 
         # for text in enumerate(conversation):
-        for document in tqdm.tqdm(documents, desc='List Trainer', disable=not self.show_training_progress):
+        for document in tqdm(documents, desc='List Trainer', disable=not self.show_training_progress):
             statement_search_text = document._.search_index
 
             statement = self.get_preprocessed_statement(
@@ -131,7 +131,7 @@ class ChatterBotCorpusTrainer(Trainer):
         for corpus_path in corpus_paths:
             data_file_paths.extend(list_corpus_files(corpus_path))
 
-        for corpus, categories, _file_path in tqdm.tqdm(
+        for corpus, categories, _file_path in tqdm(
             load_corpus(*data_file_paths),
             desc='ChatterBot Corpus Trainer',
             disable=not self.show_training_progress

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -338,7 +338,7 @@ class UbuntuCorpusTrainer(Trainer):
 
             statements_from_file = []
 
-            for tsv_file in tqdm.tqdm(tsv_files, desc=f'Training with batch {batch_number} of {len(file_groups)}'):
+            for tsv_file in tqdm(tsv_files, desc=f'Training with batch {batch_number} of {len(file_groups)}'):
                 with open(tsv_file, 'r', encoding='utf-8') as tsv:
                     reader = csv.reader(tsv, delimiter='\t')
 

--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -3,6 +3,8 @@ import sys
 import csv
 import time
 import glob
+import json
+import tarfile
 from tqdm import tqdm
 from dateutil import parser as date_parser
 from chatterbot.conversation import Statement
@@ -69,7 +71,6 @@ class Trainer(object):
         Create a file from the database that can be used to
         train other chat bots.
         """
-        import json
         export = {'conversations': self._generate_export_data()}
         with open(file_path, 'w+', encoding='utf8') as jsonfile:
             json.dump(export, jsonfile, ensure_ascii=False)
@@ -265,8 +266,6 @@ class UbuntuCorpusTrainer(Trainer):
         """
         Extract a tar file at the specified file path.
         """
-        import tarfile
-
         print('Extracting {}'.format(file_path))
 
         if not os.path.exists(self.extracted_data_directory):

--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -107,6 +107,8 @@ def print_progress_bar(description, iteration_counter, total_items, progress_bar
 
     :returns: void
     :rtype: void
+
+    DEPRECTTED: use `tqdm` instead
     """
     import sys
 

--- a/chatterbot/utils.py
+++ b/chatterbot/utils.py
@@ -1,6 +1,9 @@
 """
 ChatterBot utility functions
 """
+import importlib
+import time
+import sys
 
 
 def import_module(dotted_path):
@@ -8,8 +11,6 @@ def import_module(dotted_path):
     Imports the specified module based on the
     dot notated import path for the module.
     """
-    import importlib
-
     module_parts = dotted_path.split('.')
     module_path = '.'.join(module_parts[:-1])
     module = importlib.import_module(module_path)
@@ -81,8 +82,6 @@ def get_response_time(chatbot, statement='Hello'):
     :returns: The response time in seconds.
     :rtype: float
     """
-    import time
-
     start_time = time.time()
 
     chatbot.get_response(statement)
@@ -110,8 +109,6 @@ def print_progress_bar(description, iteration_counter, total_items, progress_bar
 
     DEPRECTTED: use `tqdm` instead
     """
-    import sys
-
     percent = float(iteration_counter) / total_items
     hashes = '#' * int(round(percent * progress_bar_length))
     spaces = ' ' * (progress_bar_length - len(hashes))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,5 @@ dev = [
     "pymongo>=4.11,<4.12",
     "spacy>=3.8,<3.9",
     "pyyaml>=6.0,<7.0",
-    "chatterbot-corpus>1.2.0"
+    "chatterbot-corpus>=1.2.2"
 ]

--- a/tests/storage/test_mongo_adapter.py
+++ b/tests/storage/test_mongo_adapter.py
@@ -445,9 +445,10 @@ class StorageAdapterCreateTestCase(MongoAdapterTestCase):
         self.assertEqual(results[1].search_text, 'b')
 
     def test_create_many_search_in_response_to(self):
+        # `search_text` must be present or `search_in_response_to` will be generated based on the `in_response_to` field
         self.adapter.create_many([
-            Statement(text='A', search_in_response_to='a'),
-            Statement(text='B', search_in_response_to='b')
+            Statement(text='A', search_text='1', search_in_response_to='a'),
+            Statement(text='B', search_text='2', search_in_response_to='b')
         ])
 
         results = list(self.adapter.filter())

--- a/tests/storage/test_sql_adapter.py
+++ b/tests/storage/test_sql_adapter.py
@@ -395,9 +395,10 @@ class StorageAdapterCreateTests(SQLStorageAdapterTestCase):
         self.assertEqual(results[1].search_text, 'b')
 
     def test_create_many_search_in_response_to(self):
+        # `search_text` must be present or `search_in_response_to` will be generated based on the `in_response_to` field
         self.adapter.create_many([
-            Statement(text='A', search_in_response_to='a'),
-            Statement(text='B', search_in_response_to='b')
+            Statement(text='A', search_text='1', search_in_response_to='a'),
+            Statement(text='B', search_text='2', search_in_response_to='b')
         ])
 
         results = list(self.adapter.filter())

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -4,6 +4,7 @@ various chat bot configurations to help prevent
 performance based regressions when changes are made.
 """
 
+import logging
 from unittest import skip
 from warnings import warn
 from random import choice
@@ -11,6 +12,9 @@ from tests.base_case import ChatBotSQLTestCase, ChatBotMongoTestCase
 from chatterbot.trainers import ListTrainer, ChatterBotCorpusTrainer, UbuntuCorpusTrainer
 from chatterbot.logic import BestMatch
 from chatterbot import comparisons, response_selection, utils
+
+
+logging.getLogger('pymongo').setLevel(logging.WARNING)
 
 
 WORDBANK = (

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -23,7 +23,7 @@ class CleanWhitespacePreprocessorTestCase(ChatBotTestCase):
     def test_clean_whitespace(self):
         statement = Statement(text='\tThe quick \nbrown fox \rjumps over \vthe \alazy \fdog\\.')
         cleaned = preprocessors.clean_whitespace(statement)
-        normal_text = 'The quick brown fox jumps over \vthe \alazy \fdog\\.'
+        normal_text = 'The quick brown fox jumps over the \alazy dog\\.'
 
         self.assertEqual(cleaned.text, normal_text)
 

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -120,7 +120,7 @@ class PosLemmaTaggerTests(TestCase):
             'Hello Dr. Salazar. How are you today?'
         )
 
-        self.assertEqual(bigram_string, 'INTJ:salazar PROPN:today')
+        self.assertEqual(bigram_string, 'INTJ:dr. PROPN:salazar PROPN:today')
 
     def test_get_text_index_string_single_character_words(self):
         bigram_string = self.tagger.get_text_index_string(

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -135,3 +135,16 @@ class PosLemmaTaggerTests(TestCase):
         )
 
         self.assertEqual(bigram_string, 'VERB:mu')
+
+
+class LowercaseTaggerTests(TestCase):
+
+    def setUp(self):
+        self.tagger = tagging.LowercaseTagger()
+
+    def test_lowercase_tagger(self):
+        tagged_text = self.tagger.get_text_index_string(
+            'Hello, how are you doing on this AWESOME day?'
+        )
+
+        self.assertEqual(tagged_text, 'hello, how are you doing on this awesome day?')

--- a/tests/training/test_ubuntu_corpus_training.py
+++ b/tests/training/test_ubuntu_corpus_training.py
@@ -177,7 +177,7 @@ class UbuntuCorpusTrainerTestCase(ChatBotTestCase):
 
         results = list(self.chatbot.storage.filter(text='Is anyone there?'))
 
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 2, msg='Results: {}'.format(results))
         self.assertEqual(results[0].search_text, 'AUX:anyone PRON:there')
 
     def test_train_sets_search_in_response_to(self):


### PR DESCRIPTION
Spacy supports functionality to improve performance when processing large amounts of text. Example from their documentation:

```diff
texts = ["This is a text", "These are lots of texts", "..."]
- docs = [nlp(text) for text in texts]
+ docs = list(nlp.pipe(texts))
```

https://spacy.io/usage/processing-pipelines#processing

***

It also looks like there are `enable` and `disable` options that can be used to include or exclude parts of the text processing pipeline. These might be a possible place to look for future performance improvements, but right now it isn't clear if adjusting these makes a significant impact.

***

Closes #2350