### PR TITLE
Remove click from direct dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,7 @@ test = [
     "sphinx>=5.3,<9.2",
     "sphinx-sitemap>=2.6.0",
     "huggingface_hub",
-    "django>=4.1,<6.0",
-    "click>=8.4,<9.0"
+    "django>=4.1,<6.0"
 ]
 dev = [
     "pint>=0.8.1",


### PR DESCRIPTION
Testing if this pin can be removed based on https://github.com/explosion/spaCy/releases/tag/release-v3.8.15