### PR TITLE
Modify TimeLogicAdapter to use SpaCy PhraseMatcher instead of NLTK NaiveBayesClassifier

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -248,29 +248,9 @@ class ChatBot(object):
         ))
 
         # Get the most recent statement in the conversation if one exists
-        latest_statement = conversation_statements[-1] if conversation_statements else None
+        latest_statement = conversation_statements[-1] if len(conversation_statements) else None
 
-        if latest_statement:
-            if latest_statement.in_response_to:
-
-                response_statements = list(self.storage.filter(
-                    conversation=conversation,
-                    text=latest_statement.in_response_to,
-                    order_by=['id']
-                ))
-
-                if response_statements:
-                    return response_statements[-1]
-                else:
-                    return StatementObject(
-                        text=latest_statement.in_response_to,
-                        conversation=conversation
-                    )
-            else:
-                # The case that the latest statement is not in response to another statement
-                return latest_statement
-
-        return None
+        return latest_statement
 
     class ChatBotException(Exception):
         pass

--- a/chatterbot/comparisons.py
+++ b/chatterbot/comparisons.py
@@ -3,8 +3,8 @@ This module contains various text-comparison algorithms
 designed to compare one statement to another.
 """
 from chatterbot import constants
-from chatterbot.exceptions import OptionalDependencyImportError
 from difflib import SequenceMatcher
+import spacy
 
 
 class Comparator:
@@ -92,15 +92,6 @@ class SpacySimilarity(Comparator):
 
     def __init__(self, language):
         super().__init__(language)
-        try:
-            import spacy
-        except ImportError:
-            message = (
-                'Unable to import "spacy".\n'
-                'Please install "spacy" before using the SpacySimilarity comparator:\n'
-                'pip install spacy'
-            )
-            raise OptionalDependencyImportError(message)
 
         try:
             model = constants.DEFAULT_LANGUAGE_TO_SPACY_MODEL_MAP[self.language]
@@ -153,15 +144,6 @@ class JaccardSimilarity(Comparator):
 
     def __init__(self, language):
         super().__init__(language)
-        try:
-            import spacy
-        except ImportError:
-            message = (
-                'Unable to import "spacy".\n'
-                'Please install "spacy" before using the JaccardSimilarity comparator:\n'
-                'pip install spacy'
-            )
-            raise OptionalDependencyImportError(message)
 
         try:
             model = constants.DEFAULT_LANGUAGE_TO_SPACY_MODEL_MAP[self.language]

--- a/chatterbot/tagging.py
+++ b/chatterbot/tagging.py
@@ -1,4 +1,5 @@
 from chatterbot import languages, constants
+import spacy
 
 
 class LowercaseTagger(object):
@@ -7,7 +8,6 @@ class LowercaseTagger(object):
     """
 
     def __init__(self, language=None):
-        import spacy
         from chatterbot.components import chatterbot_lowercase_indexer  # noqa
 
         self.language = language or languages.ENG
@@ -38,7 +38,6 @@ class LowercaseTagger(object):
 class PosLemmaTagger(object):
 
     def __init__(self, language=None):
-        import spacy
         from chatterbot.components import chatterbot_bigram_indexer  # noqa
 
         self.language = language or languages.ENG

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -19,7 +19,7 @@ To install ChatterBot from PyPi using pip run the following command in your term
 Optional dependencies
 ---------------------
 
-ChatterBot offers two collections of optional dependencies: ``dev`` and ``test``. Neither of these are required for all ChatterBot use cases, but both provide full support for additional features. The ``dev`` collection includes dependencies such as ``nltk``, and ``spacy``. Separately the ``test`` collection includes dependencies such as ``flake8``, and ``coverage``. The specifics of each collection of optional dependencies can be reviewed via the project's `pyproject.yml`_ file. To install these optional dependencies, you can use the following commands.
+ChatterBot offers two collections of optional dependencies: ``dev`` and ``test``. Neither of these are required for all ChatterBot use cases, but both provide full support for additional features. The ``dev`` collection includes dependencies such as ``pymongo``, and ``pint`` (which are useful for working on various changes during development but are not required to use all chatterbot features). Separately the ``test`` collection includes dependencies such as ``flake8``, and ``coverage``. The specifics of each collection of optional dependencies can be reviewed via the project's `pyproject.yml`_ file. To install these optional dependencies, you can use the following commands.
 
 .. code-block:: bash
 

