### PR TITLE
Persist tags to output

### DIFF
--- a/chatterbot/chatterbot.py
+++ b/chatterbot/chatterbot.py
@@ -232,6 +232,8 @@ class ChatBot(object):
             persona='bot:' + self.name
         )
 
+        response.add_tags(*result.get_tags())
+
         response.confidence = result.confidence
 
         return response

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -222,6 +222,16 @@ class ChatterBotResponseTestCase(ChatBotTestCase):
         self.assertIsLength(results, 2)
         self.assertIn('test', results[0].get_tags())
 
+    def test_response_preserves_tags(self):
+        """
+        The response returned from the chatbot should preserve tags
+        from the statement that was used to generated the response.
+        """
+        self._create_with_search_text(text='Hello', tags=['test'])
+        response = self.chatbot.get_response('Hello')
+
+        self.assertEqual(response.get_tags(), ['test'])
+
     def test_get_response_with_text_and_kwargs(self):
         self.chatbot.get_response('Hello', conversation='greetings')
 


### PR DESCRIPTION
This pull request makes it so that tags will be persisted to the statement the bot generates.
For example:

```python
from chatterbot import ChatBot
from chatterbot.trainers import ChatterBotCorpusTrainer

bot = ChatBot('Debug')

trainer = ChatterBotCorpusTrainer(bot, read_only=True)

trainer.train('chatterbot.corpus.english')

bot_input = bot.get_response('Hello')
print(bot_input.tags, bot_input.get_tags())

# prints ['conversation'] based on the matching response from the english corpus
```

Closes #2219

I believe this also closes #2068, and closes #1626 