### PR TITLE
Generate response search index when in_response_to key is present in files

### DIFF
--- a/chatterbot/tagging.py
+++ b/chatterbot/tagging.py
@@ -1,3 +1,4 @@
+from typing import List, Union, Tuple
 from chatterbot import languages
 from chatterbot.utils import get_model_for_language
 import spacy
@@ -20,7 +21,7 @@ class LowercaseTagger(object):
             'chatterbot_lowercase_indexer', name='chatterbot_lowercase_indexer', last=True
         )
 
-    def get_text_index_string(self, text):
+    def get_text_index_string(self, text: Union[str, List[str]]):
         if isinstance(text, list):
             documents = self.nlp.pipe(text)
             return [document._.search_index for document in documents]
@@ -28,7 +29,7 @@ class LowercaseTagger(object):
             document = self.nlp(text)
             return document._.search_index
 
-    def as_nlp_pipeline(self, texts):
+    def as_nlp_pipeline(self, texts: Union[List[str], Tuple[str, dict]]):
 
         process_as_tuples = texts and isinstance(texts[0], tuple)
 
@@ -52,7 +53,7 @@ class PosLemmaTagger(object):
             'chatterbot_bigram_indexer', name='chatterbot_bigram_indexer', last=True
         )
 
-    def get_text_index_string(self, text):
+    def get_text_index_string(self, text: Union[str, List[str]]):
         """
         Return a string of text containing part-of-speech, lemma pairs.
         """
@@ -63,7 +64,7 @@ class PosLemmaTagger(object):
             document = self.nlp(text)
             return document._.search_index
 
-    def as_nlp_pipeline(self, texts):
+    def as_nlp_pipeline(self, texts: Union[List[str], Tuple[str, dict]]):
         """
         Accepts a single string or a list of strings, or a list of tuples
         where the first element is the text and the second element is a

--- a/docs/training.rst
+++ b/docs/training.rst
@@ -139,6 +139,8 @@ Training with CSV or TSV formatted data
 .. autoclass:: chatterbot.trainers.CsvFileTrainer
    :members: train
 
+   .. autoattribute:: chatterbot.trainers.CsvFileTrainer.DEFAULT_STATEMENT_TO_HEADER_MAPPING
+
 
 Example CSV data format:
 
@@ -168,6 +170,8 @@ Training with JSON formatted data
 
 .. autoclass:: chatterbot.trainers.JsonFileTrainer
    :members: train
+
+   .. autoattribute:: chatterbot.trainers.JsonFileTrainer.DEFAULT_STATEMENT_TO_KEY_MAPPING
 
 
 Example JSON data format:

--- a/tests/training/test_data/json_corpus/1.json
+++ b/tests/training/test_data/json_corpus/1.json
@@ -4,13 +4,19 @@
             "text": "Hello",
             "in_response_to": null,
             "persona": "user 1",
-            "conversation": "test"
+            "conversation": "test",
+            "tags": [
+                "greeting"
+            ]
         },
         {
             "text": "Is anyone there?",
             "in_response_to": "Hello",
             "persona": "user 1",
-            "conversation": "test"
+            "conversation": "test",
+            "tags": [
+                "question"
+            ]
         },
         {
             "text": "Yes",


### PR DESCRIPTION
This adds a fix so that when training using files (ex. `json`) that specify an `in_response_to` field the key will be used instead of the sequential file order.

* For #2411

***

Also includes a few documentation updates to help better convey the expected structure of `json` files.

* Closes #2409