--- a/examples/terminal_example.py
+++ b/examples/terminal_example.py
@@ -5,14 +5,18 @@ from chatterbot import ChatBot
 # import logging
 # logging.basicConfig(level=logging.INFO)
 
+# NOTE: The order of logic adapters is important
+# because the first logic adapter takes precedence
+# if a good response cannot be determined.
+
 # Create a new instance of a ChatBot
 bot = ChatBot(
     'Terminal',
     storage_adapter='chatterbot.storage.SQLStorageAdapter',
     logic_adapters=[
-        'chatterbot.logic.MathematicalEvaluation',
+        'chatterbot.logic.BestMatch',
         'chatterbot.logic.TimeLogicAdapter',
-        'chatterbot.logic.BestMatch'
+        'chatterbot.logic.MathematicalEvaluation'
     ],
     database_uri='sqlite:///database.sqlite3'
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     "mathparse>=0.1,<0.2",
     "python-dateutil>=2.9,<2.10",
     "sqlalchemy>=2.0,<2.1",
+    "spacy>=3.8,<3.9",
     "tqdm",
 ]
 
@@ -74,10 +75,8 @@ test = [
     "sphinx>=5.3,<8.2"
 ]
 dev = [
-    "nltk>=3.9,<4.0",
     "pint>=0.8.1",
     "pymongo>=4.11,<4.12",
-    "spacy>=3.8,<3.9",
     "pyyaml>=6.0,<7.0",
     "chatterbot-corpus>=1.2.2"
 ]

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -139,9 +139,9 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
         self.assertEqual(second_response.confidence, 0)
         self.assertEqual(second_response.in_response_to, 'How are you?')
 
-        # Make sure that the second response was saved to the database
+        # Make sure that the previous response was saved to the database
         self.assertIsLength(results, 1)
-        self.assertEqual(results[0].in_response_to, 'Hi')
+        self.assertEqual(results[0].in_response_to, 'Hello')
 
     def test_statement_added_to_conversation(self):
         """
@@ -274,7 +274,7 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
 
         response = self.chatbot.get_latest_response('test')
 
-        self.assertEqual(response.text, 'A')
+        self.assertEqual(response.text, 'B')
 
     def test_get_latest_response_from_two_responses(self):
         self.chatbot.storage.create(text='A', conversation='test')
@@ -283,7 +283,7 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
 
         response = self.chatbot.get_latest_response('test')
 
-        self.assertEqual(response.text, 'B')
+        self.assertEqual(response.text, 'C')
 
     def test_get_latest_response_from_three_responses(self):
         self.chatbot.storage.create(text='A', conversation='test')
@@ -293,7 +293,7 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
 
         response = self.chatbot.get_latest_response('test')
 
-        self.assertEqual(response.text, 'C')
+        self.assertEqual(response.text, 'D')
 
     def test_search_text_results_after_training(self):
         """


### PR DESCRIPTION
Overall the `PhraseMatcher` seems to be better suited for the purpose of this logic adapter (matching a set of examples of questions asking what the current time is). Notably this change was brought about by noticing that the `TimeLogicAdapter` was being overly confident in its identification of time related statements and was yielding a high number of false-positives.

***

Additionally I'm going to use this pull request to close off a number of old issues related to `nltk` since this logic adapter was the last place `nltk` was used in ChatterBot.

Closes #1746, closes #2138, closes #1953, closes #1857, closes #1856, closes #1813, closes #1800, closes #1720, closes #1618, closes #1678