### PR TITLE
Keep the procfs check in the dir_fd extraction guard

### DIFF
--- a/chatterbot/trainers.py
+++ b/chatterbot/trainers.py
@@ -25,11 +25,6 @@ _DIR_FD_EXTRACTION_SUPPORTED = (
     and os.rename in os.supports_dir_fd
     and os.path.isdir('/proc/self/fd')
 )
-_DIR_FD_EXTRACTION_SUPPORTED = (
-    hasattr(os, 'O_NOFOLLOW')
-    and os.mkdir in os.supports_dir_fd
-    and os.rename in os.supports_dir_fd
-)
 
 
 class Trainer(object):

--- a/tests/training/test_ubuntu_corpus_training.py
+++ b/tests/training/test_ubuntu_corpus_training.py
@@ -483,3 +483,18 @@ class UbuntuCorpusTrainerTestCase(ChatBotTestCase):
             shutil.rmtree(relocated_original, ignore_errors=True)
             shutil.rmtree(attacker_target, ignore_errors=True)
             shutil.rmtree(independent_dir, ignore_errors=True)
+
+    def test_dir_fd_extraction_support_implies_procfs(self):
+        """
+        The dir_fd extraction path anchors tarfile's writes through
+        /proc/self/fd/N, so it must stay disabled anywhere procfs is absent.
+        Enabling it without procfs makes extract() fail on the first write.
+        """
+        from chatterbot import trainers
+
+        if trainers._DIR_FD_EXTRACTION_SUPPORTED:
+            self.assertTrue(
+                os.path.isdir('/proc/self/fd'),
+                'dir_fd extraction is enabled but /proc/self/fd is unavailable, '
+                'so the extraction root resolves to a nonexistent path'
+            )


### PR DESCRIPTION
Ran the branch on macOS before reviewing the race fix and hit this first, so flagging it ahead of the rest.

`_DIR_FD_EXTRACTION_SUPPORTED` is assigned twice. The second assignment overwrites the first and drops the `os.path.isdir('/proc/self/fd')` term, so the flag ends up true on any POSIX platform with `O_NOFOLLOW` and dir_fd support, not just Linux as the comment above it intends.

That matters because the dir_fd path sets `extraction_root = '/proc/self/fd/{}'.format(base_fd)`. On macOS the `os.mkdir(staging_name, dir_fd=base_fd)` succeeds, since that one is genuinely fd-relative, and then `tarfile` tries to write through a path that does not resolve:

```
_DIR_FD_EXTRACTION_SUPPORTED = True
RESULT: EXTRACT FAILED -> OSError : [Errno 30] Read-only file system: '/proc'
```

So `UbuntuCorpusTrainer.extract()` fails on the first write for every macOS and BSD user rather than falling back to the plain staging-plus-rename path. On Linux nothing changes, since `/proc/self/fd` is there either way.

Removing the duplicate restores the intended guard. After it, same machine:

```
_DIR_FD_EXTRACTION_SUPPORTED = False
extract OK -> ['ubuntu_dialogs']
```

Also added a test asserting the flag implies procfs is present, since a Linux-only CI will not catch this class of thing on its own.

Still working through the race condition itself and will comment on #2449 with those numbers separately